### PR TITLE
Add WidgetObject pattern for unit tests and clr-datagrid widget object

### DIFF
--- a/projects/components/src/utils/test/datagrid/datagrid-widget-object.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid-widget-object.ts
@@ -1,0 +1,48 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { WidgetObject } from '../widget-object';
+import { DebugElement } from '@angular/core';
+import { ClrDatagrid } from '@clr/angular';
+
+const ROW_TAG = 'clr-dg-row';
+const CELL_TAG = 'clr-dg-cell';
+const COLUMN_CSS_SELECTOR = '.datagrid-column';
+
+export class DatagridWidgetObject extends WidgetObject<ClrDatagrid> {
+    static tagName = `clr-datagrid`;
+
+    private getCell(row: number, column: number): Element {
+        return this.root.nativeElement.querySelectorAll(ROW_TAG)[row].querySelectorAll(CELL_TAG)[column];
+    }
+
+    getCellText(row: number, column: number): string {
+        return this.getText(this.getCell(row, column));
+    }
+
+    private get columns(): DebugElement[] {
+        return this.findElements(COLUMN_CSS_SELECTOR, this.root);
+    }
+
+    get columnCount(): number {
+        return this.component.columns ? this.component.columns.length : this.columns.length;
+    }
+
+    getColumnHeader(columnIndex: number): string {
+        return this.getText(this.columns[columnIndex]);
+    }
+
+    get columnHeaders(): string[] {
+        return this.columns.map(col => this.getText(col));
+    }
+
+    private get rows(): DebugElement[] {
+        return this.root.nativeElement.querySelectorAll(ROW_TAG);
+    }
+
+    get rowCount(): number {
+        return this.rows.length;
+    }
+}

--- a/projects/components/src/utils/test/widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object.spec.ts
@@ -1,0 +1,204 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { TestBed, async } from '@angular/core/testing';
+import { Component, DebugElement, Input, Type } from '@angular/core';
+import { HasFinder, WidgetFinder, WidgetObject } from './widget-object';
+
+/**
+ * This is the reusable component being tested, typically goes in its own file
+ */
+@Component({
+    selector: 'vcd-click-tracker',
+    template: `
+        <div>
+            <h1>{{ header }}</h1>
+            <p (click)="clickCount = clickCount + 1">
+                Clicks: <span class="click-count">{{ clickCount }}</span>
+            </p>
+        </div>
+    `,
+})
+class ClickTrackerComponent {
+    @Input() header = 'Click Tracker';
+    clickCount = 0;
+}
+
+/**
+ * Each component being tested should have a matching widget object.
+ *
+ * This class could be tested mostly through the component instance but we are using the HTML to show the base class's
+ * functionality
+ */
+class ClickTrackerWidgetObject extends WidgetObject<ClickTrackerComponent> {
+    static tagName = `vcd-click-tracker`;
+
+    get clickCount(): number {
+        // If we wanted to use the instance, but we want to show base functionali
+        // return this.component.clickCount;
+        return Number(this.getText('.click-count'));
+    }
+
+    get headerText(): string {
+        // If we wanted to use the instance
+        // return this.component.header;
+        return this.getText('h1');
+    }
+
+    /**
+     * Tests should not return DebugElements, this is just to showcase the base class's findElement
+     */
+    get itself(): DebugElement {
+        // Since we're not passing a selector, or a parent, the root debug element is returned
+        return this.findElement();
+    }
+
+    clickTrackedElement(): void {
+        // Clicking requires the DOM
+        this.click('p');
+    }
+}
+
+/**
+ * These are the host components that are typically created within the test
+ */
+@Component({
+    template: `
+        <vcd-click-tracker header="First" class="first"></vcd-click-tracker>
+        <vcd-click-tracker header="Second" class="second"></vcd-click-tracker>
+    `,
+})
+class HostWithTwoComponent {}
+
+/**
+ * This is the host component that is typically created within the test
+ */
+@Component({
+    template: `
+        <vcd-click-tracker header="First"></vcd-click-tracker>
+    `,
+})
+class HostWithOneComponent {}
+
+function setup(fixtureRoot: Type<unknown>): void {
+    beforeEach(async function(this: HasFinder): Promise<void> {
+        await TestBed.configureTestingModule({
+            declarations: [ClickTrackerComponent, fixtureRoot],
+        }).compileComponents();
+        this.finder = new WidgetFinder(fixtureRoot);
+    });
+
+    afterEach(function(this: HasFinder): void {
+        if (this.finder) {
+            this.finder.destroy();
+        }
+    });
+}
+
+describe('WidgetFinder', () => {
+    describe('when there are multiple instances within host', () => {
+        setup(HostWithTwoComponent);
+
+        describe('find', () => {
+            it('finds object by simple CSS classNames', function(this: HasFinder): void {
+                const widget = this.finder.find({
+                    woConstructor: ClickTrackerWidgetObject,
+                    className: 'second',
+                });
+                expect(widget.headerText).toBe('Second');
+            });
+
+            it('throws an error if widget is not found', function(this: HasFinder): void {
+                expect(() => {
+                    this.finder.find({
+                        woConstructor: ClickTrackerWidgetObject,
+                        className: 'does-not-exist',
+                    });
+                }).toThrow();
+            });
+
+            it('throws an error if multiple widgets are found', function(this: HasFinder): void {
+                expect(() => {
+                    this.finder.find({
+                        woConstructor: ClickTrackerWidgetObject,
+                    });
+                }).toThrow();
+            });
+        });
+
+        describe('findWidgets', () => {
+            it('does not throw an error if no widgets are found', function(this: HasFinder): void {
+                expect(() => {
+                    this.finder.findWidgets({
+                        woConstructor: ClickTrackerWidgetObject,
+                        className: 'does-not-exist',
+                    });
+                }).not.toThrow();
+            });
+        });
+    });
+
+    describe('when there is a single instance within host', () => {
+        setup(HostWithOneComponent);
+
+        describe('find', () => {
+            it('returns the first one within the fixture if no classname is specified', function(this: HasFinder): void {
+                const widget = this.finder.find({ woConstructor: ClickTrackerWidgetObject });
+                expect(widget.headerText).toBe('First');
+            });
+        });
+    });
+});
+
+interface HasClickTracker {
+    clickTracker: ClickTrackerWidgetObject;
+}
+
+/**
+ * For all these tests of base class functionality, you must look at the implementation of the methods being called
+ * in the concrete {@link ClickTrackerWidgetObject}
+ */
+describe('WidgetObject (through ClickTracerWidgetObject)', () => {
+    beforeEach(async(function(this: HasClickTracker): void {
+        TestBed.configureTestingModule({
+            declarations: [ClickTrackerComponent],
+        }).compileComponents();
+
+        const fixture = TestBed.createComponent(ClickTrackerComponent);
+        fixture.detectChanges();
+        this.clickTracker = new ClickTrackerWidgetObject(fixture);
+    }));
+
+    afterEach(function(this: HasClickTracker): void {
+        if (this.clickTracker) {
+            this.clickTracker.destroy();
+        }
+    });
+
+    describe('constructor', () => {
+        it('can be called when you create the instance directly', function(this: HasClickTracker): void {
+            expect(this.clickTracker).toBeTruthy();
+        });
+    });
+
+    describe('getText', () => {
+        it('can find elements within itself passing a css query', function(this: HasClickTracker): void {
+            expect(this.clickTracker.clickCount).toBe(0);
+        });
+    });
+
+    describe('click', () => {
+        it('calls detectChanges after clicking', function(this: HasClickTracker): void {
+            this.clickTracker.clickTrackedElement();
+            expect(this.clickTracker.clickCount).toBe(1);
+        });
+    });
+
+    describe('findElement', () => {
+        it('returns the element itself when no CSS query is passed in', function(this: HasClickTracker): void {
+            expect(this.clickTracker.itself.componentInstance).toBe(this.clickTracker.component);
+        });
+    });
+});

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -1,0 +1,187 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { DebugElement, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FindableWidget } from './widget-object';
+
+/**
+ * An implementation of the page object pattern, but applied to widgets, since they can be reused on multiple pages.
+ *
+ * The main purpose for the wrapper are providing access to the internals of a widget avoiding duplication of code that
+ * queries the internals of a component from a test.
+ *
+ * ## Subclass Rules
+ *
+ * - Methods exposed by subclasses should not expose HTMLElements or DebugElements directly. That would encourage
+ * callers to query it from the outside creating potential duplicate querying code and abstraction leaks.
+ *  - Subclasses also should not have testing assertions. They should only provide the state and the calling test can
+ * assert code on its own.
+ *
+ * `T` is the type of the JS/TS object being wrapped
+ */
+export abstract class WidgetObject<T> {
+    /**
+     *
+     * Constructor should only be called directly if you are directly instantiating the widget being wrapped (T). If you
+     * need to find a widget within the tree, you should use {@link findWidget}.
+     *
+     * @param component The component instance being managed. Whenever possible, we should access the component's API.
+     * @param root The root element (host) for the component instance. We typically prefer to interact with the
+     * component but there are times when we must check the DOM.
+     * @param fixture The test fixture, so we can call {@link ComponentFixture#detectChanges} after something that
+     * requires re-rendering of the DOM.
+     */
+    constructor(
+        protected fixture: ComponentFixture<any>,
+        protected root: DebugElement = fixture.debugElement,
+        public component: T = fixture.componentInstance
+    ) {}
+
+    detectChanges(): void {
+        this.fixture.detectChanges();
+    }
+
+    destroy(): void {
+        this.fixture.destroy();
+        this.fixture.debugElement.nativeElement.remove();
+    }
+
+    /**
+     * Finds first element within this widget matching the given selector
+     * @param cssSelector What to search for
+     * @param parent Where to start the search; defaults to the root of this component
+     */
+    protected findElement(cssSelector?: string, parent: DebugElement = this.root): DebugElement {
+        if (!cssSelector) {
+            return parent;
+        }
+        return parent.query(By.css(cssSelector));
+    }
+
+    protected findElements(cssSelector?: string, parent: DebugElement = this.root): DebugElement[] {
+        if (!cssSelector) {
+            throw Error(`A css selector of desired elements is expected`);
+        }
+        return parent.queryAll(By.css(cssSelector));
+    }
+
+    /**
+     * Clicks an element and detects changes so the DOM is immediately updated
+     * @param cssSelector Pass this in if you want to click a specific element. If not passed in, the entire node will
+     * receive the click event
+     */
+    protected click(cssSelector?: string): void {
+        const nativeElement: HTMLBaseElement = this.findElement(cssSelector).nativeElement;
+        nativeElement.click();
+        this.detectChanges();
+    }
+
+    /**
+     * Returns text content of this widget
+     * @param val Pass this in if you want to retrieve text for a specific element within this widget.
+     */
+    protected getText(val?: Element | DebugElement | string): string {
+        let nativeElement;
+        if (typeof val === 'string') {
+            nativeElement = this.findElement(val).nativeElement;
+        } else {
+            nativeElement = (val as DebugElement).nativeElement || val;
+        }
+        return nativeElement.textContent.trim() || '';
+    }
+}
+
+/**
+ * Subclasses should implement the FindableWidget interface so they can be found with {@link WidgetFinder}
+ *
+ * ## Note
+ * This is done by creating a static property `tagName`on your subclass, not a regular instance, since this
+ * interface represents a constructor for a {@link WidgetObject}, not an instance.
+ */
+export interface FindableWidget<T> extends Type<WidgetObject<T>> {
+    tagName: string;
+}
+
+/**
+ * Arguments for {@link WidgetFinder#findWidgets} and {@link WidgetFinder#find}
+ */
+interface FindParams<T> {
+    /**
+     * The constructor of the widget to be found
+     */
+    woConstructor: T;
+    /**
+     * If provided, search starts from this container. It defaults to the fixture's root debugElement
+     */
+    ancestor?: DebugElement;
+    /**
+     * Optional CSS class name that can be used when there could be multiple instances of the object within the
+     * fixture tree
+     */
+    className?: string;
+}
+
+/**
+ * Finds instances that implement {@link FindableWidget}
+ */
+export class WidgetFinder {
+    // We don't care or could possibly know the type of fixture
+    private fixture: ComponentFixture<unknown>;
+
+    /**
+     * @param componentConstructor The host component to be created as the root of the tests's fixture
+     */
+    constructor(componentConstructor: Type<unknown>) {
+        this.fixture = TestBed.createComponent(componentConstructor);
+    }
+
+    /**
+     * Finds widgets within a fixture
+     * @return A Potentially empty list of widgets matching the given specs
+     */
+    public findWidgets<C, T extends FindableWidget<C>>(params: FindParams<T>): InstanceType<T>[] {
+        const { woConstructor, ancestor = this.fixture.debugElement, className = '' } = params;
+
+        let query = woConstructor.tagName;
+        if (className) {
+            query += `.${className}`;
+        }
+        const componentRoots = ancestor.queryAll(By.css(query));
+        const widgets = componentRoots.map(
+            // Typescript is not able to infer it correctly as the subclass but we know for sure
+            root => new woConstructor(this.fixture, root, root.componentInstance) as InstanceType<T>
+        );
+        widgets.forEach(widget => widget.detectChanges());
+        return widgets;
+    }
+
+    /**
+     * Finds a single widget object
+     * @throws An error if the widget is not found or if there are multiple instances
+     */
+    public find<C, T extends FindableWidget<C>>(params: FindParams<T>): InstanceType<T> {
+        const widgets = this.findWidgets(params);
+        if (widgets.length === 0) {
+            throw Error(`Did not find a <${params.woConstructor.tagName}>`);
+        }
+        if (widgets.length > 1) {
+            throw Error(`Expected to find a single <${params.woConstructor.tagName}> but found ${widgets.length}`);
+        }
+        return widgets[0];
+    }
+
+    destroy(): void {
+        this.fixture.destroy();
+    }
+}
+
+/**
+ * Can be used in tests that use `this` to share a finder with before/AfterEach instead of leaky closures
+ */
+export interface HasFinder {
+    finder: WidgetFinder;
+}


### PR DESCRIPTION
**What it solves:**
Providing access to the internals of a widget while unit testing components

**Why:**
For avoiding duplication of code that queries the internals of a component from a test

**Manual testing:**
As these are unit testing utilities, They will be put to test while writing widget objects as part of testing those components

**Resolves**
https://jira.eng.vmware.com/browse/VDUCC-51