### PR TITLE
Unit tests for DataExporter and the csv exporter service

### DIFF
--- a/projects/components/src/data-exporter/csv-exporter.service.spec.ts
+++ b/projects/components/src/data-exporter/csv-exporter.service.spec.ts
@@ -4,27 +4,102 @@
  */
 
 import { TestBed } from '@angular/core/testing';
+import { CsvExporterService } from './csv-exporter.service';
 
 describe('CsvExporterService', () => {
-    beforeEach(() => {
-        return TestBed.configureTestingModule({});
-    });
-
     describe('createCsv', () => {
-        it('creates a csv out of 2D array of cell values', () => {});
+        it('creates a csv out of 2D array of cell values', () => {
+            const service: CsvExporterService = TestBed.get(CsvExporterService);
+            expect(service.createCsv([['a', 'b'], [1, 2]])).toEqual('a,b\n1,2');
+        });
 
-        it('encodes new lines by wrapping with double quotes', () => {});
+        it('encodes new lines by wrapping with double quotes', () => {
+            const service: CsvExporterService = TestBed.get(CsvExporterService);
+            expect(service.createCsv([['a', 'b'], ['1\n1', 2]])).toEqual('a,b\n"1\n1",2');
+        });
 
-        it('encodes commas by wrapping with double quotes', () => {});
+        it('encodes commas by wrapping with double quotes', () => {
+            const service: CsvExporterService = TestBed.get(CsvExporterService);
+            expect(service.createCsv([['a', 'b'], ['1,1', 2]])).toEqual('a,b\n"1,1",2');
+        });
 
-        it('does not wrap with double quotes if there are no new lines', () => {});
+        it('encodes double quotes with ""', () => {
+            const service: CsvExporterService = TestBed.get(CsvExporterService);
+            expect(service.createCsv([['a', 'b'], ['1"2', 2]])).toEqual('a,b\n"1""2",2');
+        });
 
-        it('encodes double quotes with ""', () => {});
+        it('encodes dates with locale strings', () => {
+            const service: CsvExporterService = TestBed.get(CsvExporterService);
+            const date = new Date(0);
+            const localeString = date.toLocaleString();
+            expect(service.createCsv([['a', 'b'], [date, 2]])).toEqual(`a,b
+"${localeString}",2`);
+        });
+
+        it('prints null and undefined as an empty string', () => {
+            const service: CsvExporterService = TestBed.get(CsvExporterService);
+            expect(service.createCsv([['a', 'b'], [null, undefined]])).toEqual('a,b\n,');
+        });
     });
 
-    describe('downloadCsvFile', () => {
-        it('creates and clicks a link', () => {});
+    describe('downloadCsvFile - msSaveBlob', () => {
+        // Currently, msSaveBlob is available in both IE and Chrome
+        const msSaveBlob = navigator.msSaveBlob;
+        beforeEach(() => {
+            if (!msSaveBlob) {
+                // Empty stub, will be spied on
+                navigator.msSaveBlob = (): any => {};
+            }
+        });
 
-        it('calls and clicks a link', () => {});
+        afterEach(() => {
+            // Restore empty msSaveBlob only if we didn't stub it.
+            // Ensures we get coverage of the non msSaveBlob path
+            if (!msSaveBlob) {
+                delete navigator.msSaveBlob;
+            }
+        });
+
+        it('uses navigator.msSaveBlob if available', () => {
+            const service: CsvExporterService = TestBed.get(CsvExporterService);
+            const rows = [['a', 'b'], ['1"2', 2], [3, 4]];
+            const csvString = service.createCsv(rows);
+
+            // Don't use spyOn, otherwise it would restore the empty function in its own afterEach()
+            navigator.msSaveBlob = jasmine.createSpy('msSaveBlob');
+            service.downloadCsvFile(csvString, 'test');
+            expect(navigator.msSaveBlob).toHaveBeenCalled();
+        });
+    });
+
+    describe('downloadCsvFile - creating a link', () => {
+        // Make sure msSaveBlob is not defined
+        const msSaveBlob = navigator.msSaveBlob;
+        beforeEach(() => {
+            if (msSaveBlob) {
+                delete navigator.msSaveBlob;
+            }
+        });
+
+        afterEach(() => {
+            if (msSaveBlob) {
+                navigator.msSaveBlob = msSaveBlob;
+            }
+        });
+        it('creates and clicks an invisible link', () => {
+            const service: CsvExporterService = TestBed.get(CsvExporterService);
+            const rows = [['a', 'b'], ['1"2', 2], [3, 4]];
+            const csvString = service.createCsv(rows);
+            spyOn(document.body, 'appendChild');
+            spyOn(document.body, 'removeChild');
+            const linkSpy = jasmine.createSpyObj('linkSpy', ['click', 'setAttribute', 'style']);
+            spyOn(document, 'createElement').and.returnValue(linkSpy);
+            service.downloadCsvFile(csvString, 'test');
+            expect(document.body.appendChild).toHaveBeenCalled();
+            expect(document.body.removeChild).toHaveBeenCalled();
+            expect(linkSpy.click).toHaveBeenCalled();
+            expect(linkSpy.setAttribute).toHaveBeenCalled();
+            expect(linkSpy.style.visibility).toBe('hidden');
+        });
     });
 });

--- a/projects/components/src/data-exporter/csv-exporter.service.ts
+++ b/projects/components/src/data-exporter/csv-exporter.service.ts
@@ -28,6 +28,7 @@ export class CsvExporterService {
     public downloadCsvFile(csvFile: string, filename: string): void {
         const mimeType = 'text/csv;charset=utf-8;';
         const blob = new Blob([csvFile], { type: mimeType });
+        // Jan 1, 2020 - Chrome and IE support this
         if (navigator.msSaveBlob) {
             navigator.msSaveBlob(blob, filename);
         } else {
@@ -47,7 +48,7 @@ export class CsvExporterService {
  * Returns a string
  * @param row A list of cells to be turned into a CSV string, separated by commas
  */
-function processRow(row: any[]): string {
+function processRow(row: unknown[]): string {
     return row.map(cell => encodeValue(cell)).join(',');
 }
 
@@ -55,8 +56,8 @@ function processRow(row: any[]): string {
  * Returns a cell's cellValue encoded against spaces, quotes, and CSV injection character
  * @param cellValue Cell cellValue to be encoded
  */
-function encodeValue(cellValue: any): string {
-    let innerValue = cellValue === null ? '' : cellValue.toString();
+function encodeValue(cellValue: unknown): string {
+    let innerValue = cellValue == null ? '' : cellValue.toString();
     if (cellValue instanceof Date) {
         innerValue = cellValue.toLocaleString();
     }
@@ -79,9 +80,9 @@ function encodeValue(cellValue: any): string {
  * Prepends a single quote to a value if it starts with =,+,=,@ to prevent formulas from being executed
  * @param value Value to be escaped
  */
-function escapeAgainstCsvInjection(value: string): string {
-    if (/^[=+\-@|%]/.test(value)) {
-        return `'${value}'`;
-    }
-    return value;
-}
+// function escapeAgainstCsvInjection(value: string): string {
+//     if (/^[=+\-@|%]/.test(value)) {
+//         return `'${value}'`;
+//     }
+//     return value;
+// }

--- a/projects/components/src/data-exporter/data-exporter.component.html
+++ b/projects/components/src/data-exporter/data-exporter.component.html
@@ -1,4 +1,4 @@
-<clr-modal [clrModalOpen]="open" (clrModalOpenChange)="openChange.emit($event)" [clrModalSize]="'sm'">
+<clr-modal [clrModalOpen]="open" (clrModalOpenChange)="openChange.emit($event)" [clrModalSize]="'sm'" #modal>
     <h3 class="modal-title">{{ dialogHeader }}</h3>
     <div class="modal-body">
         <button
@@ -10,7 +10,7 @@
         >
             Select All
         </button>
-        <ul class="list-unstyled" [formGroup]="formGroup">
+        <ul class="list-unstyled column-selection" [formGroup]="formGroup">
             <li *ngFor="let col of columns">
                 <clr-checkbox-wrapper>
                     <input type="checkbox" clrCheckbox [formControlName]="col.fieldName" />
@@ -25,8 +25,10 @@
     <hr />
 
     <div class="modal-footer">
-        <button type="button" class="btn btn-outline" (click)="open = false">Cancel</button>
-        <button type="button" class="btn btn-primary" [disabled]="!isExportEnabled" (click)="onClickExport()">
+        <button type="button" class="btn btn-outline cancel" (click)="open = false">
+            Cancel
+        </button>
+        <button type="button" class="btn btn-primary export" [disabled]="!isExportEnabled" (click)="onClickExport()">
             Export
         </button>
     </div>

--- a/projects/components/src/data-exporter/data-exporter.component.spec.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.spec.ts
@@ -11,6 +11,9 @@ import { Component } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DataExporterWidgetObject } from './data-exporter.wo';
 import { HasFinder, WidgetFinder } from '../utils/test/widget-object';
+import { CsvExporterService } from './csv-exporter.service';
+
+type TestHostFinder = HasFinder<TestHostComponent>;
 
 describe('VcdExportTableComponent', () => {
     beforeEach(async () => {
@@ -30,59 +33,185 @@ describe('VcdExportTableComponent', () => {
         }
     });
 
+    function openDataExporter(finder: WidgetFinder<TestHostComponent>): void {
+        finder.hostComponent.dataExporterOpen = true;
+        finder.detectChanges();
+    }
+
     describe('opening/closing with two way binding and ngIf', () => {
         it('does not display in the DOM when closed', function(this: HasFinder): void {
-            expect(this.finder.find({ woConstructor: DataExporterWidgetObject })).toBeNull();
+            expect(this.finder.findWidgets(DataExporterWidgetObject).length).toBe(0);
         });
 
-        it('is added to the DOM when displayed', function(this: HasFinder): void {
-            (this.finder.fixture.componentInstance as TestHostComponent).dataExporterOpen = true;
-            this.finder.fixture.detectChanges();
-            expect(this.finder.find({ woConstructor: DataExporterWidgetObject })).not.toBeNull();
+        it('is added to the DOM when displayed', function(this: TestHostFinder): void {
+            openDataExporter(this.finder);
+            expect(this.finder.findWidgets(DataExporterWidgetObject).length).toBe(1);
         });
 
-        it('is removed from the DOM after being closed by the user', function(this: HasFinder): void {
-            (this.finder.fixture.componentInstance as TestHostComponent).dataExporterOpen = true;
-            this.finder.fixture.detectChanges();
-            this.finder.find({ woConstructor: DataExporterWidgetObject }).clickCancel();
-            expect(this.finder.find({ woConstructor: DataExporterWidgetObject })).toBeNull();
+        it('is removed from the DOM after being closed by the user', function(this: TestHostFinder): void {
+            openDataExporter(this.finder);
+            this.finder.find(DataExporterWidgetObject).clickCancel();
+            expect(this.finder.findWidgets(DataExporterWidgetObject).length).toBe(0);
         });
     });
 
-    describe('columns', () => {
-        it('displays them as checkboxes', () => {});
+    describe('@Input: columns', () => {
+        it('displays them as checkboxes', function(this: TestHostFinder): void {
+            openDataExporter(this.finder);
+            expect(this.finder.find(DataExporterWidgetObject).columnCheckBoxes).toEqual(['Name', 'Description']);
+        });
     });
 
-    describe('fileName', () => {
-        it('customizes the file to be downloaded', () => {});
+    describe('@Input: fileName', () => {
+        it('customizes the file to be downloaded', function(this: TestHostFinder): void {
+            openDataExporter(this.finder);
+            const exporter = this.finder.find(DataExporterWidgetObject);
+            exporter.component.fileName = 'my-export.csv';
+            const downloadService = TestBed.get(CsvExporterService) as CsvExporterService;
+            const spy = spyOn(downloadService, 'downloadCsvFile');
+            spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
+                e.exportData(TestData.exportData);
+                expect(spy.calls.mostRecent().args[1]).toBe('my-export.csv');
+            });
+            exporter.clickExport();
+        });
     });
 
-    describe('showSelectAll', () => {
-        it('hides the select all columns option when set to false', () => {});
+    describe('@Input: showSelectAll', () => {
+        it('hides the select all columns option when set to false', function(this: TestHostFinder): void {
+            openDataExporter(this.finder);
+            const exporter = this.finder.find(DataExporterWidgetObject);
+            exporter.component.showSelectAll = false;
+            this.finder.detectChanges();
+            expect(this.finder.find(DataExporterWidgetObject).isSelectAllVisible).toBe(false);
+        });
+        it('is disabled when all checkboxes are clicked', function(this: TestHostFinder): void {
+            openDataExporter(this.finder);
+            const exporter = this.finder.find(DataExporterWidgetObject);
+            expect(exporter.isSelectAllEnabled).toBe(false);
+        });
+
+        it('selects all checkboxes when clicked', function(this: TestHostFinder): void {
+            openDataExporter(this.finder);
+            const exporter = this.finder.find(DataExporterWidgetObject);
+            exporter.clickColumn(0);
+            exporter.clickColumn(1);
+            expect(exporter.isSelectAllEnabled).toBe(true);
+            exporter.clickSelectAll();
+            expect(exporter.columnCheckBoxes);
+        });
     });
 
-    describe('@Output', () => {
-        describe('dataExportRequest', () => {
-            describe('updateProgress', () => {
-                it('updates the progress bar', () => {});
-                it('displays a looping progress bar when set to -1', () => {});
+    describe('@Output - dataExporter', () => {
+        describe('updateProgress', () => {
+            it('displays a looping progress bar when set to -1', function(this: TestHostFinder): void {
+                openDataExporter(this.finder);
+                const exporter = this.finder.find(DataExporterWidgetObject);
+                const downloadService = TestBed.get(CsvExporterService) as CsvExporterService;
+                spyOn(downloadService, 'downloadCsvFile');
+
+                spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
+                    e.updateProgress(-1);
+                    this.finder.detectChanges();
+                    expect(exporter.isLoopingProgressBar).toBe(true, 'Looping bar should have been visible');
+                });
+                exporter.clickExport();
             });
 
-            describe('exportData', () => {
-                it('dismisses the dialog and calls the service to create a client side download', () => {});
-            });
-
-            describe('selectedColumns', () => {
-                it('contains the columns selected by the users', () => {});
+            it('updates the progress bar when passed values', function(this: TestHostFinder): void {
+                openDataExporter(this.finder);
+                const exporter = this.finder.find(DataExporterWidgetObject);
+                const downloadService = TestBed.get(CsvExporterService) as CsvExporterService;
+                spyOn(downloadService, 'downloadCsvFile');
+                spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
+                    e.updateProgress(0);
+                    expect(exporter.component.progress).toBe(0);
+                    e.updateProgress(0.5);
+                    expect(exporter.component.progress).toBe(0.5);
+                });
+                exporter.clickExport();
             });
         });
-    });
 
-    describe('Select All', () => {
-        it('selects all checkboxes when clicked', () => {});
-        it('is disabled when all checkboxes are clicked', () => {});
+        describe('exportData', () => {
+            it('dismisses the dialog and calls the service to create a client side download', function(this: TestHostFinder): void {
+                openDataExporter(this.finder);
+                const exporter = this.finder.find(DataExporterWidgetObject);
+                const downloadService = TestBed.get(CsvExporterService) as CsvExporterService;
+                spyOn(downloadService, 'downloadCsvFile');
+                spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
+                    e.exportData(TestData.exportData);
+                    this.finder.detectChanges();
+                    const exportData: unknown[][] = [
+                        TestData.exportColumns.map(col => col.displayName),
+                        ...TestData.exportData.map(row => Object.values(row)),
+                    ];
+                    const csvString = downloadService.createCsv(exportData);
+                    expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(
+                        csvString,
+                        exporter.component.fileName
+                    );
+                    this.finder.detectChanges();
+                    expect(this.finder.hostComponent.dataExporterOpen).toBe(false);
+                });
+
+                exporter.clickExport();
+            });
+
+            it('does not download a file if the dialog has been closed', function(this: TestHostFinder): void {
+                openDataExporter(this.finder);
+                const exporter = this.finder.find(DataExporterWidgetObject);
+                const downloadService = TestBed.get(CsvExporterService) as CsvExporterService;
+                spyOn(downloadService, 'downloadCsvFile');
+                spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
+                    exporter.clickCancel();
+                    e.exportData(TestData.exportData);
+                    this.finder.detectChanges();
+                    expect(downloadService.downloadCsvFile).not.toHaveBeenCalled();
+                    this.finder.detectChanges();
+                });
+
+                exporter.clickExport();
+            });
+
+            it('uses field name if there is no matching displayName for a field', function(this: TestHostFinder): void {
+                openDataExporter(this.finder);
+                const exporter = this.finder.find(DataExporterWidgetObject);
+                const downloadService = TestBed.get(CsvExporterService) as CsvExporterService;
+                spyOn(downloadService, 'downloadCsvFile');
+                spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
+                    e.exportData(TestData.exportDataWrongField);
+                    this.finder.detectChanges();
+                    expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(
+                        'noexist\nJack\nJill',
+                        exporter.component.fileName
+                    );
+                });
+
+                exporter.clickExport();
+            });
+        });
+
+        describe('selectedColumns', () => {
+            it('contains the columns selected by the users', function(this: TestHostFinder): void {
+                openDataExporter(this.finder);
+                const exporter = this.finder.find(DataExporterWidgetObject);
+                spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
+                    expect(e.selectedColumns).toEqual(TestData.exportColumns);
+                });
+                exporter.clickExport();
+            });
+        });
     });
 });
+
+const TestData = {
+    /** The progress calls that to updateProgress will be called with the following values */
+    progressStates: [-1, 0.5, 1],
+    exportColumns: [{ fieldName: 'name', displayName: 'Name' }, { fieldName: 'desc', displayName: 'Description' }],
+    exportData: [{ name: 'Jaak', desc: 'Tis what tis' }, { name: 'Jill', desc: 'Still tis what tis' }],
+    exportDataWrongField: [{ noexist: 'Jack' }, { noexist: 'Jill' }],
+};
 
 @Component({
     template: `
@@ -90,32 +219,15 @@ describe('VcdExportTableComponent', () => {
             *ngIf="dataExporterOpen"
             [(open)]="dataExporterOpen"
             [columns]="exportColumns"
+            (dataExportRequest)="onExportRequest($event)"
         ></vcd-data-exporter>
     `,
 })
 class TestHostComponent {
     dataExporterOpen = false;
 
-    exportColumns: ExportColumn[] = [
-        { fieldName: 'name', displayName: 'Name' },
-        { fieldName: 'desc', displayName: 'Description' },
-    ];
+    exportColumns: ExportColumn[] = TestData.exportColumns;
 
-    onExportRequest(request: DataExportRequestEvent): void {
-        let currentProgress = 0;
-
-        const updateProgress = () => {
-            currentProgress += 0.2;
-            if (currentProgress < 1) {
-                request.updateProgress(currentProgress);
-                setTimeout(updateProgress, 50);
-            } else {
-                request.exportData([
-                    { name: 'Jaak', desc: 'Tis what tis' },
-                    { name: 'Jill', desc: 'Still tis what tis' },
-                ]);
-            }
-        };
-        updateProgress();
-    }
+    // Will be mocked in tests
+    onExportRequest(request: DataExportRequestEvent): void {}
 }

--- a/projects/components/src/data-exporter/data-exporter.component.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.ts
@@ -36,7 +36,7 @@ export interface DataExportRequestEvent {
      * This should only be called once after all data fetching is finished
      * @param records Records to be converted into a csv file
      */
-    exportData: (records: any[]) => void;
+    exportData: (records: object[]) => void;
 
     /**
      * Columns selected by the user.
@@ -82,10 +82,19 @@ export class DataExporterComponent implements OnInit {
     /**
      * Whether the dialog is open
      */
-    @Input() open = false;
+    @Input()
+    set open(value: boolean) {
+        this._open = value;
+        this.openChange.emit(value);
+    }
+    get open(): boolean {
+        return this._open;
+    }
+
+    private _open = false;
 
     /**
-     * Fires when {@link open} changes. Its parameter indicates the new state.
+     * Fires when {@link _open} changes. Its parameter indicates the new state.
      */
     @Output() openChange = new EventEmitter<boolean>();
 
@@ -116,8 +125,8 @@ export class DataExporterComponent implements OnInit {
     onClickExport(): void {
         this._isRequestPending = true;
         this.dataExportRequest.emit({
-            exportData: this.exportData,
-            updateProgress: this.updateProgress,
+            exportData: this.exportData.bind(this),
+            updateProgress: this.updateProgress.bind(this),
             selectedColumns: this.columns.filter(col => this.formGroup.controls[col.fieldName].value),
         });
     }
@@ -157,7 +166,7 @@ export class DataExporterComponent implements OnInit {
         this.formGroup = new FormGroup(controls);
     }
 
-    private exportData = (records: any[]) => {
+    private exportData(records: object[]): void {
         if (!this.open) {
             return;
         }
@@ -173,11 +182,11 @@ export class DataExporterComponent implements OnInit {
 
         const csvFile = this.csvExporterService.createCsv(rows);
         this.csvExporterService.downloadCsvFile(csvFile, this.fileName);
-    };
+    }
 
-    private updateProgress = (progress: number) => {
+    private updateProgress(progress: number): void {
         this._progress = progress;
-    };
+    }
 
     private getDisplayNameForField(fieldName: string): string {
         for (const column of this.columns) {

--- a/projects/components/src/data-exporter/data-exporter.wo.ts
+++ b/projects/components/src/data-exporter/data-exporter.wo.ts
@@ -5,22 +5,70 @@
 
 import { DataExporterComponent } from './data-exporter.component';
 import { WidgetObject } from '../utils/test/widget-object';
+import { DebugElement } from '@angular/core';
 
+const Css = {
+    SelectAll: '.select-all',
+    SelectColumn: '.column-selection label',
+};
 /**
  * Testing Object for {@link DataExporterComponent}
  */
 export class DataExporterWidgetObject extends WidgetObject<DataExporterComponent> {
     static tagName = 'vcd-data-exporter';
 
-    get isOpen(): boolean {
-        return this.component.open;
+    /**
+     * Whether the progress bar is currently showing indefinite progress, that is a looping loading indicator
+     */
+    get isLoopingProgressBar(): boolean {
+        return !!this.findElement('.progress.loop');
     }
 
+    /**
+     * The strings for the available check boxes
+     */
     get columnCheckBoxes(): string[] {
-        return this.findElements('.column-selection ').map(el => this.getText(el));
+        return this.getTexts('.column-selection label');
+    }
+
+    /**
+     * Whether the select all button is displayed
+     */
+    get isSelectAllVisible(): boolean {
+        return !!this.selectAllLink;
+    }
+
+    private get selectAllLink(): DebugElement {
+        return this.findElement(Css.SelectAll);
+    }
+
+    /**
+     * Click the select all link. Throws an error if the link is not available
+     */
+    clickSelectAll(): void {
+        this.click(Css.SelectAll);
+    }
+
+    /**
+     * Whether the select all link is enabled. Throws an error if link is not available
+     */
+    get isSelectAllEnabled(): boolean {
+        return !this.selectAllLink.nativeElement.disabled;
+    }
+
+    /**
+     * Clicks the checkbox for a colum
+     * @param index Index of column, 0 based
+     */
+    clickColumn(index: number): void {
+        this.click(`.column-selection li:nth-of-type(${index + 1}) label`);
     }
 
     clickCancel(): void {
         this.click('.cancel');
+    }
+
+    clickExport(): void {
+        this.click('.export');
     }
 }

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -11,19 +11,18 @@ const ROW_TAG = 'clr-dg-row';
 const CELL_TAG = 'clr-dg-cell';
 const COLUMN_CSS_SELECTOR = '.datagrid-column';
 
+/**
+ * Can be used by anyone who needs to assert information about a Clarity DataGrid
+ */
 export class DatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     static tagName = `clr-datagrid`;
 
-    private getCell(row: number, column: number): Element {
-        return this.root.nativeElement.querySelectorAll(ROW_TAG)[row].querySelectorAll(CELL_TAG)[column];
-    }
-
     getCellText(row: number, column: number): string {
-        return this.getText(this.getCell(row, column));
+        return this.getText(`${ROW_TAG}:nth-of-type(${row + 1}) ${CELL_TAG}:nth-of-type(${column + 1})`);
     }
 
     private get columns(): DebugElement[] {
-        return this.findElements(COLUMN_CSS_SELECTOR, this.root);
+        return this.findElements(COLUMN_CSS_SELECTOR);
     }
 
     get columnCount(): number {
@@ -31,15 +30,15 @@ export class DatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     getColumnHeader(columnIndex: number): string {
-        return this.getText(this.columns[columnIndex]);
+        return this.getText(`${COLUMN_CSS_SELECTOR}:nth-of-type(${columnIndex + 1})`);
     }
 
     get columnHeaders(): string[] {
-        return this.columns.map(col => this.getText(col));
+        return this.getTexts(COLUMN_CSS_SELECTOR);
     }
 
     private get rows(): DebugElement[] {
-        return this.root.nativeElement.querySelectorAll(ROW_TAG);
+        return this.findElements(ROW_TAG);
     }
 
     get rowCount(): number {

--- a/projects/components/src/utils/test/widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object.spec.ts
@@ -47,14 +47,6 @@ class ClickTrackerWidgetObject extends WidgetObject<ClickTrackerComponent> {
         return this.getText('h1');
     }
 
-    /**
-     * Tests should not return DebugElements, this is just to showcase the base class's findElement
-     */
-    get itself(): DebugElement {
-        // Since we're not passing a selector, or a parent, the root debug element is returned
-        return this.findElement();
-    }
-
     clickTrackedElement(): void {
         // Clicking requires the DOM
         this.click('p');
@@ -121,9 +113,7 @@ describe('WidgetFinder', () => {
 
             it('throws an error if multiple widgets are found', function(this: HasFinder): void {
                 expect(() => {
-                    this.finder.find({
-                        woConstructor: ClickTrackerWidgetObject,
-                    });
+                    this.finder.find(ClickTrackerWidgetObject);
                 }).toThrow();
             });
         });
@@ -145,7 +135,7 @@ describe('WidgetFinder', () => {
 
         describe('find', () => {
             it('returns the first one within the fixture if no classname is specified', function(this: HasFinder): void {
-                const widget = this.finder.find({ woConstructor: ClickTrackerWidgetObject });
+                const widget = this.finder.find(ClickTrackerWidgetObject);
                 expect(widget.headerText).toBe('First');
             });
         });
@@ -193,12 +183,6 @@ describe('WidgetObject (through ClickTracerWidgetObject)', () => {
         it('calls detectChanges after clicking', function(this: HasClickTracker): void {
             this.clickTracker.clickTrackedElement();
             expect(this.clickTracker.clickCount).toBe(1);
-        });
-    });
-
-    describe('findElement', () => {
-        it('returns the element itself when no CSS query is passed in', function(this: HasClickTracker): void {
-            expect(this.clickTracker.itself.componentInstance).toBe(this.clickTracker.component);
         });
     });
 });

--- a/projects/examples/src/app/app.component.spec.ts
+++ b/projects/examples/src/app/app.component.spec.ts
@@ -6,11 +6,15 @@
 import { TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
+import { ClarityModule } from '@clr/angular';
+import { ComponentsModule } from '../../../components/src/lib/components.module';
+import { DataExporterModule } from '../../../components/src/data-exporter/data-exporter.module';
+import { DocLibModule } from '../../../doc-lib/src/lib/doc-lib.module';
 
 describe('AppComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [RouterTestingModule],
+            imports: [RouterTestingModule, ClarityModule, DataExporterModule, DocLibModule],
             declarations: [AppComponent],
         }).compileComponents();
     });

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { FormsModule } from '@angular/forms';
 
 import localeFr from '@angular/common/locales/fr';
 import localeEs from '@angular/common/locales/es';
+import { ComponentsModule } from '../../../components/src/lib/components.module';
 
 registerLocaleData(localeFr, 'fr');
 registerLocaleData(localeEs, 'es');


### PR DESCRIPTION
## Description

Some slightly unrelated changes were applied

* Made minor changes to the datagrid widget object to better comply with how it searches, that is, it should not rely on DOM searches and should prefer using DebugElement for queries. That way, you can still grab references to angular child components attached to the DebugElement
* Added Components module to app.module since main app wasn't running.

## Testing Done:

* Ensured 100% coverage for the components project
* Fixed examples unit tests that had been broken

Signed-off-by: Juan Mendes <jmendes@vmware.com>