### PR TITLE
Implemented details for grid rows

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -25,6 +25,11 @@
             >
             </ng-template>
         </clr-dg-cell>
+        <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="detailTemplate !== undefined">
+            <clr-dg-row-detail *clrIfExpanded>
+                <ng-content *ngTemplateOutlet="detailTemplate; context: { record: restItem }"> </ng-content>
+            </clr-dg-row-detail>
+        </ng-container>
     </clr-dg-row>
 
     <clr-dg-footer> </clr-dg-footer>

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, TemplateRef, ContentChild } from '@angular/core';
 import { DatagridComponent, GridDataFetchResult, GridState } from './datagrid.component';
 import { GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';
 import { TestBed } from '@angular/core/testing';
@@ -201,6 +201,23 @@ describe('DatagridComponent', () => {
                 expect(this.clrGridWidget.isColumnDisplayed(3)).toBe(true);
             });
         });
+
+        describe('Row expansion functionality', () => {
+            beforeEach(function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.columns = [
+                    {
+                        displayName: 'Column',
+                        renderer: 'name',
+                    },
+                ];
+                this.finder.detectChanges();
+            });
+
+            it('opens one detail pane when you click the button', function(this: HasFinderAndGrid): void {
+                this.clrGridWidget.clickDetailsButton(0);
+                expect(this.clrGridWidget.getAllDetailContents().length).toEqual(1);
+            });
+        });
     });
 
     describe('Column Renderers', () => {
@@ -253,7 +270,9 @@ describe('DatagridComponent', () => {
             [columns]="columns"
             [clrDatagridCssClass]="clrDatagridCssClass"
             [clrDatarowCssClassGetter]="clrDatarowCssClassGetter"
-        ></vcd-datagrid>
+        >
+            <ng-template let-record="record"> DETAILS: {{ record.name }} </ng-template>
+        </vcd-datagrid>
     `,
 })
 export class HostWithDatagridComponent {

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';
+import {
+    Component,
+    EventEmitter,
+    Input,
+    OnInit,
+    Output,
+    TemplateRef,
+    ViewChild,
+    ContentChild,
+    ElementRef,
+} from '@angular/core';
 import { FunctionRenderer, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';
 import { ClrDatagridFilter } from '@clr/angular';
 import { ComponentRendererSpec } from './interfaces/component-renderer.interface';
@@ -116,6 +126,8 @@ export class DatagridComponent<R> implements OnInit {
         this.isLoading = false;
         this.items = result.items;
     }
+
+    @ContentChild(TemplateRef, { static: false }) detailTemplate!: TemplateRef<ElementRef>;
 
     /**
      * Type of row selection on the grid

--- a/projects/components/src/datagrid/datagrid.module.ts
+++ b/projects/components/src/datagrid/datagrid.module.ts
@@ -12,13 +12,14 @@ import { PipesModule } from '../common/pipes/pipes.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FunctionRendererPipe } from './pipes/function-renderer.pipe';
 import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 const directives = [DatagridComponent, ComponentRendererOutletDirective];
 const pipes = [FunctionRendererPipe];
 const renderers = [BoldTextRendererComponent];
 
 @NgModule({
-    imports: [CommonModule, ClarityModule, PipesModule, ReactiveFormsModule],
+    imports: [CommonModule, ClarityModule, PipesModule, ReactiveFormsModule, BrowserAnimationsModule],
     declarations: [...directives, ...renderers, ...pipes],
     providers: [],
     exports: [DatagridComponent, ...renderers],

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -67,7 +67,6 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
      * Returns the CSS class of the Clarity datagrid.
      */
     get gridCssClass(): string[] {
-        console.log(this.root.classes);
         return Object.keys(this.root.classes);
     }
 
@@ -76,6 +75,20 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
      */
     getRowsCssClass(index: number): string[] {
         return Object.keys(this.rows[index].classes);
+    }
+
+    /**
+     * Returns the native element contents within all the detail pane open.
+     */
+    getAllDetailContents(): string[] {
+        return this.findElements('clr-dg-row-detail').map(detail => detail.nativeElement);
+    }
+
+    /**
+     * Clicks the given details button.
+     */
+    clickDetailsButton(row: number): void {
+        this.detailsButtons[row].nativeElement.click();
     }
 
     /**
@@ -95,5 +108,9 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
 
     private get columns(): DebugElement[] {
         return this.findElements(COLUMN_CSS_SELECTOR);
+    }
+
+    private get detailsButtons(): DebugElement[] {
+        return this.findElements('.datagrid-expandable-caret-button');
     }
 }

--- a/projects/examples/gen/components-compodoc-documentation/documentation.json
+++ b/projects/examples/gen/components-compodoc-documentation/documentation.json
@@ -1,0 +1,4924 @@
+{
+    "pipes": [
+        {
+            "name": "FunctionRendererPipe",
+            "id": "pipe-FunctionRendererPipe-27c07bcc8b8b7101e8bad7ce47a36363",
+            "file": "projects/components/src/datagrid/pipes/function-renderer.pipe.ts",
+            "type": "pipe",
+            "description": "<p>Used for executing the functions of column cells which use functions to calculate their values from different\nproperties of an object</p>\n",
+            "properties": [],
+            "methods": [
+                {
+                    "name": "transform",
+                    "args": [
+                        {
+                            "name": "item",
+                            "type": "any"
+                        },
+                        {
+                            "name": "renderer",
+                            "type": "function",
+                            "function": [
+                                {
+                                    "name": "val",
+                                    "type": "any"
+                                }
+                            ]
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 17,
+                    "modifierKind": [
+                        114
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "item",
+                            "type": "any",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "renderer",
+                            "type": "function",
+                            "function": [
+                                {
+                                    "name": "val",
+                                    "type": "any"
+                                }
+                            ],
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "pure": true,
+            "ngname": "functionRenderer",
+            "sourceCode": "import { Pipe, PipeTransform } from '@angular/core';\n\n/**\n * Used for executing the functions of column cells which use functions to calculate their values from different\n * properties of an object\n */\n@Pipe({\n    name: 'functionRenderer',\n    pure: true,\n})\nexport class FunctionRendererPipe implements PipeTransform {\n    public transform(item: any, renderer: (val: any) => any): string {\n        if (!item || !renderer) {\n            return null;\n        }\n        return renderer(item);\n    }\n}\n"
+        },
+        {
+            "name": "NestedPropertyPipe",
+            "id": "pipe-NestedPropertyPipe-62501f3ebba6bc3a1379a1a25de58770",
+            "file": "projects/components/src/common/pipes/nested-property.pipe.ts",
+            "type": "pipe",
+            "description": "<p>Used for extracting the value of nested property of an object.</p>\n<p>Example:\nconst obj = {\n     a: {\n         b: {\n             c: &#39;c&#39;\n         }\n     }\n}</p>\n<p>Invoking <code>{{ obj | nestedProperty: &#39;a.b.c&#39; }}</code> in a template produces c</p>\n",
+            "properties": [],
+            "methods": [
+                {
+                    "name": "transform",
+                    "args": [
+                        {
+                            "name": "item",
+                            "type": "any"
+                        },
+                        {
+                            "name": "property",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [
+                        "T"
+                    ],
+                    "line": 32,
+                    "modifierKind": [
+                        114
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "item",
+                            "type": "any",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "property",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "pure": true,
+            "ngname": "nestedProperty",
+            "sourceCode": "import { Inject, LOCALE_ID, Pipe, PipeTransform } from '@angular/core';\nimport { DatePipe, DecimalPipe } from '@angular/common';\n\nconst OBJECT_PROPERTY_SEPARATOR = '.';\nconst DATE_OBJECT_CLASS = '[object Date]';\n\n/**\n * Used for extracting the value of nested property of an object.\n *\n * Example:\n * const obj = {\n *     a: {\n *         b: {\n *             c: 'c'\n *         }\n *     }\n * }\n *\n * Invoking `{{ obj | nestedProperty: 'a.b.c' }}` in a template produces c\n */\n@Pipe({\n    name: 'nestedProperty',\n    pure: true,\n})\nexport class NestedPropertyPipe implements PipeTransform {\n    constructor(@Inject(LOCALE_ID) private localeId: string) {}\n    public transform<T>(item: any, property: string): string {\n        if (!item || !property) {\n            return null;\n        }\n        const splitProperty = property.split(OBJECT_PROPERTY_SEPARATOR);\n        let returnValue;\n        if (splitProperty.length > 1) {\n            let value = item;\n            for (const nestedProp of splitProperty) {\n                if (isNullOrUndefined(value) || isNullOrUndefined(value[nestedProp])) {\n                    return null;\n                }\n                value = value[nestedProp];\n            }\n            returnValue = value;\n        } else {\n            if (isNullOrUndefined(item[property])) {\n                return null;\n            }\n            returnValue = item[property];\n        }\n\n        if (typeof returnValue === 'number') {\n            return new DecimalPipe(this.localeId).transform(returnValue);\n        }\n        return returnValue instanceof Date ? new DatePipe(this.localeId).transform(returnValue) : returnValue;\n    }\n}\n\n/**\n * Utility method for covering the 'null' and 'undefined' checks as 'value == null' is equivalent to 'value === null || value === undefined'\n */\nfunction isNullOrUndefined(value: unknown): boolean {\n    return value == null;\n}\n"
+        }
+    ],
+    "interfaces": [
+        {
+            "name": "BoldTextRendererConfig",
+            "id": "interface-BoldTextRendererConfig-ef925c06bd38d69b8ef18b74dacdb84a",
+            "file": "projects/components/src/datagrid/renderers/bold-text-renderer.component.ts",
+            "type": "interface",
+            "sourceCode": "import { Component, Input } from '@angular/core';\nimport { ComponentRenderer } from '../interfaces/component-renderer.interface';\n\n/**\n * {@link ComponentRenderer.config} type that the {@link BoldTextRendererComponent} can understand\n */\nexport interface BoldTextRendererConfig {\n    /**\n     * Text to be displayed in bold font\n     */\n    text: string;\n}\n\n/**\n * A {@link ComponentRenderer} component that is used for rendering a bold text inside a column cell template\n *\n * @example Example usage with RendererSpec:\n *     columns: GridColumn<MockRecord>[] = [\n *       {\n *         displayName: 'Component Renderer',\n *         renderer: RendererSpec(\n *           BoldTextRendererComponent,\n *           (record: MockRecord) => ({text: record.name})\n *         )\n *       }\n *     ];\n */\n@Component({\n    template: `\n        <strong>{{ config.text }}</strong>\n    `,\n})\nexport class BoldTextRendererComponent implements ComponentRenderer<BoldTextRendererConfig> {\n    @Input()\n    config: BoldTextRendererConfig;\n}\n",
+            "properties": [
+                {
+                    "name": "text",
+                    "type": "string",
+                    "optional": false,
+                    "description": "<p>Text to be displayed in bold font</p>\n",
+                    "line": 16
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>{@link ComponentRenderer.config} type that the {@link BoldTextRendererComponent} can understand</p>\n",
+            "methods": []
+        },
+        {
+            "name": "Button",
+            "id": "interface-Button-854c889708b9cf13ff0ebef598ca2faa",
+            "file": "projects/components/src/datagrid/datagrid.component.ts",
+            "type": "interface",
+            "sourceCode": "import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';\nimport { FunctionRenderer, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';\nimport { ClrDatagridFilter } from '@clr/angular';\nimport { ComponentRendererSpec } from './interfaces/component-renderer.interface';\n\n/**\n * Different types of row selection on the grid\n */\nexport enum GridSelectionType {\n    /**\n     * For selecting multiple rows\n     */\n    Multi = 'MULTI',\n    /**\n     * For selecting only one row at a time\n     */\n    Single = 'SINGLE',\n    /**\n     * Disables the selection\n     */\n    None = 'NONE',\n}\n\n/**\n * TODO: This API is going to have more properties and is going to be defined as part of\n *  https://jira.eng.vmware.com/browse/VDUCC-21\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface Button {}\n\n/**\n * Representation of data required for rendering contents of cells and pagination information\n */\nexport interface GridDataFetchResult<R> {\n    /**\n     * Items to be listed in the grid\n     */\n    items: R[];\n    /**\n     * Total number of items\n     */\n    totalItems?: number;\n    /**\n     * Number of the page being indexed\n     */\n    page?: number;\n    /**\n     * Size of a page\n     */\n    pageSize?: number;\n}\n\n/**\n * The current state of various features of the grid like filtering, sorting, pagination. This object is emitted as\n * part of the event {@link DatagridComponent.gridRefresh}. The handler then used this object to construct a query.\n * TODO: This interface is going to defined as part of working on the following tasks:\n *  https://jira.eng.vmware.com/browse/VDUCC-14\n *  https://jira.eng.vmware.com/browse/VDUCC-15\n *  https://jira.eng.vmware.com/browse/VDUCC-20\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface GridState<R> {}\n\n/**\n * For simplifying logic inside the HTML template to differentiate between different {@link GridColumn.renderer}\n * types.\n */\ninterface ColumnConfigInternal<R, T> extends GridColumn<R> {\n    fieldName?: string;\n    fieldRenderer?: FunctionRenderer<R>;\n    fieldColumnRendererSpec?: ComponentRendererSpec<R, T>;\n}\n\n/**\n * Component used for saving the time required for developing a data grid. It takes different properties required for\n * rendering as Inputs and Outputs.\n *\n * Example usage in a component:\n * In the component view, different properties required for the grid are wired as Inputs and Outputs.\n * <vcd-datagrid\n *    (onGridRefresh)=\"fetchData()\"\n *    [columns]=\"columns\"\n *    [gridData]=\"gridData\">\n *  </vcd-datagrid>\n *\n */\n@Component({\n    selector: 'vcd-datagrid',\n    templateUrl: './datagrid.component.html',\n})\nexport class DatagridComponent<R> implements OnInit {\n    GridColumnHideable = GridColumnHideable;\n\n    /**\n     * Sets the configuration of columns on the grid and updates the {@link columnsConfig} array\n     */\n    @Input()\n    set columns(cols: GridColumn<R>[]) {\n        this._columns = cols;\n        this.getColumnsConfig();\n    }\n    get columns(): GridColumn<R>[] {\n        return this._columns;\n    }\n    private _columns: GridColumn<R>[];\n\n    /**\n     * Set from the caller component using this grid. The input is set upon fetching data by the caller\n     */\n    @Input() set gridData(result: GridDataFetchResult<R>) {\n        this.isLoading = false;\n        this.items = result.items;\n    }\n\n    /**\n     * Type of row selection on the grid\n     */\n    selectionType: GridSelectionType.None;\n\n    /**\n     * The CSS class to use for the Clarity datagrid.\n     */\n    @Input() clrDatagridCssClass = '';\n\n    /**\n     * Fired whenever the selection changes. The event data is array of rows selected. The array will contain only one\n     * element in case of single selection\n     */\n    selectionChanged: EventEmitter<R[]>;\n\n    /**\n     * Buttons to display in the toolbar on top of data grid\n     * showHide - Buttons that are not shown always (Eg: Delete button is hidden when there are no rows selected)\n     * enableDisable - Buttons that are always shown but disabled in certain conditions (Eg: Add/New button is always\n     * visible but disabled when no rights)\n     *\n     * TODO: There might be one more property required to define how many buttons should be visible before overflowing.\n     *  This API is going to be refined as part of https://jira.eng.vmware.com/browse/VDUCC-21\n     */\n    buttons: {\n        showHide: Button[];\n        enableDisable: Button[];\n    };\n\n    /**\n     * When there is no data, show this message.\n     *\n     * TODO: Try to avoid showing this before initial load.\n     */\n    emptyGridPlaceholder: string;\n\n    /**\n     * Inline HTML that is passed with the record/rest item as context\n     *\n     * TODO: https://jira.eng.vmware.com/browse/VDUCC-18\n     */\n    expandableRowTemplate: TemplateRef<R>;\n\n    /**\n     * TODO: Pagination requires some more research to be defined properly and is going to be defined as part of\n     *  https://jira.eng.vmware.com/browse/VDUCC-20\n     */\n    pagination: {\n        paginationKey: string;\n        /**\n         * Available page size options in the dropdown\n         */\n        pageSizeOptions: number[];\n\n        /**\n         * Number of items to be displayed on one page. As a result, the server will return a set of pages with the defined\n         * number of items per page(They can be smaller than the number here in case of last page, filtering etc.,)\n         *\n         * Magic: Auto calculates the size based on available height of the container\n         */\n        pageSize: number | 'Magic';\n    };\n\n    /**\n     * Desired height of the grid\n     *\n     * TODO: Should we provide this option for setting the grid height and also for auto grow of the height of the grid.\n     *  Also investigate if we can set this through CSS instead of an input\n     *  The above to-do is going to be worked as part of https://jira.eng.vmware.com/browse/VDUCC-25\n     */\n    height: number;\n\n    /**\n     * Loading indicator on the grid\n     */\n    isLoading = false;\n\n    /**\n     * Used for simplifying logic inside the HTML template to differentiate between different\n     * {@link GridColumn.renderer} types.\n     */\n    columnsConfig: ColumnConfigInternal<R, unknown>[];\n\n    /**\n     * List of items used for displaying rows on the grid\n     */\n    items: R[];\n\n    /**\n     * Emitted during the initial rendering, and is emitted whenever filtering/sorting/paging params change\n     * {@link #GridState} is the type of value emitted\n     */\n    @Output()\n    gridRefresh: EventEmitter<GridState<R>> = new EventEmitter<GridState<R>>();\n\n    @ViewChild(ClrDatagridFilter, { static: false }) numericFilter: ClrDatagridFilter;\n\n    /**\n     * Gives the CSS class to use for a given datarow based on its relative index and entity definition.\n     */\n    @Input() clrDatarowCssClassGetter(row: R, index: number): string {\n        return '';\n    }\n\n    ngOnInit(): void {\n        this.isLoading = true;\n        this.gridRefresh.emit({});\n    }\n\n    isColumnHideable(column: GridColumn<R>): boolean {\n        return column && column.hideable && column.hideable !== GridColumnHideable.Never;\n    }\n\n    /**\n     * Defines the {@property columnsConfig} by adding extra property required for differentiating different kinds\n     * of renderers which is required in the HTML template.\n     */\n    private getColumnsConfig(): void {\n        this.columnsConfig = this.columns.map(column => {\n            const columnConfig: ColumnConfigInternal<R, unknown> = {\n                ...column,\n            };\n\n            if (column.renderer instanceof Function) {\n                columnConfig.fieldRenderer = column.renderer as FunctionRenderer<R>;\n            } else if ((column.renderer as ComponentRendererSpec<R, unknown>).config) {\n                columnConfig.fieldColumnRendererSpec = column.renderer as ComponentRendererSpec<R, unknown>;\n            } else {\n                columnConfig.fieldName = column.renderer as string;\n            }\n\n            return columnConfig;\n        });\n    }\n}\n",
+            "properties": [],
+            "indexSignatures": [],
+            "description": "<p>TODO: This API is going to have more properties and is going to be defined as part of\n  <a href=\"https://jira.eng.vmware.com/browse/VDUCC-21\">https://jira.eng.vmware.com/browse/VDUCC-21</a></p>\n",
+            "methods": []
+        },
+        {
+            "name": "ColumnConfigInternal",
+            "id": "interface-ColumnConfigInternal-854c889708b9cf13ff0ebef598ca2faa",
+            "file": "projects/components/src/datagrid/datagrid.component.ts",
+            "type": "interface",
+            "sourceCode": "import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';\nimport { FunctionRenderer, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';\nimport { ClrDatagridFilter } from '@clr/angular';\nimport { ComponentRendererSpec } from './interfaces/component-renderer.interface';\n\n/**\n * Different types of row selection on the grid\n */\nexport enum GridSelectionType {\n    /**\n     * For selecting multiple rows\n     */\n    Multi = 'MULTI',\n    /**\n     * For selecting only one row at a time\n     */\n    Single = 'SINGLE',\n    /**\n     * Disables the selection\n     */\n    None = 'NONE',\n}\n\n/**\n * TODO: This API is going to have more properties and is going to be defined as part of\n *  https://jira.eng.vmware.com/browse/VDUCC-21\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface Button {}\n\n/**\n * Representation of data required for rendering contents of cells and pagination information\n */\nexport interface GridDataFetchResult<R> {\n    /**\n     * Items to be listed in the grid\n     */\n    items: R[];\n    /**\n     * Total number of items\n     */\n    totalItems?: number;\n    /**\n     * Number of the page being indexed\n     */\n    page?: number;\n    /**\n     * Size of a page\n     */\n    pageSize?: number;\n}\n\n/**\n * The current state of various features of the grid like filtering, sorting, pagination. This object is emitted as\n * part of the event {@link DatagridComponent.gridRefresh}. The handler then used this object to construct a query.\n * TODO: This interface is going to defined as part of working on the following tasks:\n *  https://jira.eng.vmware.com/browse/VDUCC-14\n *  https://jira.eng.vmware.com/browse/VDUCC-15\n *  https://jira.eng.vmware.com/browse/VDUCC-20\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface GridState<R> {}\n\n/**\n * For simplifying logic inside the HTML template to differentiate between different {@link GridColumn.renderer}\n * types.\n */\ninterface ColumnConfigInternal<R, T> extends GridColumn<R> {\n    fieldName?: string;\n    fieldRenderer?: FunctionRenderer<R>;\n    fieldColumnRendererSpec?: ComponentRendererSpec<R, T>;\n}\n\n/**\n * Component used for saving the time required for developing a data grid. It takes different properties required for\n * rendering as Inputs and Outputs.\n *\n * Example usage in a component:\n * In the component view, different properties required for the grid are wired as Inputs and Outputs.\n * <vcd-datagrid\n *    (onGridRefresh)=\"fetchData()\"\n *    [columns]=\"columns\"\n *    [gridData]=\"gridData\">\n *  </vcd-datagrid>\n *\n */\n@Component({\n    selector: 'vcd-datagrid',\n    templateUrl: './datagrid.component.html',\n})\nexport class DatagridComponent<R> implements OnInit {\n    GridColumnHideable = GridColumnHideable;\n\n    /**\n     * Sets the configuration of columns on the grid and updates the {@link columnsConfig} array\n     */\n    @Input()\n    set columns(cols: GridColumn<R>[]) {\n        this._columns = cols;\n        this.getColumnsConfig();\n    }\n    get columns(): GridColumn<R>[] {\n        return this._columns;\n    }\n    private _columns: GridColumn<R>[];\n\n    /**\n     * Set from the caller component using this grid. The input is set upon fetching data by the caller\n     */\n    @Input() set gridData(result: GridDataFetchResult<R>) {\n        this.isLoading = false;\n        this.items = result.items;\n    }\n\n    /**\n     * Type of row selection on the grid\n     */\n    selectionType: GridSelectionType.None;\n\n    /**\n     * The CSS class to use for the Clarity datagrid.\n     */\n    @Input() clrDatagridCssClass = '';\n\n    /**\n     * Fired whenever the selection changes. The event data is array of rows selected. The array will contain only one\n     * element in case of single selection\n     */\n    selectionChanged: EventEmitter<R[]>;\n\n    /**\n     * Buttons to display in the toolbar on top of data grid\n     * showHide - Buttons that are not shown always (Eg: Delete button is hidden when there are no rows selected)\n     * enableDisable - Buttons that are always shown but disabled in certain conditions (Eg: Add/New button is always\n     * visible but disabled when no rights)\n     *\n     * TODO: There might be one more property required to define how many buttons should be visible before overflowing.\n     *  This API is going to be refined as part of https://jira.eng.vmware.com/browse/VDUCC-21\n     */\n    buttons: {\n        showHide: Button[];\n        enableDisable: Button[];\n    };\n\n    /**\n     * When there is no data, show this message.\n     *\n     * TODO: Try to avoid showing this before initial load.\n     */\n    emptyGridPlaceholder: string;\n\n    /**\n     * Inline HTML that is passed with the record/rest item as context\n     *\n     * TODO: https://jira.eng.vmware.com/browse/VDUCC-18\n     */\n    expandableRowTemplate: TemplateRef<R>;\n\n    /**\n     * TODO: Pagination requires some more research to be defined properly and is going to be defined as part of\n     *  https://jira.eng.vmware.com/browse/VDUCC-20\n     */\n    pagination: {\n        paginationKey: string;\n        /**\n         * Available page size options in the dropdown\n         */\n        pageSizeOptions: number[];\n\n        /**\n         * Number of items to be displayed on one page. As a result, the server will return a set of pages with the defined\n         * number of items per page(They can be smaller than the number here in case of last page, filtering etc.,)\n         *\n         * Magic: Auto calculates the size based on available height of the container\n         */\n        pageSize: number | 'Magic';\n    };\n\n    /**\n     * Desired height of the grid\n     *\n     * TODO: Should we provide this option for setting the grid height and also for auto grow of the height of the grid.\n     *  Also investigate if we can set this through CSS instead of an input\n     *  The above to-do is going to be worked as part of https://jira.eng.vmware.com/browse/VDUCC-25\n     */\n    height: number;\n\n    /**\n     * Loading indicator on the grid\n     */\n    isLoading = false;\n\n    /**\n     * Used for simplifying logic inside the HTML template to differentiate between different\n     * {@link GridColumn.renderer} types.\n     */\n    columnsConfig: ColumnConfigInternal<R, unknown>[];\n\n    /**\n     * List of items used for displaying rows on the grid\n     */\n    items: R[];\n\n    /**\n     * Emitted during the initial rendering, and is emitted whenever filtering/sorting/paging params change\n     * {@link #GridState} is the type of value emitted\n     */\n    @Output()\n    gridRefresh: EventEmitter<GridState<R>> = new EventEmitter<GridState<R>>();\n\n    @ViewChild(ClrDatagridFilter, { static: false }) numericFilter: ClrDatagridFilter;\n\n    /**\n     * Gives the CSS class to use for a given datarow based on its relative index and entity definition.\n     */\n    @Input() clrDatarowCssClassGetter(row: R, index: number): string {\n        return '';\n    }\n\n    ngOnInit(): void {\n        this.isLoading = true;\n        this.gridRefresh.emit({});\n    }\n\n    isColumnHideable(column: GridColumn<R>): boolean {\n        return column && column.hideable && column.hideable !== GridColumnHideable.Never;\n    }\n\n    /**\n     * Defines the {@property columnsConfig} by adding extra property required for differentiating different kinds\n     * of renderers which is required in the HTML template.\n     */\n    private getColumnsConfig(): void {\n        this.columnsConfig = this.columns.map(column => {\n            const columnConfig: ColumnConfigInternal<R, unknown> = {\n                ...column,\n            };\n\n            if (column.renderer instanceof Function) {\n                columnConfig.fieldRenderer = column.renderer as FunctionRenderer<R>;\n            } else if ((column.renderer as ComponentRendererSpec<R, unknown>).config) {\n                columnConfig.fieldColumnRendererSpec = column.renderer as ComponentRendererSpec<R, unknown>;\n            } else {\n                columnConfig.fieldName = column.renderer as string;\n            }\n\n            return columnConfig;\n        });\n    }\n}\n",
+            "properties": [
+                {
+                    "name": "fieldColumnRendererSpec",
+                    "type": "ComponentRendererSpec<R | T>",
+                    "optional": true,
+                    "description": "",
+                    "line": 76
+                },
+                {
+                    "name": "fieldName",
+                    "type": "string",
+                    "optional": true,
+                    "description": "",
+                    "line": 74
+                },
+                {
+                    "name": "fieldRenderer",
+                    "type": "FunctionRenderer<R>",
+                    "optional": true,
+                    "description": "",
+                    "line": 75
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>For simplifying logic inside the HTML template to differentiate between different {@link GridColumn.renderer}\ntypes.</p>\n",
+            "methods": [],
+            "extends": "GridColumn"
+        },
+        {
+            "name": "ComponentRenderer",
+            "id": "interface-ComponentRenderer-0d0574277ff6e63b8489cd30d4971526",
+            "file": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+            "type": "interface",
+            "sourceCode": "import { Type } from '@angular/core';\n\n/**\n * Implemented by all the component renderers\n */\nexport interface ComponentRenderer<T> {\n    /**\n     * Object used by the component renderers inside their HTML template\n     */\n    config: T;\n}\n\n/**\n * Used for the type safety of {@link ComponentRendererSpec#type}\n */\nexport type ComponentRendererConstructor<V> = Type<ComponentRenderer<V>>;\n\n/**\n * An object that contains the constructor of a component{@link ComponentRenderer} to be displayed and value getter\n * function definition that would get the value to be used by the component in its template. This is useful for dynamically\n * rendering/configuring filters and columns/cells\n *\n * The directive{@link ComponentRendererOutletDirective} using this renderer spec to display the component will be\n * responsible for setting the actual renderer's value{@link ComponentRenderer#config} after dynamically\n * initializing it. But the caller is responsible for providing a config\n */\nexport interface ComponentRendererSpec<R, V> {\n    /**\n     * Constructor of a specific type of component renderer desired to be used\n     */\n    type: ComponentRendererConstructor<V>;\n\n    /**\n     * This can either be a function that creates the config object (in case of a cell renderer) or config object itself (in\n     * case of a filter renderer) to be set on the ComponentRenderer.\n     * @param value An object to be transformed into {@link ComponentRenderer#config}. It's passed in by the calling\n     * component\n     */\n    config: ((value?: R) => V) | V;\n}\n\n/**\n * Utility function to enforce type safety on output of the config function. The output is used as value context\n * inside ComponentRenderer's template\n *\n * Example usage:\n * const gridColumn = {\n *   renderer: RendererSpec<SomeRecord, IconRendererConfiguration>(IconComponentRendererCtor, (r: SomeRecord) => v)\n * }\n *\n * In the above example, this method helps in making sure that the value \"v\" returned by the config function is of\n * IconRendererConfiguration type\n */\nexport function RendererSpec<R, C>(componentRendererSpec: {\n    type: ComponentRendererConstructor<C>;\n    /**\n     *  'C & {}' makes the return type be not used as the inference site for C and instead use the constructor type from\n     *  the first argument.\n     *  {@link https://stackoverflow.com/questions/59055154/typescript-generics-infer-type-from-the-type-of-function-arguments}\n     */\n    config: ((record?: R) => C & {}) | C;\n}): ComponentRendererSpec<R, C> {\n    return componentRendererSpec;\n}\n",
+            "properties": [
+                {
+                    "name": "config",
+                    "type": "T",
+                    "optional": false,
+                    "description": "<p>Object used by the component renderers inside their HTML template</p>\n",
+                    "line": 15
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Implemented by all the component renderers</p>\n",
+            "methods": []
+        },
+        {
+            "name": "ComponentRendererSpec",
+            "id": "interface-ComponentRendererSpec-0d0574277ff6e63b8489cd30d4971526",
+            "file": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+            "type": "interface",
+            "sourceCode": "import { Type } from '@angular/core';\n\n/**\n * Implemented by all the component renderers\n */\nexport interface ComponentRenderer<T> {\n    /**\n     * Object used by the component renderers inside their HTML template\n     */\n    config: T;\n}\n\n/**\n * Used for the type safety of {@link ComponentRendererSpec#type}\n */\nexport type ComponentRendererConstructor<V> = Type<ComponentRenderer<V>>;\n\n/**\n * An object that contains the constructor of a component{@link ComponentRenderer} to be displayed and value getter\n * function definition that would get the value to be used by the component in its template. This is useful for dynamically\n * rendering/configuring filters and columns/cells\n *\n * The directive{@link ComponentRendererOutletDirective} using this renderer spec to display the component will be\n * responsible for setting the actual renderer's value{@link ComponentRenderer#config} after dynamically\n * initializing it. But the caller is responsible for providing a config\n */\nexport interface ComponentRendererSpec<R, V> {\n    /**\n     * Constructor of a specific type of component renderer desired to be used\n     */\n    type: ComponentRendererConstructor<V>;\n\n    /**\n     * This can either be a function that creates the config object (in case of a cell renderer) or config object itself (in\n     * case of a filter renderer) to be set on the ComponentRenderer.\n     * @param value An object to be transformed into {@link ComponentRenderer#config}. It's passed in by the calling\n     * component\n     */\n    config: ((value?: R) => V) | V;\n}\n\n/**\n * Utility function to enforce type safety on output of the config function. The output is used as value context\n * inside ComponentRenderer's template\n *\n * Example usage:\n * const gridColumn = {\n *   renderer: RendererSpec<SomeRecord, IconRendererConfiguration>(IconComponentRendererCtor, (r: SomeRecord) => v)\n * }\n *\n * In the above example, this method helps in making sure that the value \"v\" returned by the config function is of\n * IconRendererConfiguration type\n */\nexport function RendererSpec<R, C>(componentRendererSpec: {\n    type: ComponentRendererConstructor<C>;\n    /**\n     *  'C & {}' makes the return type be not used as the inference site for C and instead use the constructor type from\n     *  the first argument.\n     *  {@link https://stackoverflow.com/questions/59055154/typescript-generics-infer-type-from-the-type-of-function-arguments}\n     */\n    config: ((record?: R) => C & {}) | C;\n}): ComponentRendererSpec<R, C> {\n    return componentRendererSpec;\n}\n",
+            "properties": [
+                {
+                    "name": "config",
+                    "type": " | V",
+                    "optional": false,
+                    "description": "<p>This can either be a function that creates the config object (in case of a cell renderer) or config object itself (in\ncase of a filter renderer) to be set on the ComponentRenderer.</p>\n",
+                    "line": 44,
+                    "jsdoctags": [
+                        {
+                            "pos": 1461,
+                            "end": 1508,
+                            "flags": 0,
+                            "kind": 292,
+                            "atToken": {
+                                "pos": 1461,
+                                "end": 1462,
+                                "flags": 0,
+                                "kind": 57
+                            },
+                            "tagName": {
+                                "pos": 1462,
+                                "end": 1467,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "name": {
+                                "pos": 1468,
+                                "end": 1473,
+                                "flags": 0,
+                                "escapedText": "value"
+                            },
+                            "isNameFirst": true,
+                            "isBracketed": false,
+                            "comment": "<p>An object to be transformed into {</p>\n"
+                        },
+                        {
+                            "pos": 1508,
+                            "end": 1514,
+                            "flags": 0,
+                            "kind": 288,
+                            "atToken": {
+                                "pos": 1508,
+                                "end": 1509,
+                                "flags": 0,
+                                "kind": 57
+                            },
+                            "tagName": {
+                                "pos": 1509,
+                                "end": 1513,
+                                "flags": 0,
+                                "escapedText": "link"
+                            },
+                            "comment": "<p>ComponentRenderer#config}. It&#39;s passed in by the calling\ncomponent</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "type",
+                    "type": "ComponentRendererConstructor<V>",
+                    "optional": false,
+                    "description": "<p>Constructor of a specific type of component renderer desired to be used</p>\n",
+                    "line": 36
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>An object that contains the constructor of a component{@link ComponentRenderer} to be displayed and value getter\nfunction definition that would get the value to be used by the component in its template. This is useful for dynamically\nrendering/configuring filters and columns/cells</p>\n<p>The directive{@link ComponentRendererOutletDirective} using this renderer spec to display the component will be\nresponsible for setting the actual renderer&#39;s value{@link ComponentRenderer#config} after dynamically\ninitializing it. But the caller is responsible for providing a config</p>\n",
+            "methods": []
+        },
+        {
+            "name": "ComponentRendererType",
+            "id": "interface-ComponentRendererType-015ff7e245db7e8600a9c1b7eecae5af",
+            "file": "projects/components/src/datagrid/directives/component-renderer-outlet.directive.ts",
+            "type": "interface",
+            "sourceCode": "import { ComponentFactoryResolver, ComponentRef, Directive, Input, ViewContainerRef } from '@angular/core';\nimport {\n    ComponentRenderer,\n    ComponentRendererConstructor,\n    ComponentRendererSpec,\n} from '../interfaces/component-renderer.interface';\n\n/**\n * Type of the Input given to the {@link ComponentRendererOutletDirective.vcdComponentRendererOutlet}\n */\nexport interface ComponentRendererType<R, T> {\n    /**\n     * Contains the constructor of component to be rendered and also the method that gets the configuration required for\n     * the component API\n     */\n    rendererSpec: ComponentRendererSpec<R, T>;\n\n    /**\n     * serves as argument for {@link ComponentRenderer.config} method\n     */\n    context: R;\n}\n\n/**\n * Component that acts as a host element for dynamic rendering of component constructors.\n * It takes {@link ComponentRendererSpec} as input and also 'context' as input that serves as argument for\n * {@link ComponentRenderer.config} method. Attaches the component to be rendered to the view container of host element\n * and updates it's configuration whenever changed.\n *\n * Example usage:\n * <ng-template\n *      [vcdComponentRendererOutlet]=\"{ rendererSpec: column.fieldColumnRendererSpec, context: restItem }\"\n * ></ng-template>\n *\n */\n@Directive({\n    selector: '[vcdComponentRendererOutlet]',\n})\nexport class ComponentRendererOutletDirective<R, T> {\n    private componentRef: ComponentRef<ComponentRenderer<T>>;\n    private componentType: ComponentRendererConstructor<T>;\n\n    constructor(private viewContainerRef: ViewContainerRef, private cfr: ComponentFactoryResolver) {}\n\n    @Input()\n    set vcdComponentRendererOutlet(renderer: ComponentRendererType<R, T>) {\n        if (this.componentType !== renderer.rendererSpec.type) {\n            // Cache the componentType to avoid redundant detaching and attaching of component to this host\n            this.componentType = renderer.rendererSpec.type;\n            this.componentRef = this.attachRenderer();\n        }\n        this.assignValue(renderer.rendererSpec.config, renderer.context);\n    }\n\n    /**\n     * Attaches the passed component type to the view of this directive host\n     */\n    private attachRenderer(): ComponentRef<ComponentRenderer<T>> {\n        if (this.componentRef) {\n            this.detachRenderer();\n        }\n        const componentFactory = this.cfr.resolveComponentFactory(this.componentType);\n        return this.viewContainerRef.createComponent(componentFactory);\n    }\n\n    /**\n     * Updates the configuration of instantiated component\n     */\n    private assignValue(config: ((r: R) => T) | T, context: R): void {\n        if (!this.componentRef || !this.componentRef.instance) {\n            return;\n        }\n        this.componentRef.instance.config = config instanceof Function ? config(context) : config;\n    }\n\n    private detachRenderer(): void {\n        this.viewContainerRef.remove();\n        this.componentRef = null;\n    }\n}\n",
+            "properties": [
+                {
+                    "name": "context",
+                    "type": "R",
+                    "optional": false,
+                    "description": "<p>serves as argument for {@link ComponentRenderer.config} method</p>\n",
+                    "line": 26
+                },
+                {
+                    "name": "rendererSpec",
+                    "type": "ComponentRendererSpec<R | T>",
+                    "optional": false,
+                    "description": "<p>Contains the constructor of component to be rendered and also the method that gets the configuration required for\nthe component API</p>\n",
+                    "line": 21
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Type of the Input given to the {@link ComponentRendererOutletDirective.vcdComponentRendererOutlet}</p>\n",
+            "methods": []
+        },
+        {
+            "name": "DataExportRequestEvent",
+            "id": "interface-DataExportRequestEvent-5a56df2974458abac65ddf748a7d4d1e",
+            "file": "projects/components/src/data-exporter/data-exporter.component.ts",
+            "type": "interface",
+            "sourceCode": "import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';\nimport { FormControl, FormGroup } from '@angular/forms';\nimport { CsvExporterService } from './csv-exporter.service';\n\n/**\n * Identifiers for each column that user is allowed to select\n */\nexport interface ExportColumn {\n    /**\n     * Displayed in the list of columns\n     */\n    displayName: string;\n    /**\n     * The name of the field in the JSON that is returned and converted to a viewable format\n     */\n    fieldName: string;\n}\n\n/**\n * Information passed to the caller so they can fetch the data\n */\nexport interface DataExportRequestEvent {\n    /**\n     * Call this to indicate a new value to be displayed in the progress indicator.\n     * @param progress A number from 0 to 1 indicating download progress. Passing -1 will make it an indeterminate\n     */\n    updateProgress: (progress: number) => void;\n\n    /**\n     * Call this when all records have been fetched to initiate the CSV creation.\n     * This should only be called once after all data fetching is finished\n     * @param records Records to be converted into a csv file\n     */\n    exportData: (records: object[]) => void;\n\n    /**\n     * Columns selected by the user.\n     */\n    selectedColumns: ExportColumn[];\n}\n\n/**\n * A dialog to export data\n *\n *  - Allows the UI to select columns to be exported\n *  - Provides a progress indicator\n *  - Converts the data that is fetched by the caller into a CSV\n */\n@Component({\n    selector: 'vcd-data-exporter',\n    templateUrl: 'data-exporter.component.html',\n    styleUrls: ['./data-exporter.component.scss'],\n})\nexport class DataExporterComponent implements OnInit {\n    constructor(private csvExporterService: CsvExporterService) {}\n\n    /**\n     * List of columns that can be exported, user may deselect some before sending the download request\n     */\n    @Input() columns: ExportColumn[] = [];\n\n    /**\n     * The name of the file to be downloaded\n     */\n    @Input() fileName = 'data-export.csv';\n\n    /**\n     * Text for the Dialog Header\n     */\n    @Input() dialogHeader = 'Select Columns';\n\n    /**\n     * Whether a box to select/deselect all rows is available\n     */\n    @Input() showSelectAll = true;\n\n    /**\n     * Whether the dialog is open\n     */\n    @Input()\n    set open(value: boolean) {\n        this._open = value;\n        this.openChange.emit(value);\n    }\n    get open(): boolean {\n        return this._open;\n    }\n\n    private _open = false;\n\n    /**\n     * Fires when {@link _open} changes. Its parameter indicates the new state.\n     */\n    @Output() openChange = new EventEmitter<boolean>();\n\n    /**\n     * Called when the export is ready to be created\n     */\n    @Output() dataExportRequest = new EventEmitter<DataExportRequestEvent>();\n\n    /**\n     * True between the time {@link dataExportRequest} fires and {@link DataExportRequestEvent.exportData} is called\n     * or an error is thrown\n     */\n    get isRequestPending(): boolean {\n        return this._isRequestPending;\n    }\n    private _isRequestPending = false;\n\n    /**\n     * Number between 0-1, used for displaying the progress bar.\n     */\n    get progress(): number {\n        return this._progress;\n    }\n    private _progress = 0;\n\n    formGroup: FormGroup;\n\n    onClickExport(): void {\n        this._isRequestPending = true;\n        this.dataExportRequest.emit({\n            exportData: this.exportData.bind(this),\n            updateProgress: this.updateProgress.bind(this),\n            selectedColumns: this.columns.filter(col => this.formGroup.controls[col.fieldName].value),\n        });\n    }\n\n    onClickCheckAll(): void {\n        for (const column of this.columns) {\n            this.formGroup.controls[column.fieldName].setValue(true);\n        }\n    }\n\n    get isSelectAllEnabled(): boolean {\n        for (const column of this.columns) {\n            if (!this.formGroup.controls[column.fieldName].value) {\n                return true;\n            }\n        }\n        return false;\n    }\n\n    get isExportEnabled(): boolean {\n        if (this.isRequestPending) {\n            return false;\n        }\n        for (const column of this.columns) {\n            if (this.formGroup.controls[column.fieldName].value) {\n                return true;\n            }\n        }\n        return false;\n    }\n\n    ngOnInit(): void {\n        const controls = this.columns.reduce((previousValue, currentValue) => {\n            previousValue[currentValue.fieldName] = new FormControl(true);\n            return previousValue;\n        }, {});\n        this.formGroup = new FormGroup(controls);\n    }\n\n    private exportData(records: object[]): void {\n        if (!this.open) {\n            return;\n        }\n        this.open = false;\n        this._isRequestPending = false;\n\n        const rows = [\n            // First row is the display names\n            Object.keys(records[0]).map(fieldName => this.getDisplayNameForField(fieldName)),\n            // Then the data\n            ...records.map(rec => Object.keys(rec).map(key => rec[key])),\n        ];\n\n        const csvFile = this.csvExporterService.createCsv(rows);\n        this.csvExporterService.downloadCsvFile(csvFile, this.fileName);\n    }\n\n    private updateProgress(progress: number): void {\n        this._progress = progress;\n    }\n\n    private getDisplayNameForField(fieldName: string): string {\n        for (const column of this.columns) {\n            if (column.fieldName === fieldName) {\n                return column.displayName;\n            }\n        }\n        return fieldName;\n    }\n}\n",
+            "properties": [
+                {
+                    "name": "exportData",
+                    "type": "function",
+                    "optional": false,
+                    "description": "<p>Call this when all records have been fetched to initiate the CSV creation.\nThis should only be called once after all data fetching is finished</p>\n",
+                    "line": 39,
+                    "jsdoctags": [
+                        {
+                            "pos": 1158,
+                            "end": 1218,
+                            "flags": 0,
+                            "kind": 292,
+                            "atToken": {
+                                "pos": 1158,
+                                "end": 1159,
+                                "flags": 0,
+                                "kind": 57
+                            },
+                            "tagName": {
+                                "pos": 1159,
+                                "end": 1164,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "name": {
+                                "pos": 1165,
+                                "end": 1172,
+                                "flags": 0,
+                                "escapedText": "records"
+                            },
+                            "isNameFirst": true,
+                            "isBracketed": false,
+                            "comment": "<p>Records to be converted into a csv file</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "selectedColumns",
+                    "type": "ExportColumn[]",
+                    "optional": false,
+                    "description": "<p>Columns selected by the user.</p>\n",
+                    "line": 44
+                },
+                {
+                    "name": "updateProgress",
+                    "type": "function",
+                    "optional": false,
+                    "description": "<p>Call this to indicate a new value to be displayed in the progress indicator.</p>\n",
+                    "line": 32,
+                    "jsdoctags": [
+                        {
+                            "pos": 821,
+                            "end": 934,
+                            "flags": 0,
+                            "kind": 292,
+                            "atToken": {
+                                "pos": 821,
+                                "end": 822,
+                                "flags": 0,
+                                "kind": 57
+                            },
+                            "tagName": {
+                                "pos": 822,
+                                "end": 827,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "name": {
+                                "pos": 828,
+                                "end": 836,
+                                "flags": 0,
+                                "escapedText": "progress"
+                            },
+                            "isNameFirst": true,
+                            "isBracketed": false,
+                            "comment": "<p>A number from 0 to 1 indicating download progress. Passing -1 will make it an indeterminate</p>\n"
+                        }
+                    ]
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Information passed to the caller so they can fetch the data</p>\n",
+            "methods": []
+        },
+        {
+            "name": "ExportColumn",
+            "id": "interface-ExportColumn-5a56df2974458abac65ddf748a7d4d1e",
+            "file": "projects/components/src/data-exporter/data-exporter.component.ts",
+            "type": "interface",
+            "sourceCode": "import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';\nimport { FormControl, FormGroup } from '@angular/forms';\nimport { CsvExporterService } from './csv-exporter.service';\n\n/**\n * Identifiers for each column that user is allowed to select\n */\nexport interface ExportColumn {\n    /**\n     * Displayed in the list of columns\n     */\n    displayName: string;\n    /**\n     * The name of the field in the JSON that is returned and converted to a viewable format\n     */\n    fieldName: string;\n}\n\n/**\n * Information passed to the caller so they can fetch the data\n */\nexport interface DataExportRequestEvent {\n    /**\n     * Call this to indicate a new value to be displayed in the progress indicator.\n     * @param progress A number from 0 to 1 indicating download progress. Passing -1 will make it an indeterminate\n     */\n    updateProgress: (progress: number) => void;\n\n    /**\n     * Call this when all records have been fetched to initiate the CSV creation.\n     * This should only be called once after all data fetching is finished\n     * @param records Records to be converted into a csv file\n     */\n    exportData: (records: object[]) => void;\n\n    /**\n     * Columns selected by the user.\n     */\n    selectedColumns: ExportColumn[];\n}\n\n/**\n * A dialog to export data\n *\n *  - Allows the UI to select columns to be exported\n *  - Provides a progress indicator\n *  - Converts the data that is fetched by the caller into a CSV\n */\n@Component({\n    selector: 'vcd-data-exporter',\n    templateUrl: 'data-exporter.component.html',\n    styleUrls: ['./data-exporter.component.scss'],\n})\nexport class DataExporterComponent implements OnInit {\n    constructor(private csvExporterService: CsvExporterService) {}\n\n    /**\n     * List of columns that can be exported, user may deselect some before sending the download request\n     */\n    @Input() columns: ExportColumn[] = [];\n\n    /**\n     * The name of the file to be downloaded\n     */\n    @Input() fileName = 'data-export.csv';\n\n    /**\n     * Text for the Dialog Header\n     */\n    @Input() dialogHeader = 'Select Columns';\n\n    /**\n     * Whether a box to select/deselect all rows is available\n     */\n    @Input() showSelectAll = true;\n\n    /**\n     * Whether the dialog is open\n     */\n    @Input()\n    set open(value: boolean) {\n        this._open = value;\n        this.openChange.emit(value);\n    }\n    get open(): boolean {\n        return this._open;\n    }\n\n    private _open = false;\n\n    /**\n     * Fires when {@link _open} changes. Its parameter indicates the new state.\n     */\n    @Output() openChange = new EventEmitter<boolean>();\n\n    /**\n     * Called when the export is ready to be created\n     */\n    @Output() dataExportRequest = new EventEmitter<DataExportRequestEvent>();\n\n    /**\n     * True between the time {@link dataExportRequest} fires and {@link DataExportRequestEvent.exportData} is called\n     * or an error is thrown\n     */\n    get isRequestPending(): boolean {\n        return this._isRequestPending;\n    }\n    private _isRequestPending = false;\n\n    /**\n     * Number between 0-1, used for displaying the progress bar.\n     */\n    get progress(): number {\n        return this._progress;\n    }\n    private _progress = 0;\n\n    formGroup: FormGroup;\n\n    onClickExport(): void {\n        this._isRequestPending = true;\n        this.dataExportRequest.emit({\n            exportData: this.exportData.bind(this),\n            updateProgress: this.updateProgress.bind(this),\n            selectedColumns: this.columns.filter(col => this.formGroup.controls[col.fieldName].value),\n        });\n    }\n\n    onClickCheckAll(): void {\n        for (const column of this.columns) {\n            this.formGroup.controls[column.fieldName].setValue(true);\n        }\n    }\n\n    get isSelectAllEnabled(): boolean {\n        for (const column of this.columns) {\n            if (!this.formGroup.controls[column.fieldName].value) {\n                return true;\n            }\n        }\n        return false;\n    }\n\n    get isExportEnabled(): boolean {\n        if (this.isRequestPending) {\n            return false;\n        }\n        for (const column of this.columns) {\n            if (this.formGroup.controls[column.fieldName].value) {\n                return true;\n            }\n        }\n        return false;\n    }\n\n    ngOnInit(): void {\n        const controls = this.columns.reduce((previousValue, currentValue) => {\n            previousValue[currentValue.fieldName] = new FormControl(true);\n            return previousValue;\n        }, {});\n        this.formGroup = new FormGroup(controls);\n    }\n\n    private exportData(records: object[]): void {\n        if (!this.open) {\n            return;\n        }\n        this.open = false;\n        this._isRequestPending = false;\n\n        const rows = [\n            // First row is the display names\n            Object.keys(records[0]).map(fieldName => this.getDisplayNameForField(fieldName)),\n            // Then the data\n            ...records.map(rec => Object.keys(rec).map(key => rec[key])),\n        ];\n\n        const csvFile = this.csvExporterService.createCsv(rows);\n        this.csvExporterService.downloadCsvFile(csvFile, this.fileName);\n    }\n\n    private updateProgress(progress: number): void {\n        this._progress = progress;\n    }\n\n    private getDisplayNameForField(fieldName: string): string {\n        for (const column of this.columns) {\n            if (column.fieldName === fieldName) {\n                return column.displayName;\n            }\n        }\n        return fieldName;\n    }\n}\n",
+            "properties": [
+                {
+                    "name": "displayName",
+                    "type": "string",
+                    "optional": false,
+                    "description": "<p>Displayed in the list of columns</p>\n",
+                    "line": 17
+                },
+                {
+                    "name": "fieldName",
+                    "type": "string",
+                    "optional": false,
+                    "description": "<p>The name of the field in the JSON that is returned and converted to a viewable format</p>\n",
+                    "line": 21
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Identifiers for each column that user is allowed to select</p>\n",
+            "methods": []
+        },
+        {
+            "name": "FindableWidget",
+            "id": "interface-FindableWidget-d181c05ac7c0b6904e1762602ec8ba0c",
+            "file": "projects/components/src/utils/test/widget-object.ts",
+            "type": "interface",
+            "sourceCode": "import { DebugElement, Type } from '@angular/core';\nimport { ComponentFixture, TestBed } from '@angular/core/testing';\nimport { By } from '@angular/platform-browser';\nimport { FindableWidget } from './widget-object';\n\n/**\n * An implementation of the page object pattern, but applied to widgets, since they can be reused on multiple pages.\n *\n * The main purpose for the wrapper are providing access to the internals of a widget avoiding duplication of code that\n * queries the internals of a component from a test.\n *\n * ## Subclass Rules\n *\n * - Methods exposed by subclasses should not expose HTMLElements or DebugElements directly. That would encourage\n * callers to query it from the outside creating potential duplicate querying code and abstraction leaks.\n *  - Subclasses also should not have testing assertions. They should only provide the state and the calling test can\n * assert code on its own.\n *\n * `T` is the type of the JS/TS object being wrapped\n *\n * It is recommended that files for implementations be named with a `.wo.ts` extension\n */\nexport abstract class WidgetObject<T> {\n    /**\n     *\n     * Constructor should only be called directly if you are directly instantiating the widget being wrapped (T). If you\n     * need to find a widget within the tree, you should use {@link find}.\n     *\n     * @param component The component instance being managed. Whenever possible, we should access the component's API.\n     * @param root The root element (host) for the component instance. We typically prefer to interact with the\n     * component but there are times when we must check the DOM.\n     * @param fixture The test fixture, so we can call {@link ComponentFixture#detectChanges} after something that\n     * requires re-rendering of the DOM.\n     */\n    constructor(\n        protected fixture: ComponentFixture<any>,\n        protected root: DebugElement = fixture.debugElement,\n        public component: T = fixture.componentInstance\n    ) {}\n\n    detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n\n    /**\n     * Finds first element within this widget matching the given selector\n     * @param cssSelector What to search for\n     * @param parent Where to start the search; defaults to the root of this component\n     */\n    protected findElement(cssSelector: string, parent: DebugElement = this.root): DebugElement {\n        return parent.query(By.css(cssSelector));\n    }\n\n    /**\n     * Same as {@link findElement} but returns all elements\n     */\n    protected findElements(cssSelector: string, parent: DebugElement = this.root): DebugElement[] {\n        return parent.queryAll(By.css(cssSelector));\n    }\n\n    /**\n     * Clicks an element and detects changes so the DOM is immediately updated\n     * @param cssSelector Pass this in if you want to click a specific element. If not passed in, the entire node will\n     * receive the click event\n     */\n    protected click(cssSelector?: string): void {\n        const nativeElement: HTMLBaseElement = this.findElement(cssSelector).nativeElement;\n        nativeElement.click();\n        this.detectChanges();\n    }\n\n    /**\n     * Returns text content of this widget\n     * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.\n     */\n\n    protected getText(cssSelector: string): string {\n        return this.getNodeText(this.findElement(cssSelector));\n    }\n\n    /**\n     * Same as {@link getText} but return the text for all matching nodes\n     */\n    protected getTexts(cssSelector: string): string[] {\n        return this.findElements(cssSelector).map(el => this.getNodeText(el));\n    }\n\n    protected getNodeText(el: DebugElement): string {\n        // The || '' is because textContent could technically be null when passed in the document\n        // element object. We know that cannot be pased in here, so we ignore it for coverage\n        // but we still need the line there to make strictNullChecks work\n        return el.nativeElement.textContent || /* istanbul ignore next */ '';\n    }\n}\n\n/**\n * Subclasses should implement the FindableWidget interface so they can be found with {@link WidgetFinder}\n *\n * ## Note\n * This is done by creating a static property `tagName`on your subclass, not a regular instance, since this\n * interface represents a constructor for a {@link WidgetObject}, not an instance.\n */\nexport interface FindableWidget<T> extends Type<WidgetObject<T>> {\n    tagName: string;\n}\n\n/**\n * Arguments for {@link WidgetFinder#findWidgets} and {@link WidgetFinder#find}\n */\ninterface FindParams<T> {\n    /**\n     * The constructor of the widget to be found\n     */\n    woConstructor: T;\n    /**\n     * If provided, search starts from this container. It defaults to the fixture's root debugElement\n     */\n    ancestor?: DebugElement;\n    /**\n     * Optional CSS class name that can be used when there could be multiple instances of the object within the\n     * fixture tree\n     */\n    className?: string;\n}\n\n/**\n * Finds instances that implement {@link FindableWidget}\n * H is the host component's type\n */\nexport class WidgetFinder<H = unknown> {\n    /**\n     * We don't care or could possibly know the type of fixture\n     */\n    private fixture: ComponentFixture<H>;\n\n    /**\n     * If you need direct access to manipulate the host\n     */\n    public hostComponent: H;\n\n    /**\n     * @param componentConstructor The host component to be created as the root of the tests's fixture\n     */\n    constructor(componentConstructor: Type<H>) {\n        this.fixture = TestBed.createComponent(componentConstructor);\n        this.hostComponent = this.fixture.componentInstance;\n    }\n\n    /**\n     * Finds widgets within a fixture\n     * @return A Potentially empty list of widgets matching the given specs\n     */\n    public findWidgets<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T>[] {\n        const defaults = { ancestor: this.fixture.debugElement, className: '' };\n        const { woConstructor, ancestor, className } = isFindParamsObject(params)\n            ? { ...defaults, ...params }\n            : { ...defaults, woConstructor: params };\n\n        let query = woConstructor.tagName;\n        if (className) {\n            query += `.${className}`;\n        }\n        const componentRoots = ancestor.queryAll(By.css(query));\n        const widgets = componentRoots.map(\n            // Typescript is not able to infer it correctly as the subclass but we know for sure\n            root => new woConstructor(this.fixture, root, root.componentInstance) as InstanceType<T>\n        );\n        return widgets;\n    }\n\n    /**\n     * Finds a single widget object\n     * @throws An error if the widget is not found or if there are multiple instances\n     */\n    public find<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T> {\n        const widgets = this.findWidgets(params);\n        const tagName = isFindParamsObject(params) ? params.woConstructor.tagName : params.tagName;\n        if (widgets.length === 0) {\n            throw Error(`Did not find a <${tagName}>`);\n        }\n        if (widgets.length > 1) {\n            throw Error(`Expected to find a single <${tagName}> but found ${widgets.length}`);\n        }\n        return widgets[0] as InstanceType<T>;\n    }\n\n    public detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n}\n\nfunction isFindParamsObject<T>(params: FindParams<T> | T): params is FindParams<T> {\n    return !!(params as FindParams<T>).woConstructor;\n}\n/**\n * Can be used in tests that use `this` to share a finder with before/AfterEach instead of leaky closures\n */\nexport interface HasFinder<T = unknown> {\n    finder: WidgetFinder<T>;\n}\n",
+            "properties": [
+                {
+                    "name": "tagName",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 109
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Subclasses should implement the FindableWidget interface so they can be found with {@link WidgetFinder}</p>\n<h2 id=\"note\">Note</h2>\n<p>This is done by creating a static property <code>tagName</code>on your subclass, not a regular instance, since this\ninterface represents a constructor for a {@link WidgetObject}, not an instance.</p>\n",
+            "methods": [],
+            "extends": "Type"
+        },
+        {
+            "name": "FindParams",
+            "id": "interface-FindParams-d181c05ac7c0b6904e1762602ec8ba0c",
+            "file": "projects/components/src/utils/test/widget-object.ts",
+            "type": "interface",
+            "sourceCode": "import { DebugElement, Type } from '@angular/core';\nimport { ComponentFixture, TestBed } from '@angular/core/testing';\nimport { By } from '@angular/platform-browser';\nimport { FindableWidget } from './widget-object';\n\n/**\n * An implementation of the page object pattern, but applied to widgets, since they can be reused on multiple pages.\n *\n * The main purpose for the wrapper are providing access to the internals of a widget avoiding duplication of code that\n * queries the internals of a component from a test.\n *\n * ## Subclass Rules\n *\n * - Methods exposed by subclasses should not expose HTMLElements or DebugElements directly. That would encourage\n * callers to query it from the outside creating potential duplicate querying code and abstraction leaks.\n *  - Subclasses also should not have testing assertions. They should only provide the state and the calling test can\n * assert code on its own.\n *\n * `T` is the type of the JS/TS object being wrapped\n *\n * It is recommended that files for implementations be named with a `.wo.ts` extension\n */\nexport abstract class WidgetObject<T> {\n    /**\n     *\n     * Constructor should only be called directly if you are directly instantiating the widget being wrapped (T). If you\n     * need to find a widget within the tree, you should use {@link find}.\n     *\n     * @param component The component instance being managed. Whenever possible, we should access the component's API.\n     * @param root The root element (host) for the component instance. We typically prefer to interact with the\n     * component but there are times when we must check the DOM.\n     * @param fixture The test fixture, so we can call {@link ComponentFixture#detectChanges} after something that\n     * requires re-rendering of the DOM.\n     */\n    constructor(\n        protected fixture: ComponentFixture<any>,\n        protected root: DebugElement = fixture.debugElement,\n        public component: T = fixture.componentInstance\n    ) {}\n\n    detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n\n    /**\n     * Finds first element within this widget matching the given selector\n     * @param cssSelector What to search for\n     * @param parent Where to start the search; defaults to the root of this component\n     */\n    protected findElement(cssSelector: string, parent: DebugElement = this.root): DebugElement {\n        return parent.query(By.css(cssSelector));\n    }\n\n    /**\n     * Same as {@link findElement} but returns all elements\n     */\n    protected findElements(cssSelector: string, parent: DebugElement = this.root): DebugElement[] {\n        return parent.queryAll(By.css(cssSelector));\n    }\n\n    /**\n     * Clicks an element and detects changes so the DOM is immediately updated\n     * @param cssSelector Pass this in if you want to click a specific element. If not passed in, the entire node will\n     * receive the click event\n     */\n    protected click(cssSelector?: string): void {\n        const nativeElement: HTMLBaseElement = this.findElement(cssSelector).nativeElement;\n        nativeElement.click();\n        this.detectChanges();\n    }\n\n    /**\n     * Returns text content of this widget\n     * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.\n     */\n\n    protected getText(cssSelector: string): string {\n        return this.getNodeText(this.findElement(cssSelector));\n    }\n\n    /**\n     * Same as {@link getText} but return the text for all matching nodes\n     */\n    protected getTexts(cssSelector: string): string[] {\n        return this.findElements(cssSelector).map(el => this.getNodeText(el));\n    }\n\n    protected getNodeText(el: DebugElement): string {\n        // The || '' is because textContent could technically be null when passed in the document\n        // element object. We know that cannot be pased in here, so we ignore it for coverage\n        // but we still need the line there to make strictNullChecks work\n        return el.nativeElement.textContent || /* istanbul ignore next */ '';\n    }\n}\n\n/**\n * Subclasses should implement the FindableWidget interface so they can be found with {@link WidgetFinder}\n *\n * ## Note\n * This is done by creating a static property `tagName`on your subclass, not a regular instance, since this\n * interface represents a constructor for a {@link WidgetObject}, not an instance.\n */\nexport interface FindableWidget<T> extends Type<WidgetObject<T>> {\n    tagName: string;\n}\n\n/**\n * Arguments for {@link WidgetFinder#findWidgets} and {@link WidgetFinder#find}\n */\ninterface FindParams<T> {\n    /**\n     * The constructor of the widget to be found\n     */\n    woConstructor: T;\n    /**\n     * If provided, search starts from this container. It defaults to the fixture's root debugElement\n     */\n    ancestor?: DebugElement;\n    /**\n     * Optional CSS class name that can be used when there could be multiple instances of the object within the\n     * fixture tree\n     */\n    className?: string;\n}\n\n/**\n * Finds instances that implement {@link FindableWidget}\n * H is the host component's type\n */\nexport class WidgetFinder<H = unknown> {\n    /**\n     * We don't care or could possibly know the type of fixture\n     */\n    private fixture: ComponentFixture<H>;\n\n    /**\n     * If you need direct access to manipulate the host\n     */\n    public hostComponent: H;\n\n    /**\n     * @param componentConstructor The host component to be created as the root of the tests's fixture\n     */\n    constructor(componentConstructor: Type<H>) {\n        this.fixture = TestBed.createComponent(componentConstructor);\n        this.hostComponent = this.fixture.componentInstance;\n    }\n\n    /**\n     * Finds widgets within a fixture\n     * @return A Potentially empty list of widgets matching the given specs\n     */\n    public findWidgets<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T>[] {\n        const defaults = { ancestor: this.fixture.debugElement, className: '' };\n        const { woConstructor, ancestor, className } = isFindParamsObject(params)\n            ? { ...defaults, ...params }\n            : { ...defaults, woConstructor: params };\n\n        let query = woConstructor.tagName;\n        if (className) {\n            query += `.${className}`;\n        }\n        const componentRoots = ancestor.queryAll(By.css(query));\n        const widgets = componentRoots.map(\n            // Typescript is not able to infer it correctly as the subclass but we know for sure\n            root => new woConstructor(this.fixture, root, root.componentInstance) as InstanceType<T>\n        );\n        return widgets;\n    }\n\n    /**\n     * Finds a single widget object\n     * @throws An error if the widget is not found or if there are multiple instances\n     */\n    public find<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T> {\n        const widgets = this.findWidgets(params);\n        const tagName = isFindParamsObject(params) ? params.woConstructor.tagName : params.tagName;\n        if (widgets.length === 0) {\n            throw Error(`Did not find a <${tagName}>`);\n        }\n        if (widgets.length > 1) {\n            throw Error(`Expected to find a single <${tagName}> but found ${widgets.length}`);\n        }\n        return widgets[0] as InstanceType<T>;\n    }\n\n    public detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n}\n\nfunction isFindParamsObject<T>(params: FindParams<T> | T): params is FindParams<T> {\n    return !!(params as FindParams<T>).woConstructor;\n}\n/**\n * Can be used in tests that use `this` to share a finder with before/AfterEach instead of leaky closures\n */\nexport interface HasFinder<T = unknown> {\n    finder: WidgetFinder<T>;\n}\n",
+            "properties": [
+                {
+                    "name": "ancestor",
+                    "type": "DebugElement",
+                    "optional": true,
+                    "description": "<p>If provided, search starts from this container. It defaults to the fixture&#39;s root debugElement</p>\n",
+                    "line": 123
+                },
+                {
+                    "name": "className",
+                    "type": "string",
+                    "optional": true,
+                    "description": "<p>Optional CSS class name that can be used when there could be multiple instances of the object within the\nfixture tree</p>\n",
+                    "line": 128
+                },
+                {
+                    "name": "woConstructor",
+                    "type": "T",
+                    "optional": false,
+                    "description": "<p>The constructor of the widget to be found</p>\n",
+                    "line": 119
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Arguments for {@link WidgetFinder#findWidgets} and {@link WidgetFinder#find}</p>\n",
+            "methods": []
+        },
+        {
+            "name": "GridColumn",
+            "id": "interface-GridColumn-031fe6ad8aab3ed85fe2659f6f59a16d",
+            "file": "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts",
+            "type": "interface",
+            "sourceCode": "import { ComponentRendererSpec } from './component-renderer.interface';\n\nexport enum GridColumnHideable {\n    /**\n     * Does not show up in column toggle box\n     */\n    Never = 'NEVER',\n    /**\n     * Shows up in column toggle box, column is visible\n     */\n    Shown = 'SHOWN',\n    /**\n     * Shows up in column toggle box, column is hidden\n     */\n    Hidden = 'HIDDEN',\n}\n\n/**\n * The sorting direction of the column values\n */\nexport enum GridColumnSortDirection {\n    Asc = 'ASCENDING',\n    Desc = 'DESCENDING',\n    None = 'NONE',\n}\n\n/**\n * Column renderer as a function. Defined in calling component when the cell value is calculated from different\n * properties.\n * @param record The record for the row being rendered\n * @return The string to be displayed for that cell\n */\nexport type FunctionRenderer<T> = (record: T) => string;\n\n/**\n * Configuration object defined in the caller. This contains properties for the column header (text, filtering,\n * sorting, toggling etc.,) and content for row cells.\n *\n * Example:\n * const gridColumn: GridColumn<SomeRecord> = {\n *   displayName: \"Column Heading\",\n *   renderer: \"someRecord.property\",\n *   hideable: \"NEVER\"\n * }\n *\n * The above column is rendered with \"Column Heading\" text in it's heading and it is not shown in the column toggler.\n * The value of the property \"someRecord.property\" is rendered in cells corresponding to the column.\n */\nexport interface GridColumn<R> {\n    /**\n     * Header text for the column\n     */\n    displayName: string;\n\n    /**\n     * Used for sorting/filtering. Not needed for columns not filterable/sortable\n     * TODO: do we need to support array type for querying across multiple columns?\n     */\n    queryFieldName?: string;\n\n    /**\n     * If the renderer passed in is a\n     * - string: Used as default renderer. Can be a dot separated string to identify a nested property of the item\n     * - {@link FunctionRenderer}: When you want to create a calculated column, but don't need custom HTML\n     * - TemplateRef: When custom HTML is needed and when it has to be passed in as a inline HTML\n     * - {@link ComponentRendererSpec}: When HTML is needed and when the HTML is provided as a component\n     */\n    renderer: string | FunctionRenderer<R> | ComponentRendererSpec<R, unknown>;\n\n    /**\n     * Whether the column shows up in the column toggler and if the column shows up, it reflects the toggle state\n     */\n    hideable?: GridColumnHideable;\n\n    /**\n     * When there is no data, show this message.\n     *\n     * Try to avoid showing this before initial load.\n     */\n    emptyColumnPlaceholder?: string;\n\n    sortDirection?: GridColumnSortDirection;\n\n    /**\n     * TODO: Should this be made to work with top level search on grids across all columns?\n     *  The above to-do is going to be worked on as part of https://jira.eng.vmware.com/browse/VDUCC-27 and\n     */\n    filter?: ComponentRendererSpec<R, unknown>;\n}\n",
+            "properties": [
+                {
+                    "name": "displayName",
+                    "type": "string",
+                    "optional": false,
+                    "description": "<p>Header text for the column</p>\n",
+                    "line": 61
+                },
+                {
+                    "name": "emptyColumnPlaceholder",
+                    "type": "string",
+                    "optional": true,
+                    "description": "<p>When there is no data, show this message.</p>\n<p>Try to avoid showing this before initial load.</p>\n",
+                    "line": 88
+                },
+                {
+                    "name": "filter",
+                    "type": "ComponentRendererSpec<R | unknown>",
+                    "optional": true,
+                    "description": "<p>TODO: Should this be made to work with top level search on grids across all columns?\n  The above to-do is going to be worked on as part of <a href=\"https://jira.eng.vmware.com/browse/VDUCC-27\">https://jira.eng.vmware.com/browse/VDUCC-27</a> and</p>\n",
+                    "line": 96
+                },
+                {
+                    "name": "hideable",
+                    "type": "GridColumnHideable",
+                    "optional": true,
+                    "description": "<p>Whether the column shows up in the column toggler and if the column shows up, it reflects the toggle state</p>\n",
+                    "line": 81
+                },
+                {
+                    "name": "queryFieldName",
+                    "type": "string",
+                    "optional": true,
+                    "description": "<p>Used for sorting/filtering. Not needed for columns not filterable/sortable\nTODO: do we need to support array type for querying across multiple columns?</p>\n",
+                    "line": 67
+                },
+                {
+                    "name": "renderer",
+                    "type": "string | FunctionRenderer<R> | ComponentRendererSpec<R | unknown>",
+                    "optional": false,
+                    "description": "<p>If the renderer passed in is a</p>\n<ul>\n<li>string: Used as default renderer. Can be a dot separated string to identify a nested property of the item</li>\n<li>{@link FunctionRenderer}: When you want to create a calculated column, but don&#39;t need custom HTML</li>\n<li>TemplateRef: When custom HTML is needed and when it has to be passed in as a inline HTML</li>\n<li>{@link ComponentRendererSpec}: When HTML is needed and when the HTML is provided as a component</li>\n</ul>\n",
+                    "line": 76
+                },
+                {
+                    "name": "sortDirection",
+                    "type": "GridColumnSortDirection",
+                    "optional": true,
+                    "description": "",
+                    "line": 90
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Configuration object defined in the caller. This contains properties for the column header (text, filtering,\nsorting, toggling etc.,) and content for row cells.</p>\n<p>Example:\nconst gridColumn: GridColumn<SomeRecord> = {\n   displayName: &quot;Column Heading&quot;,\n   renderer: &quot;someRecord.property&quot;,\n   hideable: &quot;NEVER&quot;\n}</p>\n<p>The above column is rendered with &quot;Column Heading&quot; text in it&#39;s heading and it is not shown in the column toggler.\nThe value of the property &quot;someRecord.property&quot; is rendered in cells corresponding to the column.</p>\n",
+            "methods": []
+        },
+        {
+            "name": "GridDataFetchResult",
+            "id": "interface-GridDataFetchResult-854c889708b9cf13ff0ebef598ca2faa",
+            "file": "projects/components/src/datagrid/datagrid.component.ts",
+            "type": "interface",
+            "sourceCode": "import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';\nimport { FunctionRenderer, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';\nimport { ClrDatagridFilter } from '@clr/angular';\nimport { ComponentRendererSpec } from './interfaces/component-renderer.interface';\n\n/**\n * Different types of row selection on the grid\n */\nexport enum GridSelectionType {\n    /**\n     * For selecting multiple rows\n     */\n    Multi = 'MULTI',\n    /**\n     * For selecting only one row at a time\n     */\n    Single = 'SINGLE',\n    /**\n     * Disables the selection\n     */\n    None = 'NONE',\n}\n\n/**\n * TODO: This API is going to have more properties and is going to be defined as part of\n *  https://jira.eng.vmware.com/browse/VDUCC-21\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface Button {}\n\n/**\n * Representation of data required for rendering contents of cells and pagination information\n */\nexport interface GridDataFetchResult<R> {\n    /**\n     * Items to be listed in the grid\n     */\n    items: R[];\n    /**\n     * Total number of items\n     */\n    totalItems?: number;\n    /**\n     * Number of the page being indexed\n     */\n    page?: number;\n    /**\n     * Size of a page\n     */\n    pageSize?: number;\n}\n\n/**\n * The current state of various features of the grid like filtering, sorting, pagination. This object is emitted as\n * part of the event {@link DatagridComponent.gridRefresh}. The handler then used this object to construct a query.\n * TODO: This interface is going to defined as part of working on the following tasks:\n *  https://jira.eng.vmware.com/browse/VDUCC-14\n *  https://jira.eng.vmware.com/browse/VDUCC-15\n *  https://jira.eng.vmware.com/browse/VDUCC-20\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface GridState<R> {}\n\n/**\n * For simplifying logic inside the HTML template to differentiate between different {@link GridColumn.renderer}\n * types.\n */\ninterface ColumnConfigInternal<R, T> extends GridColumn<R> {\n    fieldName?: string;\n    fieldRenderer?: FunctionRenderer<R>;\n    fieldColumnRendererSpec?: ComponentRendererSpec<R, T>;\n}\n\n/**\n * Component used for saving the time required for developing a data grid. It takes different properties required for\n * rendering as Inputs and Outputs.\n *\n * Example usage in a component:\n * In the component view, different properties required for the grid are wired as Inputs and Outputs.\n * <vcd-datagrid\n *    (onGridRefresh)=\"fetchData()\"\n *    [columns]=\"columns\"\n *    [gridData]=\"gridData\">\n *  </vcd-datagrid>\n *\n */\n@Component({\n    selector: 'vcd-datagrid',\n    templateUrl: './datagrid.component.html',\n})\nexport class DatagridComponent<R> implements OnInit {\n    GridColumnHideable = GridColumnHideable;\n\n    /**\n     * Sets the configuration of columns on the grid and updates the {@link columnsConfig} array\n     */\n    @Input()\n    set columns(cols: GridColumn<R>[]) {\n        this._columns = cols;\n        this.getColumnsConfig();\n    }\n    get columns(): GridColumn<R>[] {\n        return this._columns;\n    }\n    private _columns: GridColumn<R>[];\n\n    /**\n     * Set from the caller component using this grid. The input is set upon fetching data by the caller\n     */\n    @Input() set gridData(result: GridDataFetchResult<R>) {\n        this.isLoading = false;\n        this.items = result.items;\n    }\n\n    /**\n     * Type of row selection on the grid\n     */\n    selectionType: GridSelectionType.None;\n\n    /**\n     * The CSS class to use for the Clarity datagrid.\n     */\n    @Input() clrDatagridCssClass = '';\n\n    /**\n     * Fired whenever the selection changes. The event data is array of rows selected. The array will contain only one\n     * element in case of single selection\n     */\n    selectionChanged: EventEmitter<R[]>;\n\n    /**\n     * Buttons to display in the toolbar on top of data grid\n     * showHide - Buttons that are not shown always (Eg: Delete button is hidden when there are no rows selected)\n     * enableDisable - Buttons that are always shown but disabled in certain conditions (Eg: Add/New button is always\n     * visible but disabled when no rights)\n     *\n     * TODO: There might be one more property required to define how many buttons should be visible before overflowing.\n     *  This API is going to be refined as part of https://jira.eng.vmware.com/browse/VDUCC-21\n     */\n    buttons: {\n        showHide: Button[];\n        enableDisable: Button[];\n    };\n\n    /**\n     * When there is no data, show this message.\n     *\n     * TODO: Try to avoid showing this before initial load.\n     */\n    emptyGridPlaceholder: string;\n\n    /**\n     * Inline HTML that is passed with the record/rest item as context\n     *\n     * TODO: https://jira.eng.vmware.com/browse/VDUCC-18\n     */\n    expandableRowTemplate: TemplateRef<R>;\n\n    /**\n     * TODO: Pagination requires some more research to be defined properly and is going to be defined as part of\n     *  https://jira.eng.vmware.com/browse/VDUCC-20\n     */\n    pagination: {\n        paginationKey: string;\n        /**\n         * Available page size options in the dropdown\n         */\n        pageSizeOptions: number[];\n\n        /**\n         * Number of items to be displayed on one page. As a result, the server will return a set of pages with the defined\n         * number of items per page(They can be smaller than the number here in case of last page, filtering etc.,)\n         *\n         * Magic: Auto calculates the size based on available height of the container\n         */\n        pageSize: number | 'Magic';\n    };\n\n    /**\n     * Desired height of the grid\n     *\n     * TODO: Should we provide this option for setting the grid height and also for auto grow of the height of the grid.\n     *  Also investigate if we can set this through CSS instead of an input\n     *  The above to-do is going to be worked as part of https://jira.eng.vmware.com/browse/VDUCC-25\n     */\n    height: number;\n\n    /**\n     * Loading indicator on the grid\n     */\n    isLoading = false;\n\n    /**\n     * Used for simplifying logic inside the HTML template to differentiate between different\n     * {@link GridColumn.renderer} types.\n     */\n    columnsConfig: ColumnConfigInternal<R, unknown>[];\n\n    /**\n     * List of items used for displaying rows on the grid\n     */\n    items: R[];\n\n    /**\n     * Emitted during the initial rendering, and is emitted whenever filtering/sorting/paging params change\n     * {@link #GridState} is the type of value emitted\n     */\n    @Output()\n    gridRefresh: EventEmitter<GridState<R>> = new EventEmitter<GridState<R>>();\n\n    @ViewChild(ClrDatagridFilter, { static: false }) numericFilter: ClrDatagridFilter;\n\n    /**\n     * Gives the CSS class to use for a given datarow based on its relative index and entity definition.\n     */\n    @Input() clrDatarowCssClassGetter(row: R, index: number): string {\n        return '';\n    }\n\n    ngOnInit(): void {\n        this.isLoading = true;\n        this.gridRefresh.emit({});\n    }\n\n    isColumnHideable(column: GridColumn<R>): boolean {\n        return column && column.hideable && column.hideable !== GridColumnHideable.Never;\n    }\n\n    /**\n     * Defines the {@property columnsConfig} by adding extra property required for differentiating different kinds\n     * of renderers which is required in the HTML template.\n     */\n    private getColumnsConfig(): void {\n        this.columnsConfig = this.columns.map(column => {\n            const columnConfig: ColumnConfigInternal<R, unknown> = {\n                ...column,\n            };\n\n            if (column.renderer instanceof Function) {\n                columnConfig.fieldRenderer = column.renderer as FunctionRenderer<R>;\n            } else if ((column.renderer as ComponentRendererSpec<R, unknown>).config) {\n                columnConfig.fieldColumnRendererSpec = column.renderer as ComponentRendererSpec<R, unknown>;\n            } else {\n                columnConfig.fieldName = column.renderer as string;\n            }\n\n            return columnConfig;\n        });\n    }\n}\n",
+            "properties": [
+                {
+                    "name": "items",
+                    "type": "R[]",
+                    "optional": false,
+                    "description": "<p>Items to be listed in the grid</p>\n",
+                    "line": 43
+                },
+                {
+                    "name": "page",
+                    "type": "number",
+                    "optional": true,
+                    "description": "<p>Number of the page being indexed</p>\n",
+                    "line": 51
+                },
+                {
+                    "name": "pageSize",
+                    "type": "number",
+                    "optional": true,
+                    "description": "<p>Size of a page</p>\n",
+                    "line": 55
+                },
+                {
+                    "name": "totalItems",
+                    "type": "number",
+                    "optional": true,
+                    "description": "<p>Total number of items</p>\n",
+                    "line": 47
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Representation of data required for rendering contents of cells and pagination information</p>\n",
+            "methods": []
+        },
+        {
+            "name": "GridState",
+            "id": "interface-GridState-854c889708b9cf13ff0ebef598ca2faa",
+            "file": "projects/components/src/datagrid/datagrid.component.ts",
+            "type": "interface",
+            "sourceCode": "import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';\nimport { FunctionRenderer, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';\nimport { ClrDatagridFilter } from '@clr/angular';\nimport { ComponentRendererSpec } from './interfaces/component-renderer.interface';\n\n/**\n * Different types of row selection on the grid\n */\nexport enum GridSelectionType {\n    /**\n     * For selecting multiple rows\n     */\n    Multi = 'MULTI',\n    /**\n     * For selecting only one row at a time\n     */\n    Single = 'SINGLE',\n    /**\n     * Disables the selection\n     */\n    None = 'NONE',\n}\n\n/**\n * TODO: This API is going to have more properties and is going to be defined as part of\n *  https://jira.eng.vmware.com/browse/VDUCC-21\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface Button {}\n\n/**\n * Representation of data required for rendering contents of cells and pagination information\n */\nexport interface GridDataFetchResult<R> {\n    /**\n     * Items to be listed in the grid\n     */\n    items: R[];\n    /**\n     * Total number of items\n     */\n    totalItems?: number;\n    /**\n     * Number of the page being indexed\n     */\n    page?: number;\n    /**\n     * Size of a page\n     */\n    pageSize?: number;\n}\n\n/**\n * The current state of various features of the grid like filtering, sorting, pagination. This object is emitted as\n * part of the event {@link DatagridComponent.gridRefresh}. The handler then used this object to construct a query.\n * TODO: This interface is going to defined as part of working on the following tasks:\n *  https://jira.eng.vmware.com/browse/VDUCC-14\n *  https://jira.eng.vmware.com/browse/VDUCC-15\n *  https://jira.eng.vmware.com/browse/VDUCC-20\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface GridState<R> {}\n\n/**\n * For simplifying logic inside the HTML template to differentiate between different {@link GridColumn.renderer}\n * types.\n */\ninterface ColumnConfigInternal<R, T> extends GridColumn<R> {\n    fieldName?: string;\n    fieldRenderer?: FunctionRenderer<R>;\n    fieldColumnRendererSpec?: ComponentRendererSpec<R, T>;\n}\n\n/**\n * Component used for saving the time required for developing a data grid. It takes different properties required for\n * rendering as Inputs and Outputs.\n *\n * Example usage in a component:\n * In the component view, different properties required for the grid are wired as Inputs and Outputs.\n * <vcd-datagrid\n *    (onGridRefresh)=\"fetchData()\"\n *    [columns]=\"columns\"\n *    [gridData]=\"gridData\">\n *  </vcd-datagrid>\n *\n */\n@Component({\n    selector: 'vcd-datagrid',\n    templateUrl: './datagrid.component.html',\n})\nexport class DatagridComponent<R> implements OnInit {\n    GridColumnHideable = GridColumnHideable;\n\n    /**\n     * Sets the configuration of columns on the grid and updates the {@link columnsConfig} array\n     */\n    @Input()\n    set columns(cols: GridColumn<R>[]) {\n        this._columns = cols;\n        this.getColumnsConfig();\n    }\n    get columns(): GridColumn<R>[] {\n        return this._columns;\n    }\n    private _columns: GridColumn<R>[];\n\n    /**\n     * Set from the caller component using this grid. The input is set upon fetching data by the caller\n     */\n    @Input() set gridData(result: GridDataFetchResult<R>) {\n        this.isLoading = false;\n        this.items = result.items;\n    }\n\n    /**\n     * Type of row selection on the grid\n     */\n    selectionType: GridSelectionType.None;\n\n    /**\n     * The CSS class to use for the Clarity datagrid.\n     */\n    @Input() clrDatagridCssClass = '';\n\n    /**\n     * Fired whenever the selection changes. The event data is array of rows selected. The array will contain only one\n     * element in case of single selection\n     */\n    selectionChanged: EventEmitter<R[]>;\n\n    /**\n     * Buttons to display in the toolbar on top of data grid\n     * showHide - Buttons that are not shown always (Eg: Delete button is hidden when there are no rows selected)\n     * enableDisable - Buttons that are always shown but disabled in certain conditions (Eg: Add/New button is always\n     * visible but disabled when no rights)\n     *\n     * TODO: There might be one more property required to define how many buttons should be visible before overflowing.\n     *  This API is going to be refined as part of https://jira.eng.vmware.com/browse/VDUCC-21\n     */\n    buttons: {\n        showHide: Button[];\n        enableDisable: Button[];\n    };\n\n    /**\n     * When there is no data, show this message.\n     *\n     * TODO: Try to avoid showing this before initial load.\n     */\n    emptyGridPlaceholder: string;\n\n    /**\n     * Inline HTML that is passed with the record/rest item as context\n     *\n     * TODO: https://jira.eng.vmware.com/browse/VDUCC-18\n     */\n    expandableRowTemplate: TemplateRef<R>;\n\n    /**\n     * TODO: Pagination requires some more research to be defined properly and is going to be defined as part of\n     *  https://jira.eng.vmware.com/browse/VDUCC-20\n     */\n    pagination: {\n        paginationKey: string;\n        /**\n         * Available page size options in the dropdown\n         */\n        pageSizeOptions: number[];\n\n        /**\n         * Number of items to be displayed on one page. As a result, the server will return a set of pages with the defined\n         * number of items per page(They can be smaller than the number here in case of last page, filtering etc.,)\n         *\n         * Magic: Auto calculates the size based on available height of the container\n         */\n        pageSize: number | 'Magic';\n    };\n\n    /**\n     * Desired height of the grid\n     *\n     * TODO: Should we provide this option for setting the grid height and also for auto grow of the height of the grid.\n     *  Also investigate if we can set this through CSS instead of an input\n     *  The above to-do is going to be worked as part of https://jira.eng.vmware.com/browse/VDUCC-25\n     */\n    height: number;\n\n    /**\n     * Loading indicator on the grid\n     */\n    isLoading = false;\n\n    /**\n     * Used for simplifying logic inside the HTML template to differentiate between different\n     * {@link GridColumn.renderer} types.\n     */\n    columnsConfig: ColumnConfigInternal<R, unknown>[];\n\n    /**\n     * List of items used for displaying rows on the grid\n     */\n    items: R[];\n\n    /**\n     * Emitted during the initial rendering, and is emitted whenever filtering/sorting/paging params change\n     * {@link #GridState} is the type of value emitted\n     */\n    @Output()\n    gridRefresh: EventEmitter<GridState<R>> = new EventEmitter<GridState<R>>();\n\n    @ViewChild(ClrDatagridFilter, { static: false }) numericFilter: ClrDatagridFilter;\n\n    /**\n     * Gives the CSS class to use for a given datarow based on its relative index and entity definition.\n     */\n    @Input() clrDatarowCssClassGetter(row: R, index: number): string {\n        return '';\n    }\n\n    ngOnInit(): void {\n        this.isLoading = true;\n        this.gridRefresh.emit({});\n    }\n\n    isColumnHideable(column: GridColumn<R>): boolean {\n        return column && column.hideable && column.hideable !== GridColumnHideable.Never;\n    }\n\n    /**\n     * Defines the {@property columnsConfig} by adding extra property required for differentiating different kinds\n     * of renderers which is required in the HTML template.\n     */\n    private getColumnsConfig(): void {\n        this.columnsConfig = this.columns.map(column => {\n            const columnConfig: ColumnConfigInternal<R, unknown> = {\n                ...column,\n            };\n\n            if (column.renderer instanceof Function) {\n                columnConfig.fieldRenderer = column.renderer as FunctionRenderer<R>;\n            } else if ((column.renderer as ComponentRendererSpec<R, unknown>).config) {\n                columnConfig.fieldColumnRendererSpec = column.renderer as ComponentRendererSpec<R, unknown>;\n            } else {\n                columnConfig.fieldName = column.renderer as string;\n            }\n\n            return columnConfig;\n        });\n    }\n}\n",
+            "properties": [],
+            "indexSignatures": [],
+            "description": "<p>The current state of various features of the grid like filtering, sorting, pagination. This object is emitted as\npart of the event {@link DatagridComponent.gridRefresh}. The handler then used this object to construct a query.\nTODO: This interface is going to defined as part of working on the following tasks:\n  <a href=\"https://jira.eng.vmware.com/browse/VDUCC-14\">https://jira.eng.vmware.com/browse/VDUCC-14</a>\n  <a href=\"https://jira.eng.vmware.com/browse/VDUCC-15\">https://jira.eng.vmware.com/browse/VDUCC-15</a>\n  <a href=\"https://jira.eng.vmware.com/browse/VDUCC-20\">https://jira.eng.vmware.com/browse/VDUCC-20</a></p>\n",
+            "methods": []
+        },
+        {
+            "name": "HasFinder",
+            "id": "interface-HasFinder-d181c05ac7c0b6904e1762602ec8ba0c",
+            "file": "projects/components/src/utils/test/widget-object.ts",
+            "type": "interface",
+            "sourceCode": "import { DebugElement, Type } from '@angular/core';\nimport { ComponentFixture, TestBed } from '@angular/core/testing';\nimport { By } from '@angular/platform-browser';\nimport { FindableWidget } from './widget-object';\n\n/**\n * An implementation of the page object pattern, but applied to widgets, since they can be reused on multiple pages.\n *\n * The main purpose for the wrapper are providing access to the internals of a widget avoiding duplication of code that\n * queries the internals of a component from a test.\n *\n * ## Subclass Rules\n *\n * - Methods exposed by subclasses should not expose HTMLElements or DebugElements directly. That would encourage\n * callers to query it from the outside creating potential duplicate querying code and abstraction leaks.\n *  - Subclasses also should not have testing assertions. They should only provide the state and the calling test can\n * assert code on its own.\n *\n * `T` is the type of the JS/TS object being wrapped\n *\n * It is recommended that files for implementations be named with a `.wo.ts` extension\n */\nexport abstract class WidgetObject<T> {\n    /**\n     *\n     * Constructor should only be called directly if you are directly instantiating the widget being wrapped (T). If you\n     * need to find a widget within the tree, you should use {@link find}.\n     *\n     * @param component The component instance being managed. Whenever possible, we should access the component's API.\n     * @param root The root element (host) for the component instance. We typically prefer to interact with the\n     * component but there are times when we must check the DOM.\n     * @param fixture The test fixture, so we can call {@link ComponentFixture#detectChanges} after something that\n     * requires re-rendering of the DOM.\n     */\n    constructor(\n        protected fixture: ComponentFixture<any>,\n        protected root: DebugElement = fixture.debugElement,\n        public component: T = fixture.componentInstance\n    ) {}\n\n    detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n\n    /**\n     * Finds first element within this widget matching the given selector\n     * @param cssSelector What to search for\n     * @param parent Where to start the search; defaults to the root of this component\n     */\n    protected findElement(cssSelector: string, parent: DebugElement = this.root): DebugElement {\n        return parent.query(By.css(cssSelector));\n    }\n\n    /**\n     * Same as {@link findElement} but returns all elements\n     */\n    protected findElements(cssSelector: string, parent: DebugElement = this.root): DebugElement[] {\n        return parent.queryAll(By.css(cssSelector));\n    }\n\n    /**\n     * Clicks an element and detects changes so the DOM is immediately updated\n     * @param cssSelector Pass this in if you want to click a specific element. If not passed in, the entire node will\n     * receive the click event\n     */\n    protected click(cssSelector?: string): void {\n        const nativeElement: HTMLBaseElement = this.findElement(cssSelector).nativeElement;\n        nativeElement.click();\n        this.detectChanges();\n    }\n\n    /**\n     * Returns text content of this widget\n     * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.\n     */\n\n    protected getText(cssSelector: string): string {\n        return this.getNodeText(this.findElement(cssSelector));\n    }\n\n    /**\n     * Same as {@link getText} but return the text for all matching nodes\n     */\n    protected getTexts(cssSelector: string): string[] {\n        return this.findElements(cssSelector).map(el => this.getNodeText(el));\n    }\n\n    protected getNodeText(el: DebugElement): string {\n        // The || '' is because textContent could technically be null when passed in the document\n        // element object. We know that cannot be pased in here, so we ignore it for coverage\n        // but we still need the line there to make strictNullChecks work\n        return el.nativeElement.textContent || /* istanbul ignore next */ '';\n    }\n}\n\n/**\n * Subclasses should implement the FindableWidget interface so they can be found with {@link WidgetFinder}\n *\n * ## Note\n * This is done by creating a static property `tagName`on your subclass, not a regular instance, since this\n * interface represents a constructor for a {@link WidgetObject}, not an instance.\n */\nexport interface FindableWidget<T> extends Type<WidgetObject<T>> {\n    tagName: string;\n}\n\n/**\n * Arguments for {@link WidgetFinder#findWidgets} and {@link WidgetFinder#find}\n */\ninterface FindParams<T> {\n    /**\n     * The constructor of the widget to be found\n     */\n    woConstructor: T;\n    /**\n     * If provided, search starts from this container. It defaults to the fixture's root debugElement\n     */\n    ancestor?: DebugElement;\n    /**\n     * Optional CSS class name that can be used when there could be multiple instances of the object within the\n     * fixture tree\n     */\n    className?: string;\n}\n\n/**\n * Finds instances that implement {@link FindableWidget}\n * H is the host component's type\n */\nexport class WidgetFinder<H = unknown> {\n    /**\n     * We don't care or could possibly know the type of fixture\n     */\n    private fixture: ComponentFixture<H>;\n\n    /**\n     * If you need direct access to manipulate the host\n     */\n    public hostComponent: H;\n\n    /**\n     * @param componentConstructor The host component to be created as the root of the tests's fixture\n     */\n    constructor(componentConstructor: Type<H>) {\n        this.fixture = TestBed.createComponent(componentConstructor);\n        this.hostComponent = this.fixture.componentInstance;\n    }\n\n    /**\n     * Finds widgets within a fixture\n     * @return A Potentially empty list of widgets matching the given specs\n     */\n    public findWidgets<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T>[] {\n        const defaults = { ancestor: this.fixture.debugElement, className: '' };\n        const { woConstructor, ancestor, className } = isFindParamsObject(params)\n            ? { ...defaults, ...params }\n            : { ...defaults, woConstructor: params };\n\n        let query = woConstructor.tagName;\n        if (className) {\n            query += `.${className}`;\n        }\n        const componentRoots = ancestor.queryAll(By.css(query));\n        const widgets = componentRoots.map(\n            // Typescript is not able to infer it correctly as the subclass but we know for sure\n            root => new woConstructor(this.fixture, root, root.componentInstance) as InstanceType<T>\n        );\n        return widgets;\n    }\n\n    /**\n     * Finds a single widget object\n     * @throws An error if the widget is not found or if there are multiple instances\n     */\n    public find<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T> {\n        const widgets = this.findWidgets(params);\n        const tagName = isFindParamsObject(params) ? params.woConstructor.tagName : params.tagName;\n        if (widgets.length === 0) {\n            throw Error(`Did not find a <${tagName}>`);\n        }\n        if (widgets.length > 1) {\n            throw Error(`Expected to find a single <${tagName}> but found ${widgets.length}`);\n        }\n        return widgets[0] as InstanceType<T>;\n    }\n\n    public detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n}\n\nfunction isFindParamsObject<T>(params: FindParams<T> | T): params is FindParams<T> {\n    return !!(params as FindParams<T>).woConstructor;\n}\n/**\n * Can be used in tests that use `this` to share a finder with before/AfterEach instead of leaky closures\n */\nexport interface HasFinder<T = unknown> {\n    finder: WidgetFinder<T>;\n}\n",
+            "properties": [
+                {
+                    "name": "finder",
+                    "type": "WidgetFinder<T>",
+                    "optional": false,
+                    "description": "",
+                    "line": 204
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "description": "<p>Can be used in tests that use <code>this</code> to share a finder with before/AfterEach instead of leaky closures</p>\n",
+            "methods": []
+        }
+    ],
+    "injectables": [
+        {
+            "name": "CsvExporterService",
+            "id": "injectable-CsvExporterService-8f65408887e8a3aabd40309e88a00f8e",
+            "file": "projects/components/src/data-exporter/csv-exporter.service.ts",
+            "properties": [],
+            "methods": [
+                {
+                    "name": "createCsv",
+                    "args": [
+                        {
+                            "name": "rows",
+                            "type": "any[][]"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 19,
+                    "description": "<p>Creates a string that can be used to create a Blob for a CSV</p>\n",
+                    "modifierKind": [
+                        114
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 347,
+                                "end": 351,
+                                "flags": 0,
+                                "escapedText": "rows"
+                            },
+                            "type": "any[][]",
+                            "tagName": {
+                                "pos": 341,
+                                "end": 346,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>2D array of data. First row is the names for the fields</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "downloadCsvFile",
+                    "args": [
+                        {
+                            "name": "csvFile",
+                            "type": "string"
+                        },
+                        {
+                            "name": "filename",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 28,
+                    "description": "<p>Does a client side download</p>\n",
+                    "modifierKind": [
+                        114
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 586,
+                                "end": 593,
+                                "flags": 0,
+                                "escapedText": "csvFile"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 580,
+                                "end": 585,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>The string contents of a CSV file to be downloaded</p>\n"
+                        },
+                        {
+                            "name": {
+                                "pos": 659,
+                                "end": 667,
+                                "flags": 0,
+                                "escapedText": "filename"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 653,
+                                "end": 658,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>The name of the file to be downloaded</p>\n"
+                        }
+                    ]
+                }
+            ],
+            "description": "",
+            "sourceCode": "import { Injectable } from '@angular/core';\n\n@Injectable({\n    providedIn: 'root',\n})\n/**\n * Encodes a data set to be downloaded as a CSV\n */\nexport class CsvExporterService {\n    /**\n     * Creates a string that can be used to create a Blob for a CSV\n     * @param rows 2D array of data. First row is the names for the fields\n     */\n    public createCsv(rows: any[][]): string {\n        return rows.map(row => processRow(row)).join('\\n');\n    }\n\n    /**\n     * Does a client side download\n     * @param csvFile The string contents of a CSV file to be downloaded\n     * @param filename The name of the file to be downloaded\n     */\n    public downloadCsvFile(csvFile: string, filename: string): void {\n        const mimeType = 'text/csv;charset=utf-8;';\n        const blob = new Blob([csvFile], { type: mimeType });\n        // Jan 1, 2020 - Chrome and IE support this\n        if (navigator.msSaveBlob) {\n            navigator.msSaveBlob(blob, filename);\n        } else {\n            const link = document.createElement('a');\n            const url = URL.createObjectURL(blob);\n            link.setAttribute('href', url);\n            link.setAttribute('download', filename);\n            link.style.visibility = 'hidden';\n            document.body.appendChild(link);\n            link.click();\n            document.body.removeChild(link);\n        }\n    }\n}\n\n/**\n * Returns a string\n * @param row A list of cells to be turned into a CSV string, separated by commas\n */\nfunction processRow(row: unknown[]): string {\n    return row.map(cell => encodeValue(cell)).join(',');\n}\n\n/**\n * Returns a cell's cellValue encoded against spaces, quotes, and CSV injection character\n * @param cellValue Cell cellValue to be encoded\n */\nfunction encodeValue(cellValue: unknown): string {\n    let innerValue = cellValue == null ? '' : cellValue.toString();\n    if (cellValue instanceof Date) {\n        innerValue = cellValue.toLocaleString();\n    }\n    // Double quotes are doubled\n    let result = innerValue.replace(/\"/g, '\"\"');\n\n    // TODO: See https://jira.eng.vmware.com/browse/VDUCC-59\n    // result = escapeAgainstCsvInjection(result);\n\n    // Add quotes around the whole thing if it contains new lines\n    if (result.search(/[\",\\n]/g) >= 0) {\n        result = `\"${result}\"`;\n    }\n    // Escape against\n    return result;\n}\n\n/**\n * TODO: See https://jira.eng.vmware.com/browse/VDUCC-59\n * Prepends a single quote to a value if it starts with =,+,=,@ to prevent formulas from being executed\n * @param value Value to be escaped\n */\n// function escapeAgainstCsvInjection(value: string): string {\n//     if (/^[=+\\-@|%]/.test(value)) {\n//         return `'${value}'`;\n//     }\n//     return value;\n// }\n",
+            "type": "injectable"
+        }
+    ],
+    "classes": [
+        {
+            "name": "CliptextWidgetObject",
+            "id": "class-CliptextWidgetObject-c94f1dd5e48e84d2df6cfdf5945c18ed",
+            "file": "projects/components/src/cliptext/cliptext.wo.ts",
+            "type": "class",
+            "sourceCode": "import { WidgetObject } from '../utils/test/widget-object';\nimport { CliptextComponent } from './cliptext.component';\n\n/**\n * Testing Object for {@link CliptextComponent}\n */\nexport class CliptextWidgetObject extends WidgetObject<CliptextComponent> {\n    static tagName = 'vcd-cliptext';\n\n    /**\n     * Sends a mouseenter event for clr tooltip\n     */\n    mouseEnter(): void {\n        this.findElement('.cliptext-container').triggerEventHandler('mouseenter', null);\n        this.fixture.detectChanges();\n    }\n\n    /**\n     * Sends a mouseleave event for clr tooltip\n     */\n    mouseLeave(): void {\n        this.findElement('.cliptext-container').triggerEventHandler('mouseleave', null);\n        this.fixture.detectChanges();\n    }\n\n    /**\n     * Whether the tooltip is visible\n     */\n    get isShowingTooltip(): boolean {\n        return Boolean(this.findElement('clr-tooltip-content'));\n    }\n\n    /**\n     * The text content of the tooltip\n     */\n    get tooltipContent(): string {\n        return this.getText('clr-tooltip-content');\n    }\n}\n",
+            "properties": [
+                {
+                    "name": "tagName",
+                    "defaultValue": "'vcd-cliptext'",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 13,
+                    "modifierKind": [
+                        115
+                    ]
+                },
+                {
+                    "name": "component",
+                    "defaultValue": "fixture.componentInstance",
+                    "type": "T",
+                    "optional": false,
+                    "description": "The component instance being managed. Whenever possible, we should access the component's API.",
+                    "line": 43,
+                    "modifierKind": [
+                        114
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                }
+            ],
+            "description": "<p>Testing Object for {@link CliptextComponent}</p>\n",
+            "rawdescription": "Testing Object for {@link CliptextComponent}",
+            "methods": [
+                {
+                    "name": "mouseEnter",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 18,
+                    "description": "<p>Sends a mouseenter event for clr tooltip</p>\n"
+                },
+                {
+                    "name": "mouseLeave",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 26,
+                    "description": "<p>Sends a mouseleave event for clr tooltip</p>\n"
+                },
+                {
+                    "name": "click",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "optional": true
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 71,
+                    "description": "<p>Clicks an element and detects changes so the DOM is immediately updated</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2836,
+                                "end": 2847,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "optional": true,
+                            "tagName": {
+                                "pos": 2830,
+                                "end": 2835,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Pass this in if you want to click a specific element. If not passed in, the entire node will\nreceive the click event</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "detectChanges",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 46,
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "findElement",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement",
+                    "typeParameters": [],
+                    "line": 55,
+                    "description": "<p>Finds first element within this widget matching the given selector</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2219,
+                                "end": 2230,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 2213,
+                                "end": 2218,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>What to search for</p>\n"
+                        },
+                        {
+                            "name": {
+                                "pos": 2264,
+                                "end": 2270,
+                                "flags": 0,
+                                "escapedText": "parent"
+                            },
+                            "type": "DebugElement",
+                            "defaultValue": "this.root",
+                            "tagName": {
+                                "pos": 2258,
+                                "end": 2263,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Where to start the search; defaults to the root of this component</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "findElements",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement[]",
+                    "typeParameters": [],
+                    "line": 62,
+                    "description": "<p>Same as {@link findElement} but returns all elements</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getNodeText",
+                    "args": [
+                        {
+                            "name": "el",
+                            "type": "DebugElement"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 93,
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "el",
+                            "type": "DebugElement",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getText",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 82,
+                    "description": "<p>Returns text content of this widget</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 3255,
+                                "end": 3266,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 3249,
+                                "end": 3254,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Pass this in if you want to retrieve text for a specific element within this widget.</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getTexts",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string[]",
+                    "typeParameters": [],
+                    "line": 89,
+                    "description": "<p>Same as {@link getText} but return the text for all matching nodes</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                }
+            ],
+            "indexSignatures": [],
+            "extends": "WidgetObject",
+            "accessors": {
+                "isShowingTooltip": {
+                    "name": "isShowingTooltip",
+                    "getSignature": {
+                        "name": "isShowingTooltip",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 34,
+                        "description": "<p>Whether the tooltip is visible</p>\n"
+                    }
+                },
+                "tooltipContent": {
+                    "name": "tooltipContent",
+                    "getSignature": {
+                        "name": "tooltipContent",
+                        "type": "string",
+                        "returnType": "string",
+                        "line": 41,
+                        "description": "<p>The text content of the tooltip</p>\n"
+                    }
+                }
+            },
+            "inputsClass": [],
+            "outputsClass": [],
+            "hostBindings": [],
+            "hostListeners": []
+        },
+        {
+            "name": "ClrDatagridWidgetObject",
+            "id": "class-ClrDatagridWidgetObject-cea284f2a68153f92703da2203c020cc",
+            "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+            "type": "class",
+            "sourceCode": "import { WidgetObject } from '../widget-object';\nimport { DebugElement } from '@angular/core';\nimport { ClrDatagrid } from '@clr/angular';\n\nconst ROW_TAG = 'clr-dg-row';\nconst CELL_TAG = 'clr-dg-cell';\nconst COLUMN_SELECTOR = 'clr-dg-column';\nconst COLUMN_CSS_SELECTOR = '.datagrid-column-title';\n\n/**\n * Widget Object for a Clarity DataGrid\n */\nexport class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {\n    static tagName = `clr-datagrid`;\n\n    /**\n     * Retrieves the text content of a cell\n     * @param row 0-based index of row\n     * @param column 0-based index of column\n     */\n    getCellText(row: number, column: number): string {\n        return this.getNodeText(this.getCell(row, column));\n    }\n\n    /**\n     * Returns the number of visible columns\n     */\n    get columnCount(): number {\n        return this.component.columns ? this.component.columns.length : this.columns.length;\n    }\n\n    /**\n     * Returns the text for a header\n     * @param columnIndex 0-based index of header to retrieve\n     */\n    getColumnHeader(columnIndex: number): string {\n        return this.getText(`${COLUMN_CSS_SELECTOR}:nth-of-type(${columnIndex + 1})`);\n    }\n\n    /**\n     * Returns an array of the texts for columns, in DOM order\n     */\n    get columnHeaders(): string[] {\n        return this.getTexts(COLUMN_CSS_SELECTOR);\n    }\n\n    /**\n     * Returns the number of rows currently displayed\n     */\n    get rowCount(): number {\n        return this.rows.length;\n    }\n\n    /**\n     * Returns whether or not the column with the given index is displayed by the CSS.\n     */\n    isColumnDisplayed(index: number): boolean {\n        return this.findElements(COLUMN_SELECTOR)[index].classes['datagrid-hidden-column'] !== true;\n    }\n\n    /*\n     * Returns the CSS class of the Clarity datagrid.\n     */\n    get gridCssClass(): string[] {\n        console.log(this.root.classes);\n        return Object.keys(this.root.classes);\n    }\n\n    /**\n     * Returns the CSS class names of the given Clarity datarow.\n     */\n    getRowsCssClass(index: number): string[] {\n        return Object.keys(this.rows[index].classes);\n    }\n\n    /**\n     * Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that\n     * subclasses should not return the DebugElement, they should return a string from a section of the HTML.\n     *\n     * @param row 0-based index of row\n     * @param column 0-based index of column\n     */\n    protected getCell(row: number, column: number): DebugElement {\n        return this.findElement(`${ROW_TAG}:nth-of-type(${row + 1}) ${CELL_TAG}:nth-of-type(${column + 1})`);\n    }\n\n    private get rows(): DebugElement[] {\n        return this.findElements(ROW_TAG);\n    }\n\n    private get columns(): DebugElement[] {\n        return this.findElements(COLUMN_CSS_SELECTOR);\n    }\n}\n",
+            "properties": [
+                {
+                    "name": "tagName",
+                    "defaultValue": "`clr-datagrid`",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 19,
+                    "modifierKind": [
+                        115
+                    ]
+                },
+                {
+                    "name": "component",
+                    "defaultValue": "fixture.componentInstance",
+                    "type": "T",
+                    "optional": false,
+                    "description": "The component instance being managed. Whenever possible, we should access the component's API.",
+                    "line": 43,
+                    "modifierKind": [
+                        114
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                }
+            ],
+            "description": "<p>Widget Object for a Clarity DataGrid</p>\n",
+            "rawdescription": "Widget Object for a Clarity DataGrid",
+            "methods": [
+                {
+                    "name": "getCell",
+                    "args": [
+                        {
+                            "name": "row",
+                            "type": "number"
+                        },
+                        {
+                            "name": "column",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement",
+                    "typeParameters": [],
+                    "line": 88,
+                    "description": "<p>Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that\nsubclasses should not return the DebugElement, they should return a string from a section of the HTML.</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2466,
+                                "end": 2469,
+                                "flags": 0,
+                                "escapedText": "row"
+                            },
+                            "type": "number",
+                            "tagName": {
+                                "pos": 2460,
+                                "end": 2465,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>0-based index of row</p>\n"
+                        },
+                        {
+                            "name": {
+                                "pos": 2505,
+                                "end": 2511,
+                                "flags": 0,
+                                "escapedText": "column"
+                            },
+                            "type": "number",
+                            "tagName": {
+                                "pos": 2499,
+                                "end": 2504,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>0-based index of column</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "getCellText",
+                    "args": [
+                        {
+                            "name": "row",
+                            "type": "number"
+                        },
+                        {
+                            "name": "column",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 26,
+                    "description": "<p>Retrieves the text content of a cell</p>\n",
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 604,
+                                "end": 607,
+                                "flags": 0,
+                                "escapedText": "row"
+                            },
+                            "type": "number",
+                            "tagName": {
+                                "pos": 598,
+                                "end": 603,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>0-based index of row</p>\n"
+                        },
+                        {
+                            "name": {
+                                "pos": 643,
+                                "end": 649,
+                                "flags": 0,
+                                "escapedText": "column"
+                            },
+                            "type": "number",
+                            "tagName": {
+                                "pos": 637,
+                                "end": 642,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>0-based index of column</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "getColumnHeader",
+                    "args": [
+                        {
+                            "name": "columnIndex",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 41,
+                    "description": "<p>Returns the text for a header</p>\n",
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 1056,
+                                "end": 1067,
+                                "flags": 0,
+                                "escapedText": "columnIndex"
+                            },
+                            "type": "number",
+                            "tagName": {
+                                "pos": 1050,
+                                "end": 1055,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>0-based index of header to retrieve</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "getRowsCssClass",
+                    "args": [
+                        {
+                            "name": "index",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string[]",
+                    "typeParameters": [],
+                    "line": 77,
+                    "description": "<p>Returns the CSS class names of the given Clarity datarow.</p>\n",
+                    "jsdoctags": [
+                        {
+                            "name": "index",
+                            "type": "number",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "isColumnDisplayed",
+                    "args": [
+                        {
+                            "name": "index",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "boolean",
+                    "typeParameters": [],
+                    "line": 62,
+                    "description": "<p>Returns whether or not the column with the given index is displayed by the CSS.</p>\n",
+                    "jsdoctags": [
+                        {
+                            "name": "index",
+                            "type": "number",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "click",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "optional": true
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 71,
+                    "description": "<p>Clicks an element and detects changes so the DOM is immediately updated</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2836,
+                                "end": 2847,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "optional": true,
+                            "tagName": {
+                                "pos": 2830,
+                                "end": 2835,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Pass this in if you want to click a specific element. If not passed in, the entire node will\nreceive the click event</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "detectChanges",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 46,
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "findElement",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement",
+                    "typeParameters": [],
+                    "line": 55,
+                    "description": "<p>Finds first element within this widget matching the given selector</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2219,
+                                "end": 2230,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 2213,
+                                "end": 2218,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>What to search for</p>\n"
+                        },
+                        {
+                            "name": {
+                                "pos": 2264,
+                                "end": 2270,
+                                "flags": 0,
+                                "escapedText": "parent"
+                            },
+                            "type": "DebugElement",
+                            "defaultValue": "this.root",
+                            "tagName": {
+                                "pos": 2258,
+                                "end": 2263,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Where to start the search; defaults to the root of this component</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "findElements",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement[]",
+                    "typeParameters": [],
+                    "line": 62,
+                    "description": "<p>Same as {@link findElement} but returns all elements</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getNodeText",
+                    "args": [
+                        {
+                            "name": "el",
+                            "type": "DebugElement"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 93,
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "el",
+                            "type": "DebugElement",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getText",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 82,
+                    "description": "<p>Returns text content of this widget</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 3255,
+                                "end": 3266,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 3249,
+                                "end": 3254,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Pass this in if you want to retrieve text for a specific element within this widget.</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getTexts",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string[]",
+                    "typeParameters": [],
+                    "line": 89,
+                    "description": "<p>Same as {@link getText} but return the text for all matching nodes</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                }
+            ],
+            "indexSignatures": [],
+            "extends": "WidgetObject",
+            "accessors": {
+                "columnCount": {
+                    "name": "columnCount",
+                    "getSignature": {
+                        "name": "columnCount",
+                        "type": "number",
+                        "returnType": "number",
+                        "line": 33,
+                        "description": "<p>Returns the number of visible columns</p>\n"
+                    }
+                },
+                "columnHeaders": {
+                    "name": "columnHeaders",
+                    "getSignature": {
+                        "name": "columnHeaders",
+                        "type": "[]",
+                        "returnType": "string[]",
+                        "line": 48,
+                        "description": "<p>Returns an array of the texts for columns, in DOM order</p>\n"
+                    }
+                },
+                "rowCount": {
+                    "name": "rowCount",
+                    "getSignature": {
+                        "name": "rowCount",
+                        "type": "number",
+                        "returnType": "number",
+                        "line": 55,
+                        "description": "<p>Returns the number of rows currently displayed</p>\n"
+                    }
+                },
+                "gridCssClass": {
+                    "name": "gridCssClass",
+                    "getSignature": {
+                        "name": "gridCssClass",
+                        "type": "[]",
+                        "returnType": "string[]",
+                        "line": 69
+                    }
+                },
+                "rows": {
+                    "name": "rows",
+                    "getSignature": {
+                        "name": "rows",
+                        "type": "[]",
+                        "returnType": "DebugElement[]",
+                        "line": 92
+                    }
+                },
+                "columns": {
+                    "name": "columns",
+                    "getSignature": {
+                        "name": "columns",
+                        "type": "[]",
+                        "returnType": "DebugElement[]",
+                        "line": 96
+                    }
+                }
+            },
+            "inputsClass": [],
+            "outputsClass": [],
+            "hostBindings": [],
+            "hostListeners": []
+        },
+        {
+            "name": "DataExporterWidgetObject",
+            "id": "class-DataExporterWidgetObject-e3f8af3b5a6b33532e739128d4ac29b6",
+            "file": "projects/components/src/data-exporter/data-exporter.wo.ts",
+            "type": "class",
+            "sourceCode": "import { DataExporterComponent } from './data-exporter.component';\nimport { WidgetObject } from '../utils/test/widget-object';\nimport { DebugElement } from '@angular/core';\n\nconst Css = {\n    SelectAll: '.select-all',\n    SelectColumn: '.column-selection label',\n};\n/**\n * Testing Object for {@link DataExporterComponent}\n */\nexport class DataExporterWidgetObject extends WidgetObject<DataExporterComponent> {\n    static tagName = 'vcd-data-exporter';\n\n    /**\n     * Whether the progress bar is currently showing indefinite progress, that is a looping loading indicator\n     */\n    get isLoopingProgressBar(): boolean {\n        return !!this.findElement('.progress.loop');\n    }\n\n    /**\n     * The strings for the available check boxes\n     */\n    get columnCheckBoxes(): string[] {\n        return this.getTexts('.column-selection label');\n    }\n\n    /**\n     * Whether the select all button is displayed\n     */\n    get isSelectAllVisible(): boolean {\n        return !!this.selectAllLink;\n    }\n\n    private get selectAllLink(): DebugElement {\n        return this.findElement(Css.SelectAll);\n    }\n\n    /**\n     * Click the select all link. Throws an error if the link is not available\n     */\n    clickSelectAll(): void {\n        this.click(Css.SelectAll);\n    }\n\n    /**\n     * Whether the select all link is enabled. Throws an error if link is not available\n     */\n    get isSelectAllEnabled(): boolean {\n        return !this.selectAllLink.nativeElement.disabled;\n    }\n\n    /**\n     * Clicks the checkbox for a colum\n     * @param index Index of column, 0 based\n     */\n    clickColumn(index: number): void {\n        this.click(`.column-selection li:nth-of-type(${index + 1}) label`);\n    }\n\n    clickCancel(): void {\n        this.click('.cancel');\n    }\n\n    clickExport(): void {\n        this.click('.export');\n    }\n}\n",
+            "properties": [
+                {
+                    "name": "tagName",
+                    "defaultValue": "'vcd-data-exporter'",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 18,
+                    "modifierKind": [
+                        115
+                    ]
+                },
+                {
+                    "name": "component",
+                    "defaultValue": "fixture.componentInstance",
+                    "type": "T",
+                    "optional": false,
+                    "description": "The component instance being managed. Whenever possible, we should access the component's API.",
+                    "line": 43,
+                    "modifierKind": [
+                        114
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                }
+            ],
+            "description": "<p>Testing Object for {@link DataExporterComponent}</p>\n",
+            "rawdescription": "Testing Object for {@link DataExporterComponent}",
+            "methods": [
+                {
+                    "name": "clickCancel",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 67
+                },
+                {
+                    "name": "clickColumn",
+                    "args": [
+                        {
+                            "name": "index",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 63,
+                    "description": "<p>Clicks the checkbox for a colum</p>\n",
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 1620,
+                                "end": 1625,
+                                "flags": 0,
+                                "escapedText": "index"
+                            },
+                            "type": "number",
+                            "tagName": {
+                                "pos": 1614,
+                                "end": 1619,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Index of column, 0 based</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "clickExport",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 71
+                },
+                {
+                    "name": "clickSelectAll",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 48,
+                    "description": "<p>Click the select all link. Throws an error if the link is not available</p>\n"
+                },
+                {
+                    "name": "click",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "optional": true
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 71,
+                    "description": "<p>Clicks an element and detects changes so the DOM is immediately updated</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2836,
+                                "end": 2847,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "optional": true,
+                            "tagName": {
+                                "pos": 2830,
+                                "end": 2835,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Pass this in if you want to click a specific element. If not passed in, the entire node will\nreceive the click event</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "detectChanges",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 46,
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "findElement",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement",
+                    "typeParameters": [],
+                    "line": 55,
+                    "description": "<p>Finds first element within this widget matching the given selector</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2219,
+                                "end": 2230,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 2213,
+                                "end": 2218,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>What to search for</p>\n"
+                        },
+                        {
+                            "name": {
+                                "pos": 2264,
+                                "end": 2270,
+                                "flags": 0,
+                                "escapedText": "parent"
+                            },
+                            "type": "DebugElement",
+                            "defaultValue": "this.root",
+                            "tagName": {
+                                "pos": 2258,
+                                "end": 2263,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Where to start the search; defaults to the root of this component</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "findElements",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement[]",
+                    "typeParameters": [],
+                    "line": 62,
+                    "description": "<p>Same as {@link findElement} but returns all elements</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getNodeText",
+                    "args": [
+                        {
+                            "name": "el",
+                            "type": "DebugElement"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 93,
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "el",
+                            "type": "DebugElement",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getText",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 82,
+                    "description": "<p>Returns text content of this widget</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 3255,
+                                "end": 3266,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 3249,
+                                "end": 3254,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Pass this in if you want to retrieve text for a specific element within this widget.</p>\n"
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                },
+                {
+                    "name": "getTexts",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string[]",
+                    "typeParameters": [],
+                    "line": 89,
+                    "description": "<p>Same as {@link getText} but return the text for all matching nodes</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ],
+                    "inheritance": {
+                        "file": "WidgetObject"
+                    }
+                }
+            ],
+            "indexSignatures": [],
+            "extends": "WidgetObject",
+            "accessors": {
+                "isLoopingProgressBar": {
+                    "name": "isLoopingProgressBar",
+                    "getSignature": {
+                        "name": "isLoopingProgressBar",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 23,
+                        "description": "<p>Whether the progress bar is currently showing indefinite progress, that is a looping loading indicator</p>\n"
+                    }
+                },
+                "columnCheckBoxes": {
+                    "name": "columnCheckBoxes",
+                    "getSignature": {
+                        "name": "columnCheckBoxes",
+                        "type": "[]",
+                        "returnType": "string[]",
+                        "line": 30,
+                        "description": "<p>The strings for the available check boxes</p>\n"
+                    }
+                },
+                "isSelectAllVisible": {
+                    "name": "isSelectAllVisible",
+                    "getSignature": {
+                        "name": "isSelectAllVisible",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 37,
+                        "description": "<p>Whether the select all button is displayed</p>\n"
+                    }
+                },
+                "selectAllLink": {
+                    "name": "selectAllLink",
+                    "getSignature": {
+                        "name": "selectAllLink",
+                        "type": "",
+                        "returnType": "DebugElement",
+                        "line": 41
+                    }
+                },
+                "isSelectAllEnabled": {
+                    "name": "isSelectAllEnabled",
+                    "getSignature": {
+                        "name": "isSelectAllEnabled",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 55,
+                        "description": "<p>Whether the select all link is enabled. Throws an error if link is not available</p>\n"
+                    }
+                }
+            },
+            "inputsClass": [],
+            "outputsClass": [],
+            "hostBindings": [],
+            "hostListeners": []
+        },
+        {
+            "name": "WidgetFinder",
+            "id": "class-WidgetFinder-d181c05ac7c0b6904e1762602ec8ba0c",
+            "file": "projects/components/src/utils/test/widget-object.ts",
+            "type": "class",
+            "sourceCode": "import { DebugElement, Type } from '@angular/core';\nimport { ComponentFixture, TestBed } from '@angular/core/testing';\nimport { By } from '@angular/platform-browser';\nimport { FindableWidget } from './widget-object';\n\n/**\n * An implementation of the page object pattern, but applied to widgets, since they can be reused on multiple pages.\n *\n * The main purpose for the wrapper are providing access to the internals of a widget avoiding duplication of code that\n * queries the internals of a component from a test.\n *\n * ## Subclass Rules\n *\n * - Methods exposed by subclasses should not expose HTMLElements or DebugElements directly. That would encourage\n * callers to query it from the outside creating potential duplicate querying code and abstraction leaks.\n *  - Subclasses also should not have testing assertions. They should only provide the state and the calling test can\n * assert code on its own.\n *\n * `T` is the type of the JS/TS object being wrapped\n *\n * It is recommended that files for implementations be named with a `.wo.ts` extension\n */\nexport abstract class WidgetObject<T> {\n    /**\n     *\n     * Constructor should only be called directly if you are directly instantiating the widget being wrapped (T). If you\n     * need to find a widget within the tree, you should use {@link find}.\n     *\n     * @param component The component instance being managed. Whenever possible, we should access the component's API.\n     * @param root The root element (host) for the component instance. We typically prefer to interact with the\n     * component but there are times when we must check the DOM.\n     * @param fixture The test fixture, so we can call {@link ComponentFixture#detectChanges} after something that\n     * requires re-rendering of the DOM.\n     */\n    constructor(\n        protected fixture: ComponentFixture<any>,\n        protected root: DebugElement = fixture.debugElement,\n        public component: T = fixture.componentInstance\n    ) {}\n\n    detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n\n    /**\n     * Finds first element within this widget matching the given selector\n     * @param cssSelector What to search for\n     * @param parent Where to start the search; defaults to the root of this component\n     */\n    protected findElement(cssSelector: string, parent: DebugElement = this.root): DebugElement {\n        return parent.query(By.css(cssSelector));\n    }\n\n    /**\n     * Same as {@link findElement} but returns all elements\n     */\n    protected findElements(cssSelector: string, parent: DebugElement = this.root): DebugElement[] {\n        return parent.queryAll(By.css(cssSelector));\n    }\n\n    /**\n     * Clicks an element and detects changes so the DOM is immediately updated\n     * @param cssSelector Pass this in if you want to click a specific element. If not passed in, the entire node will\n     * receive the click event\n     */\n    protected click(cssSelector?: string): void {\n        const nativeElement: HTMLBaseElement = this.findElement(cssSelector).nativeElement;\n        nativeElement.click();\n        this.detectChanges();\n    }\n\n    /**\n     * Returns text content of this widget\n     * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.\n     */\n\n    protected getText(cssSelector: string): string {\n        return this.getNodeText(this.findElement(cssSelector));\n    }\n\n    /**\n     * Same as {@link getText} but return the text for all matching nodes\n     */\n    protected getTexts(cssSelector: string): string[] {\n        return this.findElements(cssSelector).map(el => this.getNodeText(el));\n    }\n\n    protected getNodeText(el: DebugElement): string {\n        // The || '' is because textContent could technically be null when passed in the document\n        // element object. We know that cannot be pased in here, so we ignore it for coverage\n        // but we still need the line there to make strictNullChecks work\n        return el.nativeElement.textContent || /* istanbul ignore next */ '';\n    }\n}\n\n/**\n * Subclasses should implement the FindableWidget interface so they can be found with {@link WidgetFinder}\n *\n * ## Note\n * This is done by creating a static property `tagName`on your subclass, not a regular instance, since this\n * interface represents a constructor for a {@link WidgetObject}, not an instance.\n */\nexport interface FindableWidget<T> extends Type<WidgetObject<T>> {\n    tagName: string;\n}\n\n/**\n * Arguments for {@link WidgetFinder#findWidgets} and {@link WidgetFinder#find}\n */\ninterface FindParams<T> {\n    /**\n     * The constructor of the widget to be found\n     */\n    woConstructor: T;\n    /**\n     * If provided, search starts from this container. It defaults to the fixture's root debugElement\n     */\n    ancestor?: DebugElement;\n    /**\n     * Optional CSS class name that can be used when there could be multiple instances of the object within the\n     * fixture tree\n     */\n    className?: string;\n}\n\n/**\n * Finds instances that implement {@link FindableWidget}\n * H is the host component's type\n */\nexport class WidgetFinder<H = unknown> {\n    /**\n     * We don't care or could possibly know the type of fixture\n     */\n    private fixture: ComponentFixture<H>;\n\n    /**\n     * If you need direct access to manipulate the host\n     */\n    public hostComponent: H;\n\n    /**\n     * @param componentConstructor The host component to be created as the root of the tests's fixture\n     */\n    constructor(componentConstructor: Type<H>) {\n        this.fixture = TestBed.createComponent(componentConstructor);\n        this.hostComponent = this.fixture.componentInstance;\n    }\n\n    /**\n     * Finds widgets within a fixture\n     * @return A Potentially empty list of widgets matching the given specs\n     */\n    public findWidgets<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T>[] {\n        const defaults = { ancestor: this.fixture.debugElement, className: '' };\n        const { woConstructor, ancestor, className } = isFindParamsObject(params)\n            ? { ...defaults, ...params }\n            : { ...defaults, woConstructor: params };\n\n        let query = woConstructor.tagName;\n        if (className) {\n            query += `.${className}`;\n        }\n        const componentRoots = ancestor.queryAll(By.css(query));\n        const widgets = componentRoots.map(\n            // Typescript is not able to infer it correctly as the subclass but we know for sure\n            root => new woConstructor(this.fixture, root, root.componentInstance) as InstanceType<T>\n        );\n        return widgets;\n    }\n\n    /**\n     * Finds a single widget object\n     * @throws An error if the widget is not found or if there are multiple instances\n     */\n    public find<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T> {\n        const widgets = this.findWidgets(params);\n        const tagName = isFindParamsObject(params) ? params.woConstructor.tagName : params.tagName;\n        if (widgets.length === 0) {\n            throw Error(`Did not find a <${tagName}>`);\n        }\n        if (widgets.length > 1) {\n            throw Error(`Expected to find a single <${tagName}> but found ${widgets.length}`);\n        }\n        return widgets[0] as InstanceType<T>;\n    }\n\n    public detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n}\n\nfunction isFindParamsObject<T>(params: FindParams<T> | T): params is FindParams<T> {\n    return !!(params as FindParams<T>).woConstructor;\n}\n/**\n * Can be used in tests that use `this` to share a finder with before/AfterEach instead of leaky closures\n */\nexport interface HasFinder<T = unknown> {\n    finder: WidgetFinder<T>;\n}\n",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "componentConstructor",
+                        "type": "Type<H>"
+                    }
+                ],
+                "line": 144,
+                "jsdoctags": [
+                    {
+                        "name": {
+                            "pos": 5445,
+                            "end": 5465,
+                            "flags": 0,
+                            "escapedText": "componentConstructor"
+                        },
+                        "type": "Type<H>",
+                        "tagName": {
+                            "pos": 5439,
+                            "end": 5444,
+                            "flags": 0,
+                            "escapedText": "param"
+                        },
+                        "comment": "<p>The host component to be created as the root of the tests&#39;s fixture</p>\n"
+                    }
+                ]
+            },
+            "properties": [
+                {
+                    "name": "fixture",
+                    "type": "ComponentFixture<H>",
+                    "optional": false,
+                    "description": "<p>We don&#39;t care or could possibly know the type of fixture</p>\n",
+                    "line": 139,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "hostComponent",
+                    "type": "H",
+                    "optional": false,
+                    "description": "<p>If you need direct access to manipulate the host</p>\n",
+                    "line": 144,
+                    "modifierKind": [
+                        114
+                    ]
+                }
+            ],
+            "description": "<p>Finds instances that implement {@link FindableWidget}\nH is the host component&#39;s type</p>\n",
+            "rawdescription": "Finds instances that implement {@link FindableWidget}\nH is the host component's type",
+            "methods": [
+                {
+                    "name": "detectChanges",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 192,
+                    "modifierKind": [
+                        114
+                    ]
+                },
+                {
+                    "name": "find",
+                    "args": [
+                        {
+                            "name": "params",
+                            "type": "FindParams<T> | T"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "InstanceType<T>",
+                    "typeParameters": [
+                        "C",
+                        "T"
+                    ],
+                    "line": 180,
+                    "description": "<p>Finds a single widget object</p>\n",
+                    "modifierKind": [
+                        114
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "params",
+                            "type": "FindParams<T> | T",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "findWidgets",
+                    "args": [
+                        {
+                            "name": "params",
+                            "type": "FindParams<T> | T"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "InstanceType[]",
+                    "typeParameters": [
+                        "C",
+                        "T"
+                    ],
+                    "line": 158,
+                    "description": "<p>Finds widgets within a fixture</p>\n",
+                    "modifierKind": [
+                        114
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "params",
+                            "type": "FindParams<T> | T",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "tagName": {
+                                "pos": 5783,
+                                "end": 5789,
+                                "flags": 0,
+                                "escapedText": "return"
+                            },
+                            "comment": "<p>A Potentially empty list of widgets matching the given specs</p>\n"
+                        }
+                    ]
+                }
+            ],
+            "indexSignatures": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "hostBindings": [],
+            "hostListeners": []
+        },
+        {
+            "name": "WidgetObject",
+            "id": "class-WidgetObject-d181c05ac7c0b6904e1762602ec8ba0c",
+            "file": "projects/components/src/utils/test/widget-object.ts",
+            "type": "class",
+            "sourceCode": "import { DebugElement, Type } from '@angular/core';\nimport { ComponentFixture, TestBed } from '@angular/core/testing';\nimport { By } from '@angular/platform-browser';\nimport { FindableWidget } from './widget-object';\n\n/**\n * An implementation of the page object pattern, but applied to widgets, since they can be reused on multiple pages.\n *\n * The main purpose for the wrapper are providing access to the internals of a widget avoiding duplication of code that\n * queries the internals of a component from a test.\n *\n * ## Subclass Rules\n *\n * - Methods exposed by subclasses should not expose HTMLElements or DebugElements directly. That would encourage\n * callers to query it from the outside creating potential duplicate querying code and abstraction leaks.\n *  - Subclasses also should not have testing assertions. They should only provide the state and the calling test can\n * assert code on its own.\n *\n * `T` is the type of the JS/TS object being wrapped\n *\n * It is recommended that files for implementations be named with a `.wo.ts` extension\n */\nexport abstract class WidgetObject<T> {\n    /**\n     *\n     * Constructor should only be called directly if you are directly instantiating the widget being wrapped (T). If you\n     * need to find a widget within the tree, you should use {@link find}.\n     *\n     * @param component The component instance being managed. Whenever possible, we should access the component's API.\n     * @param root The root element (host) for the component instance. We typically prefer to interact with the\n     * component but there are times when we must check the DOM.\n     * @param fixture The test fixture, so we can call {@link ComponentFixture#detectChanges} after something that\n     * requires re-rendering of the DOM.\n     */\n    constructor(\n        protected fixture: ComponentFixture<any>,\n        protected root: DebugElement = fixture.debugElement,\n        public component: T = fixture.componentInstance\n    ) {}\n\n    detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n\n    /**\n     * Finds first element within this widget matching the given selector\n     * @param cssSelector What to search for\n     * @param parent Where to start the search; defaults to the root of this component\n     */\n    protected findElement(cssSelector: string, parent: DebugElement = this.root): DebugElement {\n        return parent.query(By.css(cssSelector));\n    }\n\n    /**\n     * Same as {@link findElement} but returns all elements\n     */\n    protected findElements(cssSelector: string, parent: DebugElement = this.root): DebugElement[] {\n        return parent.queryAll(By.css(cssSelector));\n    }\n\n    /**\n     * Clicks an element and detects changes so the DOM is immediately updated\n     * @param cssSelector Pass this in if you want to click a specific element. If not passed in, the entire node will\n     * receive the click event\n     */\n    protected click(cssSelector?: string): void {\n        const nativeElement: HTMLBaseElement = this.findElement(cssSelector).nativeElement;\n        nativeElement.click();\n        this.detectChanges();\n    }\n\n    /**\n     * Returns text content of this widget\n     * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.\n     */\n\n    protected getText(cssSelector: string): string {\n        return this.getNodeText(this.findElement(cssSelector));\n    }\n\n    /**\n     * Same as {@link getText} but return the text for all matching nodes\n     */\n    protected getTexts(cssSelector: string): string[] {\n        return this.findElements(cssSelector).map(el => this.getNodeText(el));\n    }\n\n    protected getNodeText(el: DebugElement): string {\n        // The || '' is because textContent could technically be null when passed in the document\n        // element object. We know that cannot be pased in here, so we ignore it for coverage\n        // but we still need the line there to make strictNullChecks work\n        return el.nativeElement.textContent || /* istanbul ignore next */ '';\n    }\n}\n\n/**\n * Subclasses should implement the FindableWidget interface so they can be found with {@link WidgetFinder}\n *\n * ## Note\n * This is done by creating a static property `tagName`on your subclass, not a regular instance, since this\n * interface represents a constructor for a {@link WidgetObject}, not an instance.\n */\nexport interface FindableWidget<T> extends Type<WidgetObject<T>> {\n    tagName: string;\n}\n\n/**\n * Arguments for {@link WidgetFinder#findWidgets} and {@link WidgetFinder#find}\n */\ninterface FindParams<T> {\n    /**\n     * The constructor of the widget to be found\n     */\n    woConstructor: T;\n    /**\n     * If provided, search starts from this container. It defaults to the fixture's root debugElement\n     */\n    ancestor?: DebugElement;\n    /**\n     * Optional CSS class name that can be used when there could be multiple instances of the object within the\n     * fixture tree\n     */\n    className?: string;\n}\n\n/**\n * Finds instances that implement {@link FindableWidget}\n * H is the host component's type\n */\nexport class WidgetFinder<H = unknown> {\n    /**\n     * We don't care or could possibly know the type of fixture\n     */\n    private fixture: ComponentFixture<H>;\n\n    /**\n     * If you need direct access to manipulate the host\n     */\n    public hostComponent: H;\n\n    /**\n     * @param componentConstructor The host component to be created as the root of the tests's fixture\n     */\n    constructor(componentConstructor: Type<H>) {\n        this.fixture = TestBed.createComponent(componentConstructor);\n        this.hostComponent = this.fixture.componentInstance;\n    }\n\n    /**\n     * Finds widgets within a fixture\n     * @return A Potentially empty list of widgets matching the given specs\n     */\n    public findWidgets<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T>[] {\n        const defaults = { ancestor: this.fixture.debugElement, className: '' };\n        const { woConstructor, ancestor, className } = isFindParamsObject(params)\n            ? { ...defaults, ...params }\n            : { ...defaults, woConstructor: params };\n\n        let query = woConstructor.tagName;\n        if (className) {\n            query += `.${className}`;\n        }\n        const componentRoots = ancestor.queryAll(By.css(query));\n        const widgets = componentRoots.map(\n            // Typescript is not able to infer it correctly as the subclass but we know for sure\n            root => new woConstructor(this.fixture, root, root.componentInstance) as InstanceType<T>\n        );\n        return widgets;\n    }\n\n    /**\n     * Finds a single widget object\n     * @throws An error if the widget is not found or if there are multiple instances\n     */\n    public find<C, T extends FindableWidget<C>>(params: FindParams<T> | T): InstanceType<T> {\n        const widgets = this.findWidgets(params);\n        const tagName = isFindParamsObject(params) ? params.woConstructor.tagName : params.tagName;\n        if (widgets.length === 0) {\n            throw Error(`Did not find a <${tagName}>`);\n        }\n        if (widgets.length > 1) {\n            throw Error(`Expected to find a single <${tagName}> but found ${widgets.length}`);\n        }\n        return widgets[0] as InstanceType<T>;\n    }\n\n    public detectChanges(): void {\n        this.fixture.detectChanges();\n    }\n}\n\nfunction isFindParamsObject<T>(params: FindParams<T> | T): params is FindParams<T> {\n    return !!(params as FindParams<T>).woConstructor;\n}\n/**\n * Can be used in tests that use `this` to share a finder with before/AfterEach instead of leaky closures\n */\nexport interface HasFinder<T = unknown> {\n    finder: WidgetFinder<T>;\n}\n",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "<p>Constructor should only be called directly if you are directly instantiating the widget being wrapped (T). If you\nneed to find a widget within the tree, you should use {@link find}.</p>\n",
+                "args": [
+                    {
+                        "name": "fixture",
+                        "type": "ComponentFixture<any>"
+                    },
+                    {
+                        "name": "root",
+                        "type": "DebugElement",
+                        "defaultValue": "fixture.debugElement"
+                    },
+                    {
+                        "name": "component",
+                        "type": "T",
+                        "defaultValue": "fixture.componentInstance"
+                    }
+                ],
+                "line": 28,
+                "jsdoctags": [
+                    {
+                        "name": {
+                            "pos": 1706,
+                            "end": 1713,
+                            "flags": 0,
+                            "escapedText": "fixture"
+                        },
+                        "type": "ComponentFixture<any>",
+                        "tagName": {
+                            "pos": 1700,
+                            "end": 1705,
+                            "flags": 0,
+                            "escapedText": "param"
+                        },
+                        "comment": "<p>The test fixture, so we can call {</p>\n"
+                    },
+                    {
+                        "name": {
+                            "pos": 1529,
+                            "end": 1533,
+                            "flags": 0,
+                            "escapedText": "root"
+                        },
+                        "type": "DebugElement",
+                        "defaultValue": "fixture.debugElement",
+                        "tagName": {
+                            "pos": 1523,
+                            "end": 1528,
+                            "flags": 0,
+                            "escapedText": "param"
+                        },
+                        "comment": "<p>The root element (host) for the component instance. We typically prefer to interact with the\ncomponent but there are times when we must check the DOM.</p>\n"
+                    },
+                    {
+                        "name": {
+                            "pos": 1410,
+                            "end": 1419,
+                            "flags": 0,
+                            "escapedText": "component"
+                        },
+                        "type": "T",
+                        "defaultValue": "fixture.componentInstance",
+                        "tagName": {
+                            "pos": 1404,
+                            "end": 1409,
+                            "flags": 0,
+                            "escapedText": "param"
+                        },
+                        "comment": "<p>The component instance being managed. Whenever possible, we should access the component&#39;s API.</p>\n"
+                    }
+                ]
+            },
+            "properties": [
+                {
+                    "name": "component",
+                    "defaultValue": "fixture.componentInstance",
+                    "type": "T",
+                    "optional": false,
+                    "description": "The component instance being managed. Whenever possible, we should access the component's API.",
+                    "line": 43,
+                    "modifierKind": [
+                        114
+                    ]
+                }
+            ],
+            "description": "<p>An implementation of the page object pattern, but applied to widgets, since they can be reused on multiple pages.</p>\n<p>The main purpose for the wrapper are providing access to the internals of a widget avoiding duplication of code that\nqueries the internals of a component from a test.</p>\n<h2 id=\"subclass-rules\">Subclass Rules</h2>\n<ul>\n<li>Methods exposed by subclasses should not expose HTMLElements or DebugElements directly. That would encourage\ncallers to query it from the outside creating potential duplicate querying code and abstraction leaks.<ul>\n<li>Subclasses also should not have testing assertions. They should only provide the state and the calling test can\nassert code on its own.</li>\n</ul>\n</li>\n</ul>\n<p><code>T</code> is the type of the JS/TS object being wrapped</p>\n<p>It is recommended that files for implementations be named with a <code>.wo.ts</code> extension</p>\n",
+            "rawdescription": "An implementation of the page object pattern, but applied to widgets, since they can be reused on multiple pages.\n\nThe main purpose for the wrapper are providing access to the internals of a widget avoiding duplication of code that\nqueries the internals of a component from a test.\n\n## Subclass Rules\n\n- Methods exposed by subclasses should not expose HTMLElements or DebugElements directly. That would encourage\ncallers to query it from the outside creating potential duplicate querying code and abstraction leaks.\n  - Subclasses also should not have testing assertions. They should only provide the state and the calling test can\nassert code on its own.\n\n`T` is the type of the JS/TS object being wrapped\n\nIt is recommended that files for implementations be named with a `.wo.ts` extension",
+            "methods": [
+                {
+                    "name": "click",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "optional": true
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 71,
+                    "description": "<p>Clicks an element and detects changes so the DOM is immediately updated</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2836,
+                                "end": 2847,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "optional": true,
+                            "tagName": {
+                                "pos": 2830,
+                                "end": 2835,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Pass this in if you want to click a specific element. If not passed in, the entire node will\nreceive the click event</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "detectChanges",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 46
+                },
+                {
+                    "name": "findElement",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement",
+                    "typeParameters": [],
+                    "line": 55,
+                    "description": "<p>Finds first element within this widget matching the given selector</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 2219,
+                                "end": 2230,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 2213,
+                                "end": 2218,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>What to search for</p>\n"
+                        },
+                        {
+                            "name": {
+                                "pos": 2264,
+                                "end": 2270,
+                                "flags": 0,
+                                "escapedText": "parent"
+                            },
+                            "type": "DebugElement",
+                            "defaultValue": "this.root",
+                            "tagName": {
+                                "pos": 2258,
+                                "end": 2263,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Where to start the search; defaults to the root of this component</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "findElements",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "DebugElement[]",
+                    "typeParameters": [],
+                    "line": 62,
+                    "description": "<p>Same as {@link findElement} but returns all elements</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "parent",
+                            "type": "DebugElement",
+                            "defaultValue": "this.root",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "getNodeText",
+                    "args": [
+                        {
+                            "name": "el",
+                            "type": "DebugElement"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 93,
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "el",
+                            "type": "DebugElement",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "getText",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 82,
+                    "description": "<p>Returns text content of this widget</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 3255,
+                                "end": 3266,
+                                "flags": 0,
+                                "escapedText": "cssSelector"
+                            },
+                            "type": "string",
+                            "tagName": {
+                                "pos": 3249,
+                                "end": 3254,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Pass this in if you want to retrieve text for a specific element within this widget.</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "getTexts",
+                    "args": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string[]",
+                    "typeParameters": [],
+                    "line": 89,
+                    "description": "<p>Same as {@link getText} but return the text for all matching nodes</p>\n",
+                    "modifierKind": [
+                        113
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "cssSelector",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "indexSignatures": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "hostBindings": [],
+            "hostListeners": []
+        }
+    ],
+    "directives": [
+        {
+            "name": "ComponentRendererOutletDirective",
+            "id": "directive-ComponentRendererOutletDirective-015ff7e245db7e8600a9c1b7eecae5af",
+            "file": "projects/components/src/datagrid/directives/component-renderer-outlet.directive.ts",
+            "type": "directive",
+            "description": "<p>Component that acts as a host element for dynamic rendering of component constructors.\nIt takes {@link ComponentRendererSpec} as input and also &#39;context&#39; as input that serves as argument for\n{@link ComponentRenderer.config} method. Attaches the component to be rendered to the view container of host element\nand updates it&#39;s configuration whenever changed.</p>\n<p>Example usage:\n&lt;ng-template\n      [vcdComponentRendererOutlet]=&quot;{ rendererSpec: column.fieldColumnRendererSpec, context: restItem }&quot;</p>\n<blockquote>\n</ng-template></blockquote>\n",
+            "sourceCode": "import { ComponentFactoryResolver, ComponentRef, Directive, Input, ViewContainerRef } from '@angular/core';\nimport {\n    ComponentRenderer,\n    ComponentRendererConstructor,\n    ComponentRendererSpec,\n} from '../interfaces/component-renderer.interface';\n\n/**\n * Type of the Input given to the {@link ComponentRendererOutletDirective.vcdComponentRendererOutlet}\n */\nexport interface ComponentRendererType<R, T> {\n    /**\n     * Contains the constructor of component to be rendered and also the method that gets the configuration required for\n     * the component API\n     */\n    rendererSpec: ComponentRendererSpec<R, T>;\n\n    /**\n     * serves as argument for {@link ComponentRenderer.config} method\n     */\n    context: R;\n}\n\n/**\n * Component that acts as a host element for dynamic rendering of component constructors.\n * It takes {@link ComponentRendererSpec} as input and also 'context' as input that serves as argument for\n * {@link ComponentRenderer.config} method. Attaches the component to be rendered to the view container of host element\n * and updates it's configuration whenever changed.\n *\n * Example usage:\n * <ng-template\n *      [vcdComponentRendererOutlet]=\"{ rendererSpec: column.fieldColumnRendererSpec, context: restItem }\"\n * ></ng-template>\n *\n */\n@Directive({\n    selector: '[vcdComponentRendererOutlet]',\n})\nexport class ComponentRendererOutletDirective<R, T> {\n    private componentRef: ComponentRef<ComponentRenderer<T>>;\n    private componentType: ComponentRendererConstructor<T>;\n\n    constructor(private viewContainerRef: ViewContainerRef, private cfr: ComponentFactoryResolver) {}\n\n    @Input()\n    set vcdComponentRendererOutlet(renderer: ComponentRendererType<R, T>) {\n        if (this.componentType !== renderer.rendererSpec.type) {\n            // Cache the componentType to avoid redundant detaching and attaching of component to this host\n            this.componentType = renderer.rendererSpec.type;\n            this.componentRef = this.attachRenderer();\n        }\n        this.assignValue(renderer.rendererSpec.config, renderer.context);\n    }\n\n    /**\n     * Attaches the passed component type to the view of this directive host\n     */\n    private attachRenderer(): ComponentRef<ComponentRenderer<T>> {\n        if (this.componentRef) {\n            this.detachRenderer();\n        }\n        const componentFactory = this.cfr.resolveComponentFactory(this.componentType);\n        return this.viewContainerRef.createComponent(componentFactory);\n    }\n\n    /**\n     * Updates the configuration of instantiated component\n     */\n    private assignValue(config: ((r: R) => T) | T, context: R): void {\n        if (!this.componentRef || !this.componentRef.instance) {\n            return;\n        }\n        this.componentRef.instance.config = config instanceof Function ? config(context) : config;\n    }\n\n    private detachRenderer(): void {\n        this.viewContainerRef.remove();\n        this.componentRef = null;\n    }\n}\n",
+            "selector": "[vcdComponentRendererOutlet]",
+            "providers": [],
+            "inputsClass": [
+                {
+                    "name": "vcdComponentRendererOutlet",
+                    "line": 51,
+                    "type": ""
+                }
+            ],
+            "outputsClass": [],
+            "hostBindings": [],
+            "hostListeners": [],
+            "propertiesClass": [
+                {
+                    "name": "componentRef",
+                    "type": "ComponentRef<ComponentRenderer<T>>",
+                    "optional": false,
+                    "description": "",
+                    "line": 45,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "componentType",
+                    "type": "ComponentRendererConstructor<T>",
+                    "optional": false,
+                    "description": "",
+                    "line": 46,
+                    "modifierKind": [
+                        112
+                    ]
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "assignValue",
+                    "args": [
+                        {
+                            "name": "config",
+                            "type": " | T"
+                        },
+                        {
+                            "name": "context",
+                            "type": "R"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 74,
+                    "description": "<p>Updates the configuration of instantiated component</p>\n",
+                    "modifierKind": [
+                        112
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "config",
+                            "type": " | T",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "context",
+                            "type": "R",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "attachRenderer",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "ComponentRef<ComponentRenderer<T>>",
+                    "typeParameters": [],
+                    "line": 63,
+                    "description": "<p>Attaches the passed component type to the view of this directive host</p>\n",
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "detachRenderer",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 81,
+                    "modifierKind": [
+                        112
+                    ]
+                }
+            ],
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "viewContainerRef",
+                        "type": "ViewContainerRef"
+                    },
+                    {
+                        "name": "cfr",
+                        "type": "ComponentFactoryResolver"
+                    }
+                ],
+                "line": 46,
+                "jsdoctags": [
+                    {
+                        "name": "viewContainerRef",
+                        "type": "ViewContainerRef",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    },
+                    {
+                        "name": "cfr",
+                        "type": "ComponentFactoryResolver",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "accessors": {
+                "vcdComponentRendererOutlet": {
+                    "name": "vcdComponentRendererOutlet",
+                    "setSignature": {
+                        "name": "vcdComponentRendererOutlet",
+                        "type": "void",
+                        "args": [
+                            {
+                                "name": "renderer",
+                                "type": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 51,
+                        "jsdoctags": [
+                            {
+                                "name": "renderer",
+                                "type": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "components": [
+        {
+            "name": "BoldTextRendererComponent",
+            "id": "component-BoldTextRendererComponent-ef925c06bd38d69b8ef18b74dacdb84a",
+            "file": "projects/components/src/datagrid/renderers/bold-text-renderer.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "styleUrls": [],
+            "styles": [],
+            "template": "<strong>{{ config.text }}</strong>\n",
+            "templateUrl": [],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "config",
+                    "line": 40,
+                    "type": "BoldTextRendererConfig"
+                }
+            ],
+            "outputsClass": [],
+            "propertiesClass": [],
+            "methodsClass": [],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "<p>A {@link ComponentRenderer} component that is used for rendering a bold text inside a column cell template</p>\n",
+            "rawdescription": "A {@link ComponentRenderer} component that is used for rendering a bold text inside a column cell template",
+            "type": "component",
+            "sourceCode": "import { Component, Input } from '@angular/core';\nimport { ComponentRenderer } from '../interfaces/component-renderer.interface';\n\n/**\n * {@link ComponentRenderer.config} type that the {@link BoldTextRendererComponent} can understand\n */\nexport interface BoldTextRendererConfig {\n    /**\n     * Text to be displayed in bold font\n     */\n    text: string;\n}\n\n/**\n * A {@link ComponentRenderer} component that is used for rendering a bold text inside a column cell template\n *\n * @example Example usage with RendererSpec:\n *     columns: GridColumn<MockRecord>[] = [\n *       {\n *         displayName: 'Component Renderer',\n *         renderer: RendererSpec(\n *           BoldTextRendererComponent,\n *           (record: MockRecord) => ({text: record.name})\n *         )\n *       }\n *     ];\n */\n@Component({\n    template: `\n        <strong>{{ config.text }}</strong>\n    `,\n})\nexport class BoldTextRendererComponent implements ComponentRenderer<BoldTextRendererConfig> {\n    @Input()\n    config: BoldTextRendererConfig;\n}\n",
+            "assetsDirs": [],
+            "styleUrlsData": "",
+            "stylesData": "",
+            "jsdoctags": [
+                {
+                    "pos": 559,
+                    "end": 568,
+                    "flags": 0,
+                    "kind": 288,
+                    "atToken": {
+                        "pos": 559,
+                        "end": 560,
+                        "flags": 0,
+                        "kind": 57
+                    },
+                    "tagName": {
+                        "pos": 560,
+                        "end": 567,
+                        "flags": 0,
+                        "escapedText": "example"
+                    },
+                    "comment": "Example usage with RendererSpec:\ncolumns: GridColumn<MockRecord>[] = [\n{\ndisplayName: 'Component Renderer',\nrenderer: RendererSpec(\n  BoldTextRendererComponent,\n  (record: MockRecord) => ({text: record.name})\n)\n}\n];"
+                }
+            ],
+            "implements": [
+                "ComponentRenderer"
+            ]
+        },
+        {
+            "name": "CliptextComponent",
+            "id": "component-CliptextComponent-f74ccec5c50416c5689ab9ec9a8c62a6",
+            "file": "projects/components/src/cliptext/cliptext.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "vcd-cliptext",
+            "styleUrls": [
+                "./cliptext.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./cliptext.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "inlineWidth",
+                    "description": "<p>Whether the tooltip should take up a block, or be inline within text</p>\n<p>If its value is falsy (default), it will be displayed as a block (take up the parent&#39;s width).\nOtherwise, it should be a CSS string to be used as its max-width;</p>\n",
+                    "line": 73,
+                    "type": "string"
+                },
+                {
+                    "name": "position",
+                    "description": "<p>Setting the position should be avoided as much as possible and considered ONLY in extremely corner case.\nSome of the reasons to avoid it are:</p>\n<ul>\n<li>Clarity will introduce smart positioning &#39;[NG] Smart Popover Component #2923&#39;</li>\n<li>Future versions may go with different implementation so position may become irrelevant</li>\n</ul>\n",
+                    "line": 43,
+                    "type": ""
+                }
+            ],
+            "outputsClass": [],
+            "propertiesClass": [
+                {
+                    "name": "_inline",
+                    "defaultValue": "false",
+                    "type": "InlineSpec",
+                    "optional": false,
+                    "description": "",
+                    "line": 77,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "_size",
+                    "defaultValue": "'md'",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 94,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "_tooltipPosition",
+                    "defaultValue": "'top-right'",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 100,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "_tooltipText",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 106,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "cliptextContainer",
+                    "type": "ElementRef",
+                    "optional": false,
+                    "description": "",
+                    "line": 109,
+                    "decorators": [
+                        {
+                            "name": "ViewChild",
+                            "stringifiedArguments": "'cliptextContainer', {static: true}"
+                        }
+                    ]
+                },
+                {
+                    "name": "clrIfOpen",
+                    "type": "ClrIfOpen",
+                    "optional": false,
+                    "description": "",
+                    "line": 112,
+                    "decorators": [
+                        {
+                            "name": "ViewChild",
+                            "stringifiedArguments": "ClrIfOpen, {static: true}"
+                        }
+                    ],
+                    "modifierKind": [
+                        112
+                    ]
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "isOverflowing",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "boolean",
+                    "typeParameters": [],
+                    "line": 140,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "ngAfterViewInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 136
+                }
+            ],
+            "hostBindings": [
+                {
+                    "name": "class.inline",
+                    "line": 79,
+                    "type": "boolean"
+                },
+                {
+                    "name": "style.maxWidth",
+                    "line": 83,
+                    "type": "string"
+                }
+            ],
+            "hostListeners": [],
+            "description": "<p>Use a cliptext component when you need to restrict a displayed text to a certain width but still provide to the user\nthe ability to see the full text if it is clipped along with a hint that clipping has taken place. Accessibility\nshould be taken into account.</p>\n<p>Example: a datagrid with a cell that contains text that cannot fit in one line. The solution is to wrap the content\non multiple lines or show as much text as it can fit in one line, showing ellipses (&#39;...&#39;) at the end to denote that\nthere is still more content and on hover over to display the full content.</p>\n<p>The current implementation is based on clarity tooltip component, where the tooltip is available only\nif clipping has occurred.</p>\n",
+            "rawdescription": "Use a cliptext component when you need to restrict a displayed text to a certain width but still provide to the user\nthe ability to see the full text if it is clipped along with a hint that clipping has taken place. Accessibility\nshould be taken into account.\n\nExample: a datagrid with a cell that contains text that cannot fit in one line. The solution is to wrap the content\non multiple lines or show as much text as it can fit in one line, showing ellipses ('...') at the end to denote that\nthere is still more content and on hover over to display the full content.\n\nThe current implementation is based on clarity tooltip component, where the tooltip is available only\nif clipping has occurred.",
+            "type": "component",
+            "sourceCode": "import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, HostBinding, Input, ViewChild } from '@angular/core';\nimport { ClrIfOpen, ClrTooltipContent } from '@clr/angular';\n\nexport enum Position {\n    TOP = 'TOP',\n    BOTTOM = 'BOTTOM',\n    BEFORE = 'BEFORE',\n    AFTER = 'AFTER',\n}\n\ntype InlineSpec = false | string;\n\n/**\n * Use a cliptext component when you need to restrict a displayed text to a certain width but still provide to the user\n * the ability to see the full text if it is clipped along with a hint that clipping has taken place. Accessibility\n * should be taken into account.\n *\n * Example: a datagrid with a cell that contains text that cannot fit in one line. The solution is to wrap the content\n * on multiple lines or show as much text as it can fit in one line, showing ellipses ('...') at the end to denote that\n * there is still more content and on hover over to display the full content.\n *\n * The current implementation is based on clarity tooltip component, where the tooltip is available only\n * if clipping has occurred.\n */\n@Component({\n    selector: 'vcd-cliptext',\n    templateUrl: './cliptext.component.html',\n    styleUrls: ['./cliptext.component.scss'],\n})\nexport class CliptextComponent implements AfterViewInit {\n    /**\n     * Setting the position should be avoided as much as possible and considered ONLY in extremely corner case.\n     * Some of the reasons to avoid it are:\n     *  - Clarity will introduce smart positioning '[NG] Smart Popover Component #2923'\n     *  - Future versions may go with different implementation so position may become irrelevant\n     */\n    @Input()\n    set position(position: Position) {\n        switch (position) {\n            // Since we use only LTR languages, the mapping is:\n            // BEFORE->left, AFTER->right, default->'top-right'\n            // If we introduce RTL languages the mapping should be:\n            // BEFORE->right, AFTER->left, default->'top-left'\n            case Position.TOP:\n                this._tooltipPosition = 'top-right';\n                break;\n            case Position.BOTTOM:\n                this._tooltipPosition = 'bottom-right';\n                break;\n            case Position.BEFORE:\n                this._tooltipPosition = 'left';\n                break;\n            case Position.AFTER:\n                this._tooltipPosition = 'right';\n                break;\n            default:\n                this._tooltipPosition = 'top-right';\n        }\n    }\n\n    /**\n     * Whether the tooltip should take up a block, or be inline within text\n     *\n     * If its value is falsy (default), it will be displayed as a block (take up the parent's width).\n     * Otherwise, it should be a CSS string to be used as its max-width;\n     */\n    @Input()\n    set inlineWidth(width: string) {\n        this._inline = width;\n    }\n\n    private _inline: InlineSpec = false;\n\n    @HostBinding('class.inline') get isInline(): boolean {\n        return !!this._inline;\n    }\n\n    @HostBinding('style.maxWidth') get maxWidth(): string {\n        return this._inline || '';\n    }\n\n    /**\n     * Same as Clarity tooltip sizes (xs, sm, md, lg) but currently only the default one (md) is used\n     */\n    get size(): string {\n        return this._size;\n    }\n\n    private _size = 'md';\n\n    get tooltipPosition(): string {\n        return this._tooltipPosition;\n    }\n\n    private _tooltipPosition = 'top-right';\n\n    get tooltipText(): string {\n        return this._tooltipText;\n    }\n\n    private _tooltipText: string;\n\n    @ViewChild('cliptextContainer', { static: true })\n    cliptextContainer: ElementRef;\n\n    @ViewChild(ClrIfOpen, { static: true })\n    private clrIfOpen: ClrIfOpen;\n\n    @ViewChild(ClrTooltipContent, { static: false })\n    set tooltipContent(tooltipContent: ClrTooltipContent) {\n        if (!tooltipContent) {\n            return;\n        }\n        if (!this.isOverflowing()) {\n            this.clrIfOpen.open = false;\n        } else {\n            // Check if the tooltip text has changed\n            const tooltipText = this.cliptextContainer.nativeElement.textContent;\n            if (this._tooltipText !== tooltipText) {\n                this._tooltipText = tooltipText;\n                // Re-trigger open so that clarity tooltip is positioned correctly\n                this.clrIfOpen.open = false;\n                this.clrIfOpen.open = true;\n                this.changeDetector.detectChanges();\n            }\n        }\n    }\n\n    constructor(private changeDetector: ChangeDetectorRef) {}\n\n    ngAfterViewInit(): void {\n        this._tooltipText = this.cliptextContainer.nativeElement.textContent;\n    }\n\n    private isOverflowing(): boolean {\n        return isTextOverflowing(this.cliptextContainer.nativeElement);\n\n        // Text overflows when the content element's width is less than its scrollWidth.\n        function isTextOverflowing(el: HTMLElement): boolean {\n            return Math.ceil(el.getBoundingClientRect().width) < el.scrollWidth;\n        }\n    }\n}\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": ":host(.inline) {\n    display: inline-block;\n    vertical-align: middle;\n}\n\nclr-tooltip {\n    display: block;\n\n    .text-truncate {\n        overflow: hidden;\n        text-overflow: ellipsis;\n        white-space: nowrap;\n    }\n}\n",
+                    "styleUrl": "./cliptext.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "changeDetector",
+                        "type": "ChangeDetectorRef"
+                    }
+                ],
+                "line": 132,
+                "jsdoctags": [
+                    {
+                        "name": "changeDetector",
+                        "type": "ChangeDetectorRef",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "AfterViewInit"
+            ],
+            "accessors": {
+                "position": {
+                    "name": "position",
+                    "setSignature": {
+                        "name": "position",
+                        "type": "void",
+                        "args": [
+                            {
+                                "name": "position",
+                                "type": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 43,
+                        "description": "<p>Setting the position should be avoided as much as possible and considered ONLY in extremely corner case.\nSome of the reasons to avoid it are:</p>\n<ul>\n<li>Clarity will introduce smart positioning &#39;[NG] Smart Popover Component #2923&#39;</li>\n<li>Future versions may go with different implementation so position may become irrelevant</li>\n</ul>\n",
+                        "jsdoctags": [
+                            {
+                                "name": "position",
+                                "type": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "inlineWidth": {
+                    "name": "inlineWidth",
+                    "setSignature": {
+                        "name": "inlineWidth",
+                        "type": "void",
+                        "args": [
+                            {
+                                "name": "width",
+                                "type": "string"
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 73,
+                        "description": "<p>Whether the tooltip should take up a block, or be inline within text</p>\n<p>If its value is falsy (default), it will be displayed as a block (take up the parent&#39;s width).\nOtherwise, it should be a CSS string to be used as its max-width;</p>\n",
+                        "jsdoctags": [
+                            {
+                                "name": "width",
+                                "type": "string",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "size": {
+                    "name": "size",
+                    "getSignature": {
+                        "name": "size",
+                        "type": "string",
+                        "returnType": "string",
+                        "line": 90,
+                        "description": "<p>Same as Clarity tooltip sizes (xs, sm, md, lg) but currently only the default one (md) is used</p>\n"
+                    }
+                },
+                "tooltipPosition": {
+                    "name": "tooltipPosition",
+                    "getSignature": {
+                        "name": "tooltipPosition",
+                        "type": "string",
+                        "returnType": "string",
+                        "line": 96
+                    }
+                },
+                "tooltipText": {
+                    "name": "tooltipText",
+                    "getSignature": {
+                        "name": "tooltipText",
+                        "type": "string",
+                        "returnType": "string",
+                        "line": 102
+                    }
+                },
+                "tooltipContent": {
+                    "name": "tooltipContent",
+                    "setSignature": {
+                        "name": "tooltipContent",
+                        "type": "void",
+                        "args": [
+                            {
+                                "name": "tooltipContent",
+                                "type": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 115,
+                        "jsdoctags": [
+                            {
+                                "name": "tooltipContent",
+                                "type": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "templateData": "<clr-tooltip>\n    <div #cliptextContainer clrTooltipTrigger class=\"cliptext-container text-truncate\" [ngClass]=\"{ inline: isInline }\">\n        <ng-content></ng-content>\n    </div>\n    <clr-tooltip-content aria-hidden=\"true\" *clrIfOpen [clrPosition]=\"tooltipPosition\" [clrSize]=\"size\">\n        <span>{{ tooltipText }}</span>\n    </clr-tooltip-content>\n</clr-tooltip>\n"
+        },
+        {
+            "name": "DataExporterComponent",
+            "id": "component-DataExporterComponent-5a56df2974458abac65ddf748a7d4d1e",
+            "file": "projects/components/src/data-exporter/data-exporter.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "vcd-data-exporter",
+            "styleUrls": [
+                "./data-exporter.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "data-exporter.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "columns",
+                    "defaultValue": "[]",
+                    "description": "<p>List of columns that can be exported, user may deselect some before sending the download request</p>\n",
+                    "line": 65,
+                    "type": "ExportColumn[]"
+                },
+                {
+                    "name": "dialogHeader",
+                    "defaultValue": "'Select Columns'",
+                    "description": "<p>Text for the Dialog Header</p>\n",
+                    "line": 75
+                },
+                {
+                    "name": "fileName",
+                    "defaultValue": "'data-export.csv'",
+                    "description": "<p>The name of the file to be downloaded</p>\n",
+                    "line": 70
+                },
+                {
+                    "name": "open",
+                    "description": "<p>Whether the dialog is open</p>\n",
+                    "line": 86,
+                    "type": "boolean"
+                },
+                {
+                    "name": "showSelectAll",
+                    "defaultValue": "true",
+                    "description": "<p>Whether a box to select/deselect all rows is available</p>\n",
+                    "line": 80
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "dataExportRequest",
+                    "defaultValue": "new EventEmitter<DataExportRequestEvent>()",
+                    "description": "<p>Called when the export is ready to be created</p>\n",
+                    "line": 104,
+                    "type": "EventEmitter"
+                },
+                {
+                    "name": "openChange",
+                    "defaultValue": "new EventEmitter<boolean>()",
+                    "description": "<p>Fires when {@link _open} changes. Its parameter indicates the new state.</p>\n",
+                    "line": 99,
+                    "type": "EventEmitter"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "_isRequestPending",
+                    "defaultValue": "false",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 113,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "_open",
+                    "defaultValue": "false",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 94,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "_progress",
+                    "defaultValue": "0",
+                    "type": "number",
+                    "optional": false,
+                    "description": "",
+                    "line": 121,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "formGroup",
+                    "type": "FormGroup",
+                    "optional": false,
+                    "description": "",
+                    "line": 123
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "exportData",
+                    "args": [
+                        {
+                            "name": "records",
+                            "type": "object[]"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 169,
+                    "modifierKind": [
+                        112
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "records",
+                            "type": "object[]",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "getDisplayNameForField",
+                    "args": [
+                        {
+                            "name": "fieldName",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "string",
+                    "typeParameters": [],
+                    "line": 191,
+                    "modifierKind": [
+                        112
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "fieldName",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 161
+                },
+                {
+                    "name": "onClickCheckAll",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 134
+                },
+                {
+                    "name": "onClickExport",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 125
+                },
+                {
+                    "name": "updateProgress",
+                    "args": [
+                        {
+                            "name": "progress",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 187,
+                    "modifierKind": [
+                        112
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "progress",
+                            "type": "number",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "<p>A dialog to export data</p>\n<ul>\n<li>Allows the UI to select columns to be exported</li>\n<li>Provides a progress indicator</li>\n<li>Converts the data that is fetched by the caller into a CSV</li>\n</ul>\n",
+            "rawdescription": "A dialog to export data\n\n  - Allows the UI to select columns to be exported\n  - Provides a progress indicator\n  - Converts the data that is fetched by the caller into a CSV",
+            "type": "component",
+            "sourceCode": "import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';\nimport { FormControl, FormGroup } from '@angular/forms';\nimport { CsvExporterService } from './csv-exporter.service';\n\n/**\n * Identifiers for each column that user is allowed to select\n */\nexport interface ExportColumn {\n    /**\n     * Displayed in the list of columns\n     */\n    displayName: string;\n    /**\n     * The name of the field in the JSON that is returned and converted to a viewable format\n     */\n    fieldName: string;\n}\n\n/**\n * Information passed to the caller so they can fetch the data\n */\nexport interface DataExportRequestEvent {\n    /**\n     * Call this to indicate a new value to be displayed in the progress indicator.\n     * @param progress A number from 0 to 1 indicating download progress. Passing -1 will make it an indeterminate\n     */\n    updateProgress: (progress: number) => void;\n\n    /**\n     * Call this when all records have been fetched to initiate the CSV creation.\n     * This should only be called once after all data fetching is finished\n     * @param records Records to be converted into a csv file\n     */\n    exportData: (records: object[]) => void;\n\n    /**\n     * Columns selected by the user.\n     */\n    selectedColumns: ExportColumn[];\n}\n\n/**\n * A dialog to export data\n *\n *  - Allows the UI to select columns to be exported\n *  - Provides a progress indicator\n *  - Converts the data that is fetched by the caller into a CSV\n */\n@Component({\n    selector: 'vcd-data-exporter',\n    templateUrl: 'data-exporter.component.html',\n    styleUrls: ['./data-exporter.component.scss'],\n})\nexport class DataExporterComponent implements OnInit {\n    constructor(private csvExporterService: CsvExporterService) {}\n\n    /**\n     * List of columns that can be exported, user may deselect some before sending the download request\n     */\n    @Input() columns: ExportColumn[] = [];\n\n    /**\n     * The name of the file to be downloaded\n     */\n    @Input() fileName = 'data-export.csv';\n\n    /**\n     * Text for the Dialog Header\n     */\n    @Input() dialogHeader = 'Select Columns';\n\n    /**\n     * Whether a box to select/deselect all rows is available\n     */\n    @Input() showSelectAll = true;\n\n    /**\n     * Whether the dialog is open\n     */\n    @Input()\n    set open(value: boolean) {\n        this._open = value;\n        this.openChange.emit(value);\n    }\n    get open(): boolean {\n        return this._open;\n    }\n\n    private _open = false;\n\n    /**\n     * Fires when {@link _open} changes. Its parameter indicates the new state.\n     */\n    @Output() openChange = new EventEmitter<boolean>();\n\n    /**\n     * Called when the export is ready to be created\n     */\n    @Output() dataExportRequest = new EventEmitter<DataExportRequestEvent>();\n\n    /**\n     * True between the time {@link dataExportRequest} fires and {@link DataExportRequestEvent.exportData} is called\n     * or an error is thrown\n     */\n    get isRequestPending(): boolean {\n        return this._isRequestPending;\n    }\n    private _isRequestPending = false;\n\n    /**\n     * Number between 0-1, used for displaying the progress bar.\n     */\n    get progress(): number {\n        return this._progress;\n    }\n    private _progress = 0;\n\n    formGroup: FormGroup;\n\n    onClickExport(): void {\n        this._isRequestPending = true;\n        this.dataExportRequest.emit({\n            exportData: this.exportData.bind(this),\n            updateProgress: this.updateProgress.bind(this),\n            selectedColumns: this.columns.filter(col => this.formGroup.controls[col.fieldName].value),\n        });\n    }\n\n    onClickCheckAll(): void {\n        for (const column of this.columns) {\n            this.formGroup.controls[column.fieldName].setValue(true);\n        }\n    }\n\n    get isSelectAllEnabled(): boolean {\n        for (const column of this.columns) {\n            if (!this.formGroup.controls[column.fieldName].value) {\n                return true;\n            }\n        }\n        return false;\n    }\n\n    get isExportEnabled(): boolean {\n        if (this.isRequestPending) {\n            return false;\n        }\n        for (const column of this.columns) {\n            if (this.formGroup.controls[column.fieldName].value) {\n                return true;\n            }\n        }\n        return false;\n    }\n\n    ngOnInit(): void {\n        const controls = this.columns.reduce((previousValue, currentValue) => {\n            previousValue[currentValue.fieldName] = new FormControl(true);\n            return previousValue;\n        }, {});\n        this.formGroup = new FormGroup(controls);\n    }\n\n    private exportData(records: object[]): void {\n        if (!this.open) {\n            return;\n        }\n        this.open = false;\n        this._isRequestPending = false;\n\n        const rows = [\n            // First row is the display names\n            Object.keys(records[0]).map(fieldName => this.getDisplayNameForField(fieldName)),\n            // Then the data\n            ...records.map(rec => Object.keys(rec).map(key => rec[key])),\n        ];\n\n        const csvFile = this.csvExporterService.createCsv(rows);\n        this.csvExporterService.downloadCsvFile(csvFile, this.fileName);\n    }\n\n    private updateProgress(progress: number): void {\n        this._progress = progress;\n    }\n\n    private getDisplayNameForField(fieldName: string): string {\n        for (const column of this.columns) {\n            if (column.fieldName === fieldName) {\n                return column.displayName;\n            }\n        }\n        return fieldName;\n    }\n}\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "div.progress {\n    visibility: hidden;\n\n    &.pending {\n        visibility: visible;\n    }\n}\nbutton.select-all {\n    margin: 0;\n    padding: 0;\n}\n",
+                    "styleUrl": "./data-exporter.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "csvExporterService",
+                        "type": "CsvExporterService"
+                    }
+                ],
+                "line": 59,
+                "jsdoctags": [
+                    {
+                        "name": "csvExporterService",
+                        "type": "CsvExporterService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "accessors": {
+                "open": {
+                    "name": "open",
+                    "setSignature": {
+                        "name": "open",
+                        "type": "void",
+                        "args": [
+                            {
+                                "name": "value",
+                                "type": "boolean"
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 86,
+                        "description": "<p>Whether the dialog is open</p>\n",
+                        "jsdoctags": [
+                            {
+                                "name": "value",
+                                "type": "boolean",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "open",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 90
+                    }
+                },
+                "isRequestPending": {
+                    "name": "isRequestPending",
+                    "getSignature": {
+                        "name": "isRequestPending",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 110,
+                        "description": "<p>True between the time {@link dataExportRequest} fires and {@link DataExportRequestEvent.exportData} is called\nor an error is thrown</p>\n"
+                    }
+                },
+                "progress": {
+                    "name": "progress",
+                    "getSignature": {
+                        "name": "progress",
+                        "type": "number",
+                        "returnType": "number",
+                        "line": 118,
+                        "description": "<p>Number between 0-1, used for displaying the progress bar.</p>\n"
+                    }
+                },
+                "isSelectAllEnabled": {
+                    "name": "isSelectAllEnabled",
+                    "getSignature": {
+                        "name": "isSelectAllEnabled",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 140
+                    }
+                },
+                "isExportEnabled": {
+                    "name": "isExportEnabled",
+                    "getSignature": {
+                        "name": "isExportEnabled",
+                        "type": "boolean",
+                        "returnType": "boolean",
+                        "line": 149
+                    }
+                }
+            },
+            "templateData": "<clr-modal [clrModalOpen]=\"open\" (clrModalOpenChange)=\"openChange.emit($event)\" [clrModalSize]=\"'sm'\" #modal>\n    <h3 class=\"modal-title\">{{ dialogHeader }}</h3>\n    <div class=\"modal-body\">\n        <button\n            *ngIf=\"showSelectAll\"\n            class=\"btn btn-sm btn-link select-all\"\n            type=\"button\"\n            (click)=\"onClickCheckAll()\"\n            [disabled]=\"!isSelectAllEnabled\"\n        >\n            Select All\n        </button>\n        <ul class=\"list-unstyled column-selection\" [formGroup]=\"formGroup\">\n            <li *ngFor=\"let col of columns\">\n                <clr-checkbox-wrapper>\n                    <input type=\"checkbox\" clrCheckbox [formControlName]=\"col.fieldName\" />\n                    <label>{{ col.displayName }}</label>\n                </clr-checkbox-wrapper>\n            </li>\n        </ul>\n        <div class=\"progress\" [ngClass]=\"{ loop: progress == -1, pending: isRequestPending }\">\n            <progress max=\"100\" value=\"{{ progress * 100 }}\"></progress>\n        </div>\n    </div>\n    <hr />\n\n    <div class=\"modal-footer\">\n        <button type=\"button\" class=\"btn btn-outline cancel\" (click)=\"open = false\">\n            Cancel\n        </button>\n        <button type=\"button\" class=\"btn btn-primary export\" [disabled]=\"!isExportEnabled\" (click)=\"onClickExport()\">\n            Export\n        </button>\n    </div>\n</clr-modal>\n"
+        },
+        {
+            "name": "DatagridComponent",
+            "id": "component-DatagridComponent-854c889708b9cf13ff0ebef598ca2faa",
+            "file": "projects/components/src/datagrid/datagrid.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "vcd-datagrid",
+            "styleUrls": [],
+            "styles": [],
+            "templateUrl": [
+                "./datagrid.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "clrDatagridCssClass",
+                    "defaultValue": "''",
+                    "description": "<p>The CSS class to use for the Clarity datagrid.</p>\n",
+                    "line": 128
+                },
+                {
+                    "name": "clrDatarowCssClassGetter",
+                    "description": "<p>Gives the CSS class to use for a given datarow based on its relative index and entity definition.</p>\n",
+                    "line": 221,
+                    "type": "string"
+                },
+                {
+                    "name": "columns",
+                    "description": "<p>Sets the configuration of columns on the grid and updates the {@link columnsConfig} array</p>\n",
+                    "line": 103,
+                    "type": "[]"
+                },
+                {
+                    "name": "gridData",
+                    "description": "<p>Set from the caller component using this grid. The input is set upon fetching data by the caller</p>\n",
+                    "line": 115,
+                    "type": ""
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "gridRefresh",
+                    "defaultValue": "new EventEmitter<GridState<R>>()",
+                    "description": "<p>Emitted during the initial rendering, and is emitted whenever filtering/sorting/paging params change\n{@link #GridState} is the type of value emitted</p>\n",
+                    "line": 214,
+                    "type": "EventEmitter<GridState<R>>"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "_columns",
+                    "type": "GridColumn<R>[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 110,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "buttons",
+                    "type": "literal type",
+                    "optional": false,
+                    "description": "<p>Buttons to display in the toolbar on top of data grid\nshowHide - Buttons that are not shown always (Eg: Delete button is hidden when there are no rows selected)\nenableDisable - Buttons that are always shown but disabled in certain conditions (Eg: Add/New button is always\nvisible but disabled when no rights)</p>\n<p>TODO: There might be one more property required to define how many buttons should be visible before overflowing.\n  This API is going to be refined as part of <a href=\"https://jira.eng.vmware.com/browse/VDUCC-21\">https://jira.eng.vmware.com/browse/VDUCC-21</a></p>\n",
+                    "line": 145
+                },
+                {
+                    "name": "columnsConfig",
+                    "type": "ColumnConfigInternal<R, unknown>[]",
+                    "optional": false,
+                    "description": "<p>Used for simplifying logic inside the HTML template to differentiate between different\n{@link GridColumn.renderer} types.</p>\n",
+                    "line": 202
+                },
+                {
+                    "name": "emptyGridPlaceholder",
+                    "type": "string",
+                    "optional": false,
+                    "description": "<p>When there is no data, show this message.</p>\n<p>TODO: Try to avoid showing this before initial load.</p>\n",
+                    "line": 155
+                },
+                {
+                    "name": "expandableRowTemplate",
+                    "type": "TemplateRef<R>",
+                    "optional": false,
+                    "description": "<p>Inline HTML that is passed with the record/rest item as context</p>\n<p>TODO: <a href=\"https://jira.eng.vmware.com/browse/VDUCC-18\">https://jira.eng.vmware.com/browse/VDUCC-18</a></p>\n",
+                    "line": 162
+                },
+                {
+                    "name": "GridColumnHideable",
+                    "defaultValue": "GridColumnHideable",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 97
+                },
+                {
+                    "name": "height",
+                    "type": "number",
+                    "optional": false,
+                    "description": "<p>Desired height of the grid</p>\n<p>TODO: Should we provide this option for setting the grid height and also for auto grow of the height of the grid.\n  Also investigate if we can set this through CSS instead of an input\n  The above to-do is going to be worked as part of <a href=\"https://jira.eng.vmware.com/browse/VDUCC-25\">https://jira.eng.vmware.com/browse/VDUCC-25</a></p>\n",
+                    "line": 191
+                },
+                {
+                    "name": "isLoading",
+                    "defaultValue": "false",
+                    "type": "",
+                    "optional": false,
+                    "description": "<p>Loading indicator on the grid</p>\n",
+                    "line": 196
+                },
+                {
+                    "name": "items",
+                    "type": "R[]",
+                    "optional": false,
+                    "description": "<p>List of items used for displaying rows on the grid</p>\n",
+                    "line": 207
+                },
+                {
+                    "name": "numericFilter",
+                    "type": "ClrDatagridFilter",
+                    "optional": false,
+                    "description": "",
+                    "line": 216,
+                    "decorators": [
+                        {
+                            "name": "ViewChild",
+                            "stringifiedArguments": "ClrDatagridFilter, {static: false}"
+                        }
+                    ]
+                },
+                {
+                    "name": "pagination",
+                    "type": "literal type",
+                    "optional": false,
+                    "description": "<p>TODO: Pagination requires some more research to be defined properly and is going to be defined as part of\n  <a href=\"https://jira.eng.vmware.com/browse/VDUCC-20\">https://jira.eng.vmware.com/browse/VDUCC-20</a></p>\n",
+                    "line": 168
+                },
+                {
+                    "name": "selectionChanged",
+                    "type": "EventEmitter<R[]>",
+                    "optional": false,
+                    "description": "<p>Fired whenever the selection changes. The event data is array of rows selected. The array will contain only one\nelement in case of single selection</p>\n",
+                    "line": 134
+                },
+                {
+                    "name": "selectionType",
+                    "type": "GridSelectionType.None",
+                    "optional": false,
+                    "description": "<p>Type of row selection on the grid</p>\n",
+                    "line": 123
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "getColumnsConfig",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 238,
+                    "description": "<p>Defines the {@property columnsConfig} by adding extra property required for differentiating different kinds\nof renderers which is required in the HTML template.</p>\n",
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "isColumnHideable",
+                    "args": [
+                        {
+                            "name": "column",
+                            "type": "GridColumn<R>"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "boolean",
+                    "typeParameters": [],
+                    "line": 230,
+                    "jsdoctags": [
+                        {
+                            "name": "column",
+                            "type": "GridColumn<R>",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 225
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "<p>Component used for saving the time required for developing a data grid. It takes different properties required for\nrendering as Inputs and Outputs.</p>\n<p>Example usage in a component:\nIn the component view, different properties required for the grid are wired as Inputs and Outputs.\n&lt;vcd-datagrid\n    (onGridRefresh)=&quot;fetchData()&quot;\n    [columns]=&quot;columns&quot;\n    [gridData]=&quot;gridData&quot;&gt;\n  </vcd-datagrid></p>\n",
+            "rawdescription": "Component used for saving the time required for developing a data grid. It takes different properties required for\nrendering as Inputs and Outputs.\n\nExample usage in a component:\nIn the component view, different properties required for the grid are wired as Inputs and Outputs.\n<vcd-datagrid\n    (onGridRefresh)=\"fetchData()\"\n    [columns]=\"columns\"\n    [gridData]=\"gridData\">\n  </vcd-datagrid>",
+            "type": "component",
+            "sourceCode": "import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';\nimport { FunctionRenderer, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';\nimport { ClrDatagridFilter } from '@clr/angular';\nimport { ComponentRendererSpec } from './interfaces/component-renderer.interface';\n\n/**\n * Different types of row selection on the grid\n */\nexport enum GridSelectionType {\n    /**\n     * For selecting multiple rows\n     */\n    Multi = 'MULTI',\n    /**\n     * For selecting only one row at a time\n     */\n    Single = 'SINGLE',\n    /**\n     * Disables the selection\n     */\n    None = 'NONE',\n}\n\n/**\n * TODO: This API is going to have more properties and is going to be defined as part of\n *  https://jira.eng.vmware.com/browse/VDUCC-21\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface Button {}\n\n/**\n * Representation of data required for rendering contents of cells and pagination information\n */\nexport interface GridDataFetchResult<R> {\n    /**\n     * Items to be listed in the grid\n     */\n    items: R[];\n    /**\n     * Total number of items\n     */\n    totalItems?: number;\n    /**\n     * Number of the page being indexed\n     */\n    page?: number;\n    /**\n     * Size of a page\n     */\n    pageSize?: number;\n}\n\n/**\n * The current state of various features of the grid like filtering, sorting, pagination. This object is emitted as\n * part of the event {@link DatagridComponent.gridRefresh}. The handler then used this object to construct a query.\n * TODO: This interface is going to defined as part of working on the following tasks:\n *  https://jira.eng.vmware.com/browse/VDUCC-14\n *  https://jira.eng.vmware.com/browse/VDUCC-15\n *  https://jira.eng.vmware.com/browse/VDUCC-20\n */\n// tslint:disable-next-line:no-empty-interface\nexport interface GridState<R> {}\n\n/**\n * For simplifying logic inside the HTML template to differentiate between different {@link GridColumn.renderer}\n * types.\n */\ninterface ColumnConfigInternal<R, T> extends GridColumn<R> {\n    fieldName?: string;\n    fieldRenderer?: FunctionRenderer<R>;\n    fieldColumnRendererSpec?: ComponentRendererSpec<R, T>;\n}\n\n/**\n * Component used for saving the time required for developing a data grid. It takes different properties required for\n * rendering as Inputs and Outputs.\n *\n * Example usage in a component:\n * In the component view, different properties required for the grid are wired as Inputs and Outputs.\n * <vcd-datagrid\n *    (onGridRefresh)=\"fetchData()\"\n *    [columns]=\"columns\"\n *    [gridData]=\"gridData\">\n *  </vcd-datagrid>\n *\n */\n@Component({\n    selector: 'vcd-datagrid',\n    templateUrl: './datagrid.component.html',\n})\nexport class DatagridComponent<R> implements OnInit {\n    GridColumnHideable = GridColumnHideable;\n\n    /**\n     * Sets the configuration of columns on the grid and updates the {@link columnsConfig} array\n     */\n    @Input()\n    set columns(cols: GridColumn<R>[]) {\n        this._columns = cols;\n        this.getColumnsConfig();\n    }\n    get columns(): GridColumn<R>[] {\n        return this._columns;\n    }\n    private _columns: GridColumn<R>[];\n\n    /**\n     * Set from the caller component using this grid. The input is set upon fetching data by the caller\n     */\n    @Input() set gridData(result: GridDataFetchResult<R>) {\n        this.isLoading = false;\n        this.items = result.items;\n    }\n\n    /**\n     * Type of row selection on the grid\n     */\n    selectionType: GridSelectionType.None;\n\n    /**\n     * The CSS class to use for the Clarity datagrid.\n     */\n    @Input() clrDatagridCssClass = '';\n\n    /**\n     * Fired whenever the selection changes. The event data is array of rows selected. The array will contain only one\n     * element in case of single selection\n     */\n    selectionChanged: EventEmitter<R[]>;\n\n    /**\n     * Buttons to display in the toolbar on top of data grid\n     * showHide - Buttons that are not shown always (Eg: Delete button is hidden when there are no rows selected)\n     * enableDisable - Buttons that are always shown but disabled in certain conditions (Eg: Add/New button is always\n     * visible but disabled when no rights)\n     *\n     * TODO: There might be one more property required to define how many buttons should be visible before overflowing.\n     *  This API is going to be refined as part of https://jira.eng.vmware.com/browse/VDUCC-21\n     */\n    buttons: {\n        showHide: Button[];\n        enableDisable: Button[];\n    };\n\n    /**\n     * When there is no data, show this message.\n     *\n     * TODO: Try to avoid showing this before initial load.\n     */\n    emptyGridPlaceholder: string;\n\n    /**\n     * Inline HTML that is passed with the record/rest item as context\n     *\n     * TODO: https://jira.eng.vmware.com/browse/VDUCC-18\n     */\n    expandableRowTemplate: TemplateRef<R>;\n\n    /**\n     * TODO: Pagination requires some more research to be defined properly and is going to be defined as part of\n     *  https://jira.eng.vmware.com/browse/VDUCC-20\n     */\n    pagination: {\n        paginationKey: string;\n        /**\n         * Available page size options in the dropdown\n         */\n        pageSizeOptions: number[];\n\n        /**\n         * Number of items to be displayed on one page. As a result, the server will return a set of pages with the defined\n         * number of items per page(They can be smaller than the number here in case of last page, filtering etc.,)\n         *\n         * Magic: Auto calculates the size based on available height of the container\n         */\n        pageSize: number | 'Magic';\n    };\n\n    /**\n     * Desired height of the grid\n     *\n     * TODO: Should we provide this option for setting the grid height and also for auto grow of the height of the grid.\n     *  Also investigate if we can set this through CSS instead of an input\n     *  The above to-do is going to be worked as part of https://jira.eng.vmware.com/browse/VDUCC-25\n     */\n    height: number;\n\n    /**\n     * Loading indicator on the grid\n     */\n    isLoading = false;\n\n    /**\n     * Used for simplifying logic inside the HTML template to differentiate between different\n     * {@link GridColumn.renderer} types.\n     */\n    columnsConfig: ColumnConfigInternal<R, unknown>[];\n\n    /**\n     * List of items used for displaying rows on the grid\n     */\n    items: R[];\n\n    /**\n     * Emitted during the initial rendering, and is emitted whenever filtering/sorting/paging params change\n     * {@link #GridState} is the type of value emitted\n     */\n    @Output()\n    gridRefresh: EventEmitter<GridState<R>> = new EventEmitter<GridState<R>>();\n\n    @ViewChild(ClrDatagridFilter, { static: false }) numericFilter: ClrDatagridFilter;\n\n    /**\n     * Gives the CSS class to use for a given datarow based on its relative index and entity definition.\n     */\n    @Input() clrDatarowCssClassGetter(row: R, index: number): string {\n        return '';\n    }\n\n    ngOnInit(): void {\n        this.isLoading = true;\n        this.gridRefresh.emit({});\n    }\n\n    isColumnHideable(column: GridColumn<R>): boolean {\n        return column && column.hideable && column.hideable !== GridColumnHideable.Never;\n    }\n\n    /**\n     * Defines the {@property columnsConfig} by adding extra property required for differentiating different kinds\n     * of renderers which is required in the HTML template.\n     */\n    private getColumnsConfig(): void {\n        this.columnsConfig = this.columns.map(column => {\n            const columnConfig: ColumnConfigInternal<R, unknown> = {\n                ...column,\n            };\n\n            if (column.renderer instanceof Function) {\n                columnConfig.fieldRenderer = column.renderer as FunctionRenderer<R>;\n            } else if ((column.renderer as ComponentRendererSpec<R, unknown>).config) {\n                columnConfig.fieldColumnRendererSpec = column.renderer as ComponentRendererSpec<R, unknown>;\n            } else {\n                columnConfig.fieldName = column.renderer as string;\n            }\n\n            return columnConfig;\n        });\n    }\n}\n",
+            "assetsDirs": [],
+            "styleUrlsData": "",
+            "stylesData": "",
+            "implements": [
+                "OnInit"
+            ],
+            "accessors": {
+                "columns": {
+                    "name": "columns",
+                    "setSignature": {
+                        "name": "columns",
+                        "type": "void",
+                        "args": [
+                            {
+                                "name": "cols",
+                                "type": "[]"
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 103,
+                        "description": "<p>Sets the configuration of columns on the grid and updates the {@link columnsConfig} array</p>\n",
+                        "jsdoctags": [
+                            {
+                                "name": "cols",
+                                "type": "[]",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "columns",
+                        "type": "[]",
+                        "returnType": "GridColumn[]",
+                        "line": 107
+                    }
+                },
+                "gridData": {
+                    "name": "gridData",
+                    "setSignature": {
+                        "name": "gridData",
+                        "type": "void",
+                        "args": [
+                            {
+                                "name": "result",
+                                "type": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 115,
+                        "description": "<p>Set from the caller component using this grid. The input is set upon fetching data by the caller</p>\n",
+                        "jsdoctags": [
+                            {
+                                "name": "result",
+                                "type": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "templateData": "<clr-datagrid [clrDgLoading]=\"isLoading\" [ngClass]=\"this.clrDatagridCssClass\">\n    <clr-dg-column *ngFor=\"let column of columnsConfig\">\n        <ng-container *ngIf=\"isColumnHideable(column); else notHideable\">\n            <ng-container *clrDgHideableColumn=\"{ hidden: column.hideable === GridColumnHideable.Hidden }\">{{\n                column.displayName\n            }}</ng-container>\n        </ng-container>\n        <ng-template #notHideable>{{ column.displayName }}</ng-template>\n    </clr-dg-column>\n\n    <clr-dg-row *ngFor=\"let restItem of items; let i = index\" [ngClass]=\"this.clrDatarowCssClassGetter(restItem, i)\">\n        <clr-dg-cell *ngFor=\"let column of columnsConfig\">\n            <!-- Default renderer -->\n            <ng-container *ngIf=\"column.fieldName\">{{ restItem | nestedProperty: column.fieldName }}</ng-container>\n\n            <!-- Renderer is a function -->\n            <ng-container *ngIf=\"column.fieldRenderer\">{{\n                restItem | functionRenderer: column.fieldRenderer\n            }}</ng-container>\n\n            <!-- Renderer is a componentRenderer -->\n            <ng-template\n                *ngIf=\"column.fieldColumnRendererSpec\"\n                [vcdComponentRendererOutlet]=\"{ rendererSpec: column.fieldColumnRendererSpec, context: restItem }\"\n            >\n            </ng-template>\n        </clr-dg-cell>\n    </clr-dg-row>\n\n    <clr-dg-footer> </clr-dg-footer>\n</clr-datagrid>\n"
+        }
+    ],
+    "modules": [
+        {
+            "name": "CliptextModule",
+            "children": [
+                {
+                    "type": "providers",
+                    "elements": []
+                },
+                {
+                    "type": "declarations",
+                    "elements": [
+                        {
+                            "name": "CliptextComponent"
+                        }
+                    ]
+                },
+                {
+                    "type": "imports",
+                    "elements": []
+                },
+                {
+                    "type": "exports",
+                    "elements": [
+                        {
+                            "name": "CliptextComponent"
+                        }
+                    ]
+                },
+                {
+                    "type": "bootstrap",
+                    "elements": []
+                },
+                {
+                    "type": "classes",
+                    "elements": []
+                }
+            ]
+        },
+        {
+            "name": "ComponentsModule",
+            "children": [
+                {
+                    "type": "providers",
+                    "elements": []
+                },
+                {
+                    "type": "declarations",
+                    "elements": []
+                },
+                {
+                    "type": "imports",
+                    "elements": [
+                        {
+                            "name": "CliptextModule"
+                        },
+                        {
+                            "name": "DataExporterModule"
+                        },
+                        {
+                            "name": "DatagridModule"
+                        }
+                    ]
+                },
+                {
+                    "type": "exports",
+                    "elements": [
+                        {
+                            "name": "CliptextModule"
+                        },
+                        {
+                            "name": "DataExporterModule"
+                        },
+                        {
+                            "name": "DatagridModule"
+                        }
+                    ]
+                },
+                {
+                    "type": "bootstrap",
+                    "elements": []
+                },
+                {
+                    "type": "classes",
+                    "elements": []
+                }
+            ]
+        },
+        {
+            "name": "DataExporterModule",
+            "children": [
+                {
+                    "type": "providers",
+                    "elements": []
+                },
+                {
+                    "type": "declarations",
+                    "elements": [
+                        {
+                            "name": "DataExporterComponent"
+                        }
+                    ]
+                },
+                {
+                    "type": "imports",
+                    "elements": []
+                },
+                {
+                    "type": "exports",
+                    "elements": [
+                        {
+                            "name": "DataExporterComponent"
+                        }
+                    ]
+                },
+                {
+                    "type": "bootstrap",
+                    "elements": []
+                },
+                {
+                    "type": "classes",
+                    "elements": []
+                }
+            ]
+        },
+        {
+            "name": "DatagridModule",
+            "children": [
+                {
+                    "type": "providers",
+                    "elements": []
+                },
+                {
+                    "type": "declarations",
+                    "elements": [
+                        {
+                            "name": "BoldTextRendererComponent"
+                        },
+                        {
+                            "name": "ComponentRendererOutletDirective"
+                        },
+                        {
+                            "name": "DatagridComponent"
+                        },
+                        {
+                            "name": "FunctionRendererPipe"
+                        }
+                    ]
+                },
+                {
+                    "type": "imports",
+                    "elements": []
+                },
+                {
+                    "type": "exports",
+                    "elements": [
+                        {
+                            "name": "BoldTextRendererComponent"
+                        },
+                        {
+                            "name": "DatagridComponent"
+                        }
+                    ]
+                },
+                {
+                    "type": "bootstrap",
+                    "elements": []
+                },
+                {
+                    "type": "classes",
+                    "elements": []
+                }
+            ]
+        },
+        {
+            "name": "PipesModule",
+            "children": [
+                {
+                    "type": "providers",
+                    "elements": []
+                },
+                {
+                    "type": "declarations",
+                    "elements": [
+                        {
+                            "name": "NestedPropertyPipe"
+                        }
+                    ]
+                },
+                {
+                    "type": "imports",
+                    "elements": []
+                },
+                {
+                    "type": "exports",
+                    "elements": [
+                        {
+                            "name": "NestedPropertyPipe"
+                        }
+                    ]
+                },
+                {
+                    "type": "bootstrap",
+                    "elements": []
+                },
+                {
+                    "type": "classes",
+                    "elements": []
+                }
+            ]
+        }
+    ],
+    "miscellaneous": {
+        "variables": [
+            {
+                "name": "CELL_TAG",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "string",
+                "defaultValue": "'clr-dg-cell'"
+            },
+            {
+                "name": "COLUMN_CSS_SELECTOR",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "string",
+                "defaultValue": "'.datagrid-column-title'"
+            },
+            {
+                "name": "COLUMN_SELECTOR",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "string",
+                "defaultValue": "'clr-dg-column'"
+            },
+            {
+                "name": "Css",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/data-exporter/data-exporter.wo.ts",
+                "type": "object",
+                "defaultValue": "{\n    SelectAll: '.select-all',\n    SelectColumn: '.column-selection label',\n}"
+            },
+            {
+                "name": "DATE_OBJECT_CLASS",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                "type": "string",
+                "defaultValue": "'[object Date]'"
+            },
+            {
+                "name": "declarations",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/common/pipes/pipes.module.ts",
+                "type": "[]",
+                "defaultValue": "[NestedPropertyPipe]"
+            },
+            {
+                "name": "directives",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/datagrid/datagrid.module.ts",
+                "type": "[]",
+                "defaultValue": "[DatagridComponent, ComponentRendererOutletDirective]"
+            },
+            {
+                "name": "OBJECT_PROPERTY_SEPARATOR",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                "type": "string",
+                "defaultValue": "'.'"
+            },
+            {
+                "name": "pipes",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/datagrid/datagrid.module.ts",
+                "type": "[]",
+                "defaultValue": "[FunctionRendererPipe]"
+            },
+            {
+                "name": "renderers",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/datagrid/datagrid.module.ts",
+                "type": "[]",
+                "defaultValue": "[BoldTextRendererComponent]"
+            },
+            {
+                "name": "ROW_TAG",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "string",
+                "defaultValue": "'clr-dg-row'"
+            }
+        ],
+        "functions": [
+            {
+                "name": "encodeValue",
+                "file": "projects/components/src/data-exporter/csv-exporter.service.ts",
+                "ctype": "miscellaneous",
+                "subtype": "function",
+                "description": "<p>Returns a cell&#39;s cellValue encoded against spaces, quotes, and CSV injection character</p>\n",
+                "args": [
+                    {
+                        "name": "cellValue"
+                    }
+                ],
+                "returnType": "string",
+                "jsdoctags": [
+                    {
+                        "name": {
+                            "pos": 1756,
+                            "end": 1765,
+                            "flags": 0,
+                            "escapedText": "cellValue"
+                        },
+                        "tagName": {
+                            "pos": 1750,
+                            "end": 1755,
+                            "flags": 0,
+                            "escapedText": "param"
+                        },
+                        "comment": "<p>Cell cellValue to be encoded</p>\n"
+                    }
+                ]
+            },
+            {
+                "name": "isFindParamsObject",
+                "file": "projects/components/src/utils/test/widget-object.ts",
+                "ctype": "miscellaneous",
+                "subtype": "function",
+                "description": "",
+                "args": [
+                    {
+                        "name": "params"
+                    }
+                ],
+                "returnType": "FindParams<T>",
+                "jsdoctags": [
+                    {
+                        "name": "params",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "isNullOrUndefined",
+                "file": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                "ctype": "miscellaneous",
+                "subtype": "function",
+                "description": "<p>Utility method for covering the &#39;null&#39; and &#39;undefined&#39; checks as &#39;value == null&#39; is equivalent to &#39;value === null || value === undefined&#39;</p>\n",
+                "args": [
+                    {
+                        "name": "value"
+                    }
+                ],
+                "returnType": "boolean",
+                "jsdoctags": [
+                    {
+                        "name": "value",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "processRow",
+                "file": "projects/components/src/data-exporter/csv-exporter.service.ts",
+                "ctype": "miscellaneous",
+                "subtype": "function",
+                "description": "<p>Returns a string</p>\n",
+                "args": [
+                    {
+                        "name": "row"
+                    }
+                ],
+                "returnType": "string",
+                "jsdoctags": [
+                    {
+                        "name": {
+                            "pos": 1470,
+                            "end": 1473,
+                            "flags": 0,
+                            "escapedText": "row"
+                        },
+                        "tagName": {
+                            "pos": 1464,
+                            "end": 1469,
+                            "flags": 0,
+                            "escapedText": "param"
+                        },
+                        "comment": "<p>A list of cells to be turned into a CSV string, separated by commas</p>\n"
+                    }
+                ]
+            },
+            {
+                "name": "RendererSpec",
+                "file": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+                "ctype": "miscellaneous",
+                "subtype": "function",
+                "description": "<p>Utility function to enforce type safety on output of the config function. The output is used as value context\ninside ComponentRenderer&#39;s template</p>\n<p>Example usage:\nconst gridColumn = {\n   renderer: RendererSpec&lt;SomeRecord, IconRendererConfiguration&gt;(IconComponentRendererCtor, (r: SomeRecord) =&gt; v)\n}</p>\n<p>In the above example, this method helps in making sure that the value &quot;v&quot; returned by the config function is of\nIconRendererConfiguration type</p>\n",
+                "args": [
+                    {
+                        "name": "componentRendererSpec"
+                    }
+                ],
+                "returnType": "ComponentRendererSpec<R, C>",
+                "jsdoctags": [
+                    {
+                        "name": "componentRendererSpec",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "WithGridBoldRenderer",
+                "file": "projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts",
+                "ctype": "miscellaneous",
+                "subtype": "function",
+                "description": "<p>Mixin that allows {@link ClrDatagridWidgetObject} to read information from {@link BoldTextRendererComponent}</p>\n",
+                "args": [
+                    {
+                        "name": "Base"
+                    }
+                ],
+                "jsdoctags": [
+                    {
+                        "name": "Base",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            }
+        ],
+        "typealiases": [
+            {
+                "name": "ComponentRendererConstructor",
+                "ctype": "miscellaneous",
+                "subtype": "typealias",
+                "rawtype": "Type<ComponentRenderer<V>>",
+                "file": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+                "description": "<p>Used for the type safety of {@link ComponentRendererSpec#type}</p>\n",
+                "kind": 161
+            },
+            {
+                "name": "FunctionRenderer",
+                "ctype": "miscellaneous",
+                "subtype": "typealias",
+                "rawtype": "function",
+                "file": "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts",
+                "description": "<p>Column renderer as a function. Defined in calling component when the cell value is calculated from different\nproperties.</p>\n",
+                "kind": 162
+            },
+            {
+                "name": "InlineSpec",
+                "ctype": "miscellaneous",
+                "subtype": "typealias",
+                "rawtype": "\"undefined\" | string",
+                "file": "projects/components/src/cliptext/cliptext.component.ts",
+                "description": "",
+                "kind": 168
+            }
+        ],
+        "enumerations": [
+            {
+                "name": "GridColumnHideable",
+                "childs": [
+                    {
+                        "name": "Never",
+                        "value": "NEVER"
+                    },
+                    {
+                        "name": "Shown",
+                        "value": "SHOWN"
+                    },
+                    {
+                        "name": "Hidden",
+                        "value": "HIDDEN"
+                    }
+                ],
+                "ctype": "miscellaneous",
+                "subtype": "enum",
+                "description": "",
+                "file": "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts"
+            },
+            {
+                "name": "GridColumnSortDirection",
+                "childs": [
+                    {
+                        "name": "Asc",
+                        "value": "ASCENDING"
+                    },
+                    {
+                        "name": "Desc",
+                        "value": "DESCENDING"
+                    },
+                    {
+                        "name": "None",
+                        "value": "NONE"
+                    }
+                ],
+                "ctype": "miscellaneous",
+                "subtype": "enum",
+                "description": "<p>The sorting direction of the column values</p>\n",
+                "file": "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts"
+            },
+            {
+                "name": "GridSelectionType",
+                "childs": [
+                    {
+                        "name": "Multi",
+                        "value": "MULTI"
+                    },
+                    {
+                        "name": "Single",
+                        "value": "SINGLE"
+                    },
+                    {
+                        "name": "None",
+                        "value": "NONE"
+                    }
+                ],
+                "ctype": "miscellaneous",
+                "subtype": "enum",
+                "description": "<p>Different types of row selection on the grid</p>\n",
+                "file": "projects/components/src/datagrid/datagrid.component.ts"
+            },
+            {
+                "name": "Position",
+                "childs": [
+                    {
+                        "name": "TOP",
+                        "value": "TOP"
+                    },
+                    {
+                        "name": "BOTTOM",
+                        "value": "BOTTOM"
+                    },
+                    {
+                        "name": "BEFORE",
+                        "value": "BEFORE"
+                    },
+                    {
+                        "name": "AFTER",
+                        "value": "AFTER"
+                    }
+                ],
+                "ctype": "miscellaneous",
+                "subtype": "enum",
+                "description": "",
+                "file": "projects/components/src/cliptext/cliptext.component.ts"
+            }
+        ],
+        "groupedVariables": {
+            "projects/components/src/utils/test/datagrid/datagrid.wo.ts": [
+                {
+                    "name": "CELL_TAG",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                    "type": "string",
+                    "defaultValue": "'clr-dg-cell'"
+                },
+                {
+                    "name": "COLUMN_CSS_SELECTOR",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                    "type": "string",
+                    "defaultValue": "'.datagrid-column-title'"
+                },
+                {
+                    "name": "COLUMN_SELECTOR",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                    "type": "string",
+                    "defaultValue": "'clr-dg-column'"
+                },
+                {
+                    "name": "ROW_TAG",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                    "type": "string",
+                    "defaultValue": "'clr-dg-row'"
+                }
+            ],
+            "projects/components/src/data-exporter/data-exporter.wo.ts": [
+                {
+                    "name": "Css",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/data-exporter/data-exporter.wo.ts",
+                    "type": "object",
+                    "defaultValue": "{\n    SelectAll: '.select-all',\n    SelectColumn: '.column-selection label',\n}"
+                }
+            ],
+            "projects/components/src/common/pipes/nested-property.pipe.ts": [
+                {
+                    "name": "DATE_OBJECT_CLASS",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                    "type": "string",
+                    "defaultValue": "'[object Date]'"
+                },
+                {
+                    "name": "OBJECT_PROPERTY_SEPARATOR",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                    "type": "string",
+                    "defaultValue": "'.'"
+                }
+            ],
+            "projects/components/src/common/pipes/pipes.module.ts": [
+                {
+                    "name": "declarations",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/common/pipes/pipes.module.ts",
+                    "type": "[]",
+                    "defaultValue": "[NestedPropertyPipe]"
+                }
+            ],
+            "projects/components/src/datagrid/datagrid.module.ts": [
+                {
+                    "name": "directives",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/datagrid/datagrid.module.ts",
+                    "type": "[]",
+                    "defaultValue": "[DatagridComponent, ComponentRendererOutletDirective]"
+                },
+                {
+                    "name": "pipes",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/datagrid/datagrid.module.ts",
+                    "type": "[]",
+                    "defaultValue": "[FunctionRendererPipe]"
+                },
+                {
+                    "name": "renderers",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "projects/components/src/datagrid/datagrid.module.ts",
+                    "type": "[]",
+                    "defaultValue": "[BoldTextRendererComponent]"
+                }
+            ]
+        },
+        "groupedFunctions": {
+            "projects/components/src/data-exporter/csv-exporter.service.ts": [
+                {
+                    "name": "encodeValue",
+                    "file": "projects/components/src/data-exporter/csv-exporter.service.ts",
+                    "ctype": "miscellaneous",
+                    "subtype": "function",
+                    "description": "<p>Returns a cell&#39;s cellValue encoded against spaces, quotes, and CSV injection character</p>\n",
+                    "args": [
+                        {
+                            "name": "cellValue"
+                        }
+                    ],
+                    "returnType": "string",
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 1756,
+                                "end": 1765,
+                                "flags": 0,
+                                "escapedText": "cellValue"
+                            },
+                            "tagName": {
+                                "pos": 1750,
+                                "end": 1755,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>Cell cellValue to be encoded</p>\n"
+                        }
+                    ]
+                },
+                {
+                    "name": "processRow",
+                    "file": "projects/components/src/data-exporter/csv-exporter.service.ts",
+                    "ctype": "miscellaneous",
+                    "subtype": "function",
+                    "description": "<p>Returns a string</p>\n",
+                    "args": [
+                        {
+                            "name": "row"
+                        }
+                    ],
+                    "returnType": "string",
+                    "jsdoctags": [
+                        {
+                            "name": {
+                                "pos": 1470,
+                                "end": 1473,
+                                "flags": 0,
+                                "escapedText": "row"
+                            },
+                            "tagName": {
+                                "pos": 1464,
+                                "end": 1469,
+                                "flags": 0,
+                                "escapedText": "param"
+                            },
+                            "comment": "<p>A list of cells to be turned into a CSV string, separated by commas</p>\n"
+                        }
+                    ]
+                }
+            ],
+            "projects/components/src/utils/test/widget-object.ts": [
+                {
+                    "name": "isFindParamsObject",
+                    "file": "projects/components/src/utils/test/widget-object.ts",
+                    "ctype": "miscellaneous",
+                    "subtype": "function",
+                    "description": "",
+                    "args": [
+                        {
+                            "name": "params"
+                        }
+                    ],
+                    "returnType": "FindParams<T>",
+                    "jsdoctags": [
+                        {
+                            "name": "params",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "projects/components/src/common/pipes/nested-property.pipe.ts": [
+                {
+                    "name": "isNullOrUndefined",
+                    "file": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                    "ctype": "miscellaneous",
+                    "subtype": "function",
+                    "description": "<p>Utility method for covering the &#39;null&#39; and &#39;undefined&#39; checks as &#39;value == null&#39; is equivalent to &#39;value === null || value === undefined&#39;</p>\n",
+                    "args": [
+                        {
+                            "name": "value"
+                        }
+                    ],
+                    "returnType": "boolean",
+                    "jsdoctags": [
+                        {
+                            "name": "value",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "projects/components/src/datagrid/interfaces/component-renderer.interface.ts": [
+                {
+                    "name": "RendererSpec",
+                    "file": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+                    "ctype": "miscellaneous",
+                    "subtype": "function",
+                    "description": "<p>Utility function to enforce type safety on output of the config function. The output is used as value context\ninside ComponentRenderer&#39;s template</p>\n<p>Example usage:\nconst gridColumn = {\n   renderer: RendererSpec&lt;SomeRecord, IconRendererConfiguration&gt;(IconComponentRendererCtor, (r: SomeRecord) =&gt; v)\n}</p>\n<p>In the above example, this method helps in making sure that the value &quot;v&quot; returned by the config function is of\nIconRendererConfiguration type</p>\n",
+                    "args": [
+                        {
+                            "name": "componentRendererSpec"
+                        }
+                    ],
+                    "returnType": "ComponentRendererSpec<R, C>",
+                    "jsdoctags": [
+                        {
+                            "name": "componentRendererSpec",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts": [
+                {
+                    "name": "WithGridBoldRenderer",
+                    "file": "projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts",
+                    "ctype": "miscellaneous",
+                    "subtype": "function",
+                    "description": "<p>Mixin that allows {@link ClrDatagridWidgetObject} to read information from {@link BoldTextRendererComponent}</p>\n",
+                    "args": [
+                        {
+                            "name": "Base"
+                        }
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "Base",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "groupedEnumerations": {
+            "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts": [
+                {
+                    "name": "GridColumnHideable",
+                    "childs": [
+                        {
+                            "name": "Never",
+                            "value": "NEVER"
+                        },
+                        {
+                            "name": "Shown",
+                            "value": "SHOWN"
+                        },
+                        {
+                            "name": "Hidden",
+                            "value": "HIDDEN"
+                        }
+                    ],
+                    "ctype": "miscellaneous",
+                    "subtype": "enum",
+                    "description": "",
+                    "file": "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts"
+                },
+                {
+                    "name": "GridColumnSortDirection",
+                    "childs": [
+                        {
+                            "name": "Asc",
+                            "value": "ASCENDING"
+                        },
+                        {
+                            "name": "Desc",
+                            "value": "DESCENDING"
+                        },
+                        {
+                            "name": "None",
+                            "value": "NONE"
+                        }
+                    ],
+                    "ctype": "miscellaneous",
+                    "subtype": "enum",
+                    "description": "<p>The sorting direction of the column values</p>\n",
+                    "file": "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts"
+                }
+            ],
+            "projects/components/src/datagrid/datagrid.component.ts": [
+                {
+                    "name": "GridSelectionType",
+                    "childs": [
+                        {
+                            "name": "Multi",
+                            "value": "MULTI"
+                        },
+                        {
+                            "name": "Single",
+                            "value": "SINGLE"
+                        },
+                        {
+                            "name": "None",
+                            "value": "NONE"
+                        }
+                    ],
+                    "ctype": "miscellaneous",
+                    "subtype": "enum",
+                    "description": "<p>Different types of row selection on the grid</p>\n",
+                    "file": "projects/components/src/datagrid/datagrid.component.ts"
+                }
+            ],
+            "projects/components/src/cliptext/cliptext.component.ts": [
+                {
+                    "name": "Position",
+                    "childs": [
+                        {
+                            "name": "TOP",
+                            "value": "TOP"
+                        },
+                        {
+                            "name": "BOTTOM",
+                            "value": "BOTTOM"
+                        },
+                        {
+                            "name": "BEFORE",
+                            "value": "BEFORE"
+                        },
+                        {
+                            "name": "AFTER",
+                            "value": "AFTER"
+                        }
+                    ],
+                    "ctype": "miscellaneous",
+                    "subtype": "enum",
+                    "description": "",
+                    "file": "projects/components/src/cliptext/cliptext.component.ts"
+                }
+            ]
+        },
+        "groupedTypeAliases": {
+            "projects/components/src/datagrid/interfaces/component-renderer.interface.ts": [
+                {
+                    "name": "ComponentRendererConstructor",
+                    "ctype": "miscellaneous",
+                    "subtype": "typealias",
+                    "rawtype": "Type<ComponentRenderer<V>>",
+                    "file": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+                    "description": "<p>Used for the type safety of {@link ComponentRendererSpec#type}</p>\n",
+                    "kind": 161
+                }
+            ],
+            "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts": [
+                {
+                    "name": "FunctionRenderer",
+                    "ctype": "miscellaneous",
+                    "subtype": "typealias",
+                    "rawtype": "function",
+                    "file": "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts",
+                    "description": "<p>Column renderer as a function. Defined in calling component when the cell value is calculated from different\nproperties.</p>\n",
+                    "kind": 162
+                }
+            ],
+            "projects/components/src/cliptext/cliptext.component.ts": [
+                {
+                    "name": "InlineSpec",
+                    "ctype": "miscellaneous",
+                    "subtype": "typealias",
+                    "rawtype": "\"undefined\" | string",
+                    "file": "projects/components/src/cliptext/cliptext.component.ts",
+                    "description": "",
+                    "kind": 168
+                }
+            ]
+        }
+    },
+    "routes": [],
+    "coverage": {
+        "count": 58,
+        "status": "good",
+        "files": [
+            {
+                "filePath": "projects/components/src/cliptext/cliptext.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "CliptextComponent",
+                "coveragePercent": 21,
+                "coverageCount": "3/14",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/cliptext/cliptext.wo.ts",
+                "type": "class",
+                "linktype": "classe",
+                "name": "CliptextWidgetObject",
+                "coveragePercent": 75,
+                "coverageCount": "9/12",
+                "status": "good"
+            },
+            {
+                "filePath": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                "type": "pipe",
+                "linktype": "pipe",
+                "name": "NestedPropertyPipe",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                "type": "function",
+                "linksubtype": "function",
+                "name": "isNullOrUndefined",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "DATE_OBJECT_CLASS",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/common/pipes/nested-property.pipe.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "OBJECT_PROPERTY_SEPARATOR",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/common/pipes/pipes.module.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "declarations",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/data-exporter/csv-exporter.service.ts",
+                "type": "injectable",
+                "linktype": "injectable",
+                "name": "CsvExporterService",
+                "coveragePercent": 66,
+                "coverageCount": "2/3",
+                "status": "good"
+            },
+            {
+                "filePath": "projects/components/src/data-exporter/csv-exporter.service.ts",
+                "type": "function",
+                "linksubtype": "function",
+                "name": "encodeValue",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/data-exporter/csv-exporter.service.ts",
+                "type": "function",
+                "linksubtype": "function",
+                "name": "processRow",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/data-exporter/data-exporter.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "DataExporterComponent",
+                "coveragePercent": 42,
+                "coverageCount": "8/19",
+                "status": "medium"
+            },
+            {
+                "filePath": "projects/components/src/data-exporter/data-exporter.component.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "DataExportRequestEvent",
+                "coveragePercent": 100,
+                "coverageCount": "4/4",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/data-exporter/data-exporter.component.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "ExportColumn",
+                "coveragePercent": 100,
+                "coverageCount": "3/3",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/data-exporter/data-exporter.wo.ts",
+                "type": "class",
+                "linktype": "classe",
+                "name": "DataExporterWidgetObject",
+                "coveragePercent": 64,
+                "coverageCount": "9/14",
+                "status": "good"
+            },
+            {
+                "filePath": "projects/components/src/data-exporter/data-exporter.wo.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "Css",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/datagrid.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "DatagridComponent",
+                "coveragePercent": 77,
+                "coverageCount": "17/22",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/datagrid.component.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "Button",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/datagrid.component.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "ColumnConfigInternal",
+                "coveragePercent": 25,
+                "coverageCount": "1/4",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/datagrid.component.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "GridDataFetchResult",
+                "coveragePercent": 100,
+                "coverageCount": "5/5",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/datagrid.component.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "GridState",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/datagrid.module.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "directives",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/datagrid.module.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "pipes",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/datagrid.module.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "renderers",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/directives/component-renderer-outlet.directive.ts",
+                "type": "directive",
+                "linktype": "directive",
+                "name": "ComponentRendererOutletDirective",
+                "coveragePercent": 37,
+                "coverageCount": "3/8",
+                "status": "medium"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/directives/component-renderer-outlet.directive.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "ComponentRendererType",
+                "coveragePercent": 100,
+                "coverageCount": "3/3",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "ComponentRenderer",
+                "coveragePercent": 100,
+                "coverageCount": "2/2",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "ComponentRendererSpec",
+                "coveragePercent": 100,
+                "coverageCount": "3/3",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/interfaces/component-renderer.interface.ts",
+                "type": "function",
+                "linksubtype": "function",
+                "name": "RendererSpec",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/interfaces/datagrid-column.interface.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "GridColumn",
+                "coveragePercent": 87,
+                "coverageCount": "7/8",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/pipes/function-renderer.pipe.ts",
+                "type": "pipe",
+                "linktype": "pipe",
+                "name": "FunctionRendererPipe",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/renderers/bold-text-renderer.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "BoldTextRendererComponent",
+                "coveragePercent": 50,
+                "coverageCount": "1/2",
+                "status": "medium"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/renderers/bold-text-renderer.component.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "BoldTextRendererConfig",
+                "coveragePercent": 100,
+                "coverageCount": "2/2",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts",
+                "type": "function",
+                "linksubtype": "function",
+                "name": "WithGridBoldRenderer",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "class",
+                "linktype": "classe",
+                "name": "ClrDatagridWidgetObject",
+                "coveragePercent": 80,
+                "coverageCount": "12/15",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "CELL_TAG",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "COLUMN_CSS_SELECTOR",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "COLUMN_SELECTOR",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/datagrid/datagrid.wo.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "ROW_TAG",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/widget-object.ts",
+                "type": "class",
+                "linktype": "classe",
+                "name": "WidgetFinder",
+                "coveragePercent": 71,
+                "coverageCount": "5/7",
+                "status": "good"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/widget-object.ts",
+                "type": "class",
+                "linktype": "classe",
+                "name": "WidgetObject",
+                "coveragePercent": 80,
+                "coverageCount": "8/10",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/widget-object.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "FindableWidget",
+                "coveragePercent": 50,
+                "coverageCount": "1/2",
+                "status": "medium"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/widget-object.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "FindParams",
+                "coveragePercent": 100,
+                "coverageCount": "4/4",
+                "status": "very-good"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/widget-object.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "HasFinder",
+                "coveragePercent": 50,
+                "coverageCount": "1/2",
+                "status": "medium"
+            },
+            {
+                "filePath": "projects/components/src/utils/test/widget-object.ts",
+                "type": "function",
+                "linksubtype": "function",
+                "name": "isFindParamsObject",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            }
+        ]
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ContentChild, TemplateRef, ElementRef } from '@angular/core';
+import { GridDataFetchResult, GridColumn, GridColumnHideable, GridState } from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+}
+
+/**
+ * A component that holds an example of the show/hide columns capability.
+ */
+@Component({
+    selector: 'vcd-datagrid-show-hide-example',
+    template: `
+        <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns">
+            <ng-template let-record="record"> DETAILS: {{ record.value }} </ng-template>
+        </vcd-datagrid>
+    `,
+})
+export class DatagridDetailRowExampleComponent {
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Column',
+            renderer: 'value',
+        },
+    ];
+
+    refresh(eventData: GridState<Data>): void {
+        this.gridData = {
+            items: [{ value: 'a' }, { value: 'b' }],
+            totalItems: 2,
+            pageSize: 2,
+            page: 1,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -12,6 +12,7 @@ import { DatagridThreeRenderersExampleComponent } from './datagrid-three-rendere
 import { DatagridThreeRenderersExampleModule } from './datagrid-three-renderers.example.module';
 import { DatagridCssClassesExampleModule } from './datagrid-css-classes.example.module';
 import { DatagridShowHideExampleModule } from './datagrid-show-hide.example.module';
+import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -33,13 +34,18 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Show/Hide datagrid columns example',
         },
+        {
+            component: DatagridDetailRowExampleComponent,
+            forComponent: null,
+            title: 'Detail row datagrid example',
+        },
     ],
 });
-
 /**
  * A module that imports all data grid example modules
  */
 @NgModule({
-    imports: [DatagridThreeRenderersExampleModule, DatagridCssClassesExampleModule, DatagridShowHideExampleModule],
+    imports: [DatagridThreeRenderersExampleModule, DatagridCssClassesExampleModule,
+            DatagridShowHideExampleModule, DatagridDetailRowExampleComponent],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
# Description

Adds the capability for clients of the library to set the details content in rows that allows the rows to expand.

# Testing Done

Added a unit test that tests that the rows have all the appropriate buttons to expand, and that the row will expand when you click the button.

Also, added an example that shows the behavior.

<img width="1007" alt="Screen Shot 2020-02-06 at 11 25 58 AM" src="https://user-images.githubusercontent.com/7528512/73957261-1fae3a80-48d4-11ea-87f0-df90a608b5a6.png">

Signed-off-by: Ryan Bradford <rbradford@vmware.com>