### PR TITLE
Update the CI-CD with Pages deployment and npm registry publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ cache:
     directories:
         - dist/components
         - dist/doc-lib
+        - dist/examples
 stages:
     - prepare
-    - build-libs
-    - build-app
+    - build-components-lib
+    - build-doc-lib
+    - build-app-aot
     - test
-    - name: publish
-      if: branch = master
+    - publish
+    - deploy
 jobs:
     include:
         - stage: prepare
@@ -24,20 +26,68 @@ jobs:
           name: Lint /examples
           script: npm run lint examples
 
-        - stage: build-libs
+        - stage: build-components-lib
           name: Build /components
           script: npm run build:components
-        - stage: build-libs
+
+        - stage: build-doc-lib
           name: Build /doc-lib
           script: npm run build:doc-lib
 
-        - stage: build-app
+        - stage: build-app-aot
           name: Build /examples
-          script: npm run build:examples
+          before_script:
+              - cd ./projects/doc-lib
+              - npm ci
+              - cd ../../
+              - npm run build-components-doc
+              - npm run build-examples-doc
+          script: npm run build:examples-aot
 
         - stage: test
           name: Unit tests for /components
           script: npm run test:ci:components
+
         - stage: test
           name: Unit Tests for /doc-lib
           script: npm run test:ci:doc-lib
+
+        - stage: publish
+          name: Publishing components to npm registry
+          script: skip
+          before_deploy:
+              - cd ./dist/components
+          deploy:
+              edge: true
+              skip_cleanup: true
+              provider: npm
+              api_key:
+                  secure: $NPM_TOKEN
+              on:
+                  repo: vmware/vmware-cloud-director-ui-components
+                  tags: true
+                  condition: $TRAVIS_TAG =~ ^components-v[0-999].[0-999].[0-999]$
+        - stage: publish
+            name: Publishing doc-lib to npm registry
+            script: skip
+            before_deploy:
+              - cd ./dist/doc-lib
+            deploy:
+              edge: true
+              skip_cleanup: true
+              provider: npm
+              api_key:
+                secure: $NPM_TOKEN
+              on:
+                repo: vmware/vmware-cloud-director-ui-components
+                tags: true
+                condition: $TRAVIS_TAG =~ ^doc-lib-v[0-999].[0-999].[0-999]$
+
+        - stage: deploy
+          name: Deploying to Github pages
+          script: skip
+          deploy:
+              - provider: pages
+                skip_cleanup: true
+                github_token: $GH_TOKEN
+                local_dir: dist/examples

--- a/package-lock.json
+++ b/package-lock.json
@@ -4266,6 +4266,12 @@
         "path-type": "^3.0.0"
       }
     },
+    "directory-tree": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/directory-tree/-/directory-tree-2.2.4.tgz",
+      "integrity": "sha512-2N43msQptKbi3WMfIs+U09yi6bfyKL+MWyj5VMj8t1F/Tx04bt1cn/EEIU3o1JBltlJk7NQnzOEuTNa/KQvbWA==",
+      "dev": true
+    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,19 +3,14 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "//": "Serves the application, running all required scripts. After initial start, just run ng serve unless you have modified the libraries",
+    "//": "Requires running build: doc-lib",
     "start": "ng build doc-lib; ng build components; npm run build:doc-lib:scripts-dev; npm run build-components-doc; npm run build-examples-doc; ng serve",
-
     "build:examples": "ng build examples",
     "build:examples-aot": "ng build examples --aot=true",
     "build:components": "ng build components",
-
-    "build:doc-lib": "ng build doc-lib; npm run build:doc-lib:scripts-dist",
-    "//": "Compiles the TS and JS into dist, used for packaging",
+    "build:doc-lib": "ng build doc-lib; npm run build:doc-lib:scripts-dist; npm run build:doc-lib:scripts-dev",
     "build:doc-lib:scripts-dist": "tsc -p projects/doc-lib/scripts/tsconfig.dist.json",
-    "//": "Compiles the TS into the dev environment, required by build-components-doc and build-examples-doc",
     "build:doc-lib:scripts-dev": "tsc -p projects/doc-lib/scripts/tsconfig.dev.json",
-
     "test": "ng test",
     "test-coverage": "ng test --code-coverage --watch=false",
     "test:ci:doc-lib": "ng test doc-lib --watch=false --browsers ChromeHeadlessNoSandbox --code-coverage",
@@ -26,11 +21,8 @@
     "lint-fix": "tslint --fix 'projects/**/*.ts' -e 'projects/doc-lib/node_modules/**/*.ts'",
 
     "e2e": "ng e2e",
-
-    "//": "Requires running build: doc-lib",
-    "build-components-doc": "cd projects/doc-lib; node $NODE_DEBUG_OPTION scripts/index.js ../components/tsconfig.lib.json ../components/src/public-api.ts ../examples/gen/components-doc.json",
-    "build-examples-doc": "cd projects/doc-lib; node $NODE_DEBUG_OPTION scripts/index.js ../examples/tsconfig.app.json ../examples/src/main.ts ../examples/gen/examples-doc.json"
-
+    "build-components-doc": "mkdir -p projects/examples/gen; cd projects/doc-lib; node $NODE_DEBUG_OPTION scripts/index.js ../components/tsconfig.lib.json ../components/src/public-api.ts ../examples/gen/components-doc.json",
+    "build-examples-doc": "mkdir -p projects/examples/gen; cd projects/doc-lib; node $NODE_DEBUG_OPTION scripts/index.js ../examples/tsconfig.app.json ../examples/src/main.ts ../examples/gen/examples-doc.json"
   },
   "private": true,
 

--- a/projects/components/src/cliptext/cliptext.component.spec.ts
+++ b/projects/components/src/cliptext/cliptext.component.spec.ts
@@ -143,6 +143,11 @@ describe('ClipTextComponent', () => {
     template: `
         <vcd-cliptext style="width: 3em">{{ text }}</vcd-cliptext>
     `,
+    styles: [
+        `vcd-cliptext ::ng-deep clr-tooltip {
+            width: 200px
+        }`
+    ]
 })
 class TestHostComponent {
     text = '';
@@ -152,5 +157,10 @@ class TestHostComponent {
     template: `
         <vcd-cliptext style="width: 3em">I am <b>bad</b></vcd-cliptext>
     `,
+    styles: [
+        `vcd-cliptext ::ng-deep clr-tooltip {
+            width: 10px
+        }`
+    ]
 })
 class TestHtmlHostComponent {}

--- a/projects/doc-lib/package-lock.json
+++ b/projects/doc-lib/package-lock.json
@@ -2223,7 +2223,8 @@
                                 },
                                 "ansi-regex": {
                                     "version": "2.1.1",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "aproba": {
                                     "version": "1.2.0",
@@ -2241,11 +2242,13 @@
                                 },
                                 "balanced-match": {
                                     "version": "1.0.0",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "brace-expansion": {
                                     "version": "1.1.11",
                                     "bundled": true,
+                                    "optional": true,
                                     "requires": {
                                         "balanced-match": "^1.0.0",
                                         "concat-map": "0.0.1"
@@ -2258,15 +2261,18 @@
                                 },
                                 "code-point-at": {
                                     "version": "1.1.0",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "concat-map": {
                                     "version": "0.0.1",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "console-control-strings": {
                                     "version": "1.1.0",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "core-util-is": {
                                     "version": "1.0.2",
@@ -2369,7 +2375,8 @@
                                 },
                                 "inherits": {
                                     "version": "2.0.4",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "ini": {
                                     "version": "1.3.5",
@@ -2379,6 +2386,7 @@
                                 "is-fullwidth-code-point": {
                                     "version": "1.0.0",
                                     "bundled": true,
+                                    "optional": true,
                                     "requires": {
                                         "number-is-nan": "^1.0.0"
                                     }
@@ -2391,17 +2399,20 @@
                                 "minimatch": {
                                     "version": "3.0.4",
                                     "bundled": true,
+                                    "optional": true,
                                     "requires": {
                                         "brace-expansion": "^1.1.7"
                                     }
                                 },
                                 "minimist": {
                                     "version": "0.0.8",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "minipass": {
                                     "version": "2.9.0",
                                     "bundled": true,
+                                    "optional": true,
                                     "requires": {
                                         "safe-buffer": "^5.1.2",
                                         "yallist": "^3.0.0"
@@ -2418,6 +2429,7 @@
                                 "mkdirp": {
                                     "version": "0.5.1",
                                     "bundled": true,
+                                    "optional": true,
                                     "requires": {
                                         "minimist": "0.0.8"
                                     }
@@ -2498,7 +2510,8 @@
                                 },
                                 "number-is-nan": {
                                     "version": "1.0.1",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "object-assign": {
                                     "version": "4.1.1",
@@ -2508,6 +2521,7 @@
                                 "once": {
                                     "version": "1.4.0",
                                     "bundled": true,
+                                    "optional": true,
                                     "requires": {
                                         "wrappy": "1"
                                     }
@@ -2583,7 +2597,8 @@
                                 },
                                 "safe-buffer": {
                                     "version": "5.1.2",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "safer-buffer": {
                                     "version": "2.1.2",
@@ -2613,6 +2628,7 @@
                                 "string-width": {
                                     "version": "1.0.2",
                                     "bundled": true,
+                                    "optional": true,
                                     "requires": {
                                         "code-point-at": "^1.0.0",
                                         "is-fullwidth-code-point": "^1.0.0",
@@ -2630,6 +2646,7 @@
                                 "strip-ansi": {
                                     "version": "3.0.1",
                                     "bundled": true,
+                                    "optional": true,
                                     "requires": {
                                         "ansi-regex": "^2.0.0"
                                     }
@@ -2668,11 +2685,13 @@
                                 },
                                 "wrappy": {
                                     "version": "1.0.2",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 },
                                 "yallist": {
                                     "version": "3.1.1",
-                                    "bundled": true
+                                    "bundled": true,
+                                    "optional": true
                                 }
                             }
                         },

--- a/projects/doc-lib/src/doc-lib.module.ts
+++ b/projects/doc-lib/src/doc-lib.module.ts
@@ -74,7 +74,7 @@ export class DocLibModule {
                 },
                 {
                     provide: StackBlitzWriterService,
-                    deps: [STACKBLITZ_DATA, DocumentationRetrieverService],
+                    deps: [STACKBLITZ_INFO, DocumentationRetrieverService],
                     useFactory: getStackBlitzWriter,
                 },
             ],


### PR DESCRIPTION
**Why?**
Deploy examples app to Github pages and publish the 2 libraries

**What?**
_Pages deployment:_
Build the examples app in aot mode and use that artifact from the ./dist to deploy. This is being done instead of production build config for building the app because, the prod config is resulting in a package([isuue](https://github.com/angular/angular-cli/issues/11915)) that is not working with the Compodoc JSONs.

_NPM publish:_
The publish stage jobs are conditional based on following conditions:
`($TRAVIS_REPO_SLUG = "vmware/vmware-cloud-director-ui-components") && 
("$TRAVIS_TAG" =~ ^LIB_NAME-v\d.\d.\d$) && 
("$TRAVIS_TAG" != "")`
They should be published to @vcd scope in the registry