### PR TITLE
Topic/rbradford/select grid

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -8,7 +8,12 @@
         <ng-template #notHideable>{{ column.displayName }}</ng-template>
     </clr-dg-column>
 
-    <clr-dg-row *ngFor="let restItem of items; let i = index" [ngClass]="this.clrDatarowCssClassGetter(restItem, i)">
+    <clr-dg-row
+        *ngFor="let restItem of items; let i = index"
+        [ngForTrackBy]="trackBy"
+        [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
+        [clrDgItem]="restItem"
+    >
         <clr-dg-cell *ngFor="let column of columnsConfig">
             <!-- Default renderer -->
             <ng-container *ngIf="column.fieldName">{{ restItem | nestedProperty: column.fieldName }}</ng-container>
@@ -31,6 +36,5 @@
             </clr-dg-row-detail>
         </ng-container>
     </clr-dg-row>
-
     <clr-dg-footer> </clr-dg-footer>
 </clr-datagrid>

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -103,7 +103,7 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     sortColumn(index: number): void {
         this.columns[index].nativeElement.click();
     }
-    
+
     /**
      * Returns the selection type of the grid.
      */

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { GridSelectionType } from './../../../datagrid/datagrid.component';
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
 import { WidgetObject } from '../widget-object';
 import { DebugElement } from '@angular/core';
 import { ClrDatagrid } from '@clr/angular';
@@ -96,6 +102,26 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
      */
     sortColumn(index: number): void {
         this.columns[index].nativeElement.click();
+    }
+    
+    /**
+     * Returns the selection type of the grid.
+     */
+    getSelectionType(): GridSelectionType {
+        if (this.findElements('clr-checkbox-wrapper').length !== 0) {
+            return GridSelectionType.Multi;
+        } else if (this.findElements('clr-radio-wrapper').length !== 0) {
+            return GridSelectionType.Single;
+        } else {
+            return GridSelectionType.None;
+        }
+    }
+
+    /**
+     * Clicks the selection icon on the given row.
+     */
+    selectRow(row: number): void {
+        this.click(`input`, this.rows[row]);
     }
 
     /**

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -67,9 +67,10 @@ export abstract class WidgetObject<T> {
      * Clicks an element and detects changes so the DOM is immediately updated
      * @param cssSelector Pass this in if you want to click a specific element. If not passed in, the entire node will
      * receive the click event
+     * @param parent the parent element for which to search for the {@param cssSelector} within. Defaults to root if not provided.
      */
-    protected click(cssSelector?: string): void {
-        const nativeElement: HTMLBaseElement = this.findElement(cssSelector).nativeElement;
+    protected click(cssSelector?: string, parent: DebugElement = this.root): void {
+        const nativeElement: HTMLBaseElement = parent.query(By.css(cssSelector)).nativeElement;
         nativeElement.click();
         this.detectChanges();
     }

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { registerLocaleData } from '@angular/common';
+
 import localeFr from '@angular/common/locales/fr';
 import localeEs from '@angular/common/locales/es';
 import { FormsModule } from '@angular/forms';

--- a/projects/examples/src/components/datagrid/datagrid-row-select.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-select.example.component.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { GridDataFetchResult, GridState, GridColumn, GridSelectionType } from '@vcd/ui-components';
+
+interface Data {
+    href: string;
+}
+
+/**
+ * Logs the selected row to the console when the selection changes.
+ * Allows for multi, single, or no selection.
+ */
+@Component({
+    selector: 'vcd-datagrid-row-select-example',
+    template: `
+    <button class="btn btn-primary" (click)="selectionType = GridSelectionType.Single">Single Select</button>
+    <button class="btn btn-primary" (click)="selectionType = GridSelectionType.Multi">Multi Select Select</button>
+    <button class="btn btn-primary" (click)="selectionType = GridSelectionType.None">No Select Select</button>
+    <button class="btn btn-primary" (click)="this.newData()">New Data</button>
+    <vcd-datagrid
+        [gridData]="gridData"
+        (gridRefresh)="refresh($event)"
+        [columns]="columns"
+        [selectionType]="selectionType"
+        (selectionChanged)="selectionChanged($event)"
+    ></vcd-datagrid>`,
+})
+export class DatagridRowSelectExampleComponent {
+    selectionType = GridSelectionType.Multi;
+    GridSelectionType = GridSelectionType;
+
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Some Column',
+            renderer: 'href',
+        },
+    ];
+
+    selectionChanged(selected: Data[]): void {
+        console.log(selected);
+    }
+
+    refresh(eventData: GridState<Data>): void {
+        this.gridData = {
+            items: [{ href: 'a' }, { href: 'b' }, { href: 'c' }],
+            totalItems: 2,
+            pageSize: 2,
+            page: 1,
+        };
+    }
+
+    newData(): void {
+        this.gridData = {
+            items: [{ href: 'a' }, { href: 'b' }, { href: 'd' }],
+            totalItems: 2,
+            pageSize: 2,
+            page: 1,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-row-select.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-select.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DatagridModule } from '@vcd/ui-components';
+import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
+
+@NgModule({
+    declarations: [DatagridRowSelectExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    exports: [DatagridRowSelectExampleComponent],
+    entryComponents: [DatagridRowSelectExampleComponent],
+})
+export class DatagridRowSelectExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -16,6 +16,8 @@ import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example
 import { DatagridDetailRowExampleModule } from './datagrid-detail-row.example.module';
 import { DatagridSortExampleModule } from './datagrid-sort.example.module';
 import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
+import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
+import { DatagridRowSelectExampleModule } from './datagrid-row-select.example.module';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -47,6 +49,11 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Shows the sorting capability of the datagrid',
         },
+        {
+            component: DatagridRowSelectExampleComponent,
+            forComponent: null,
+            title: 'Select datagrid row example',
+        },
     ],
 });
 /**
@@ -59,6 +66,7 @@ Documentation.registerDocumentationEntry({
         DatagridShowHideExampleModule,
         DatagridDetailRowExampleModule,
         DatagridSortExampleModule,
+        DatagridRowSelectExampleModule
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
### Description

Implements the clarity grid row selection features for the VCD datagrid. Allows for both single and multi selection.

### Testing Done

Added a unit test that tests single, multi, and no selection types. Tests the output for single and multi also. 

Also, added an example that shows both single and multi selection:

![select-rows](https://user-images.githubusercontent.com/7528512/72930602-45f7a600-3d2a-11ea-98cd-ae19b3b23148.gif)