### PR TITLE
Adds Clarity

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -98,9 +98,14 @@
               "projects/examples/src/assets"
             ],
             "styles": [
+              "node_modules/@clr/icons/clr-icons.min.css",
+              "node_modules/@clr/ui/clr-ui.min.css",
               "projects/examples/src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [
+              "node_modules/@webcomponents/custom-elements/custom-elements.min.js",
+              "node_modules/@clr/icons/clr-icons.min.js"
+            ]
           },
           "configurations": {
             "production": {
@@ -194,6 +199,7 @@
           }
         }
       }
-    }},
+    }
+  },
   "defaultProject": "examples"
 }

--- a/projects/examples/src/app/app.component.html
+++ b/projects/examples/src/app/app.component.html
@@ -1,5 +1,15 @@
+<clr-alert [clrAlertType]="'info'" [clrAlertAppLevel]="true">
+    <clr-alert-item>
+        <span class="alert-text">
+            Stay tuned! We will have components showing up here soon.
+        </span>
+        <div class="alert-actions">
+            <button class="btn alert-action">Fix</button>
+        </div>
+    </clr-alert-item>
+</clr-alert>
 <h1>VCD UI Common Components</h1>
-Stay tuned! We will have components showing up here soon.
 <router-outlet></router-outlet>
 <vcd-components></vcd-components>
 <vcd-doc-lib></vcd-doc-lib>
+<clr-icon shape="atom"></clr-icon>

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -10,10 +10,12 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { ComponentsModule } from '@vmw/vcd-ui-components';
 import { DocLibModule } from '@vmw/vcd-ui-doc-lib';
+import { ClarityModule } from '@clr/angular';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
     declarations: [AppComponent],
-    imports: [BrowserModule, AppRoutingModule, ComponentsModule, DocLibModule],
+    imports: [BrowserModule, AppRoutingModule, ComponentsModule, DocLibModule, ClarityModule, BrowserAnimationsModule],
     providers: [],
     bootstrap: [AppComponent],
 })


### PR DESCRIPTION
Uses a Clarity icon and an alert in examples app.

## Testing Done

* Ran examples container
* Saw a Clarity icon
* Saw a Clarity alert

![image](https://user-images.githubusercontent.com/549331/70751379-439f3680-1cfe-11ea-87e8-096af709b3cb.png)


Signed-off-by: Juan Mendes <mendesjuan@gmail.com>