### PR TITLE
Added sorting capabilities to datagrid columns

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,5 +1,5 @@
-<clr-datagrid [clrDgLoading]="isLoading" [ngClass]="this.clrDatagridCssClass">
-    <clr-dg-column *ngFor="let column of columnsConfig">
+<clr-datagrid [clrDgLoading]="isLoading" [ngClass]="this.clrDatagridCssClass" (clrDgRefresh)="gridStateChanged($event)">
+    <clr-dg-column *ngFor="let column of columnsConfig" [clrDgField]="column.queryFieldName">
         <ng-container *ngIf="isColumnHideable(column); else notHideable">
             <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
                 column.displayName

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -134,22 +134,19 @@ describe('DatagridComponent', () => {
         });
 
         it('displays loading indicators while data is loading', function(this: HasFinderAndGrid): void {
-            spyOn(this.finder.hostComponent, 'refresh').and.callFake(() => {
-                this.finder.detectChanges();
-                expect(this.clrGridWidget.component.loading).toBe(true, 'Initially loading indicator should be true');
-                this.finder.hostComponent.gridData = {
-                    items: mockData,
-                    totalItems: 2,
-                    pageSize: 2,
-                    page: 1,
-                };
-                this.finder.detectChanges();
-                expect(this.clrGridWidget.component.loading).toBe(
-                    false,
-                    'After setting gridData, loading indicator should not be visible'
-                );
-            });
             this.finder.detectChanges();
+            expect(this.clrGridWidget.component.loading).toBe(true, 'Initially loading indicator should be true');
+            this.finder.hostComponent.gridData = {
+                items: mockData,
+                totalItems: 2,
+                pageSize: 2,
+                page: 1,
+            };
+            this.finder.detectChanges();
+            expect(this.clrGridWidget.component.loading).toBe(
+                false,
+                'After setting gridData, loading indicator should not be visible'
+            );
         });
 
         describe('Show/Hide Functionality', () => {
@@ -216,6 +213,47 @@ describe('DatagridComponent', () => {
             it('opens one detail pane when you click the button', function(this: HasFinderAndGrid): void {
                 this.clrGridWidget.clickDetailsButton(0);
                 expect(this.clrGridWidget.getAllDetailContents().length).toEqual(1);
+            });
+        });
+
+        describe('@Output() refresh', () => {
+            beforeEach(function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.columns = [
+                    {
+                        displayName: 'Column',
+                        renderer: 'name',
+                        queryFieldName: 'a',
+                    },
+                    {
+                        displayName: 'other',
+                        renderer: 'name',
+                    },
+                ];
+                this.finder.detectChanges();
+            });
+
+            it('emits the column information when the column sorted', function(this: HasFinderAndGrid): void {
+                const refreshMethod = spyOn(this.finder.hostComponent, 'refresh');
+                this.clrGridWidget.sortColumn(0);
+                expect(refreshMethod).toHaveBeenCalledWith({
+                    sortColumn: {
+                        name: 'a',
+                        reverse: false,
+                    },
+                });
+                this.clrGridWidget.sortColumn(0);
+                expect(refreshMethod).toHaveBeenCalledWith({
+                    sortColumn: {
+                        name: 'a',
+                        reverse: true,
+                    },
+                });
+            });
+
+            it('does not sort a column without a queryFieldName', function(this: HasFinderAndGrid): void {
+                const refreshMethod = spyOn(this.finder.hostComponent, 'refresh');
+                this.clrGridWidget.sortColumn(1);
+                expect(refreshMethod).toHaveBeenCalledTimes(0);
             });
         });
     });

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -15,7 +15,7 @@ import {
     ElementRef,
 } from '@angular/core';
 import { FunctionRenderer, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';
-import { ClrDatagridFilter } from '@clr/angular';
+import { ClrDatagridFilter, ClrDatagridStateInterface, ClrDatagridSortOrder } from '@clr/angular';
 import { ComponentRendererSpec } from './interfaces/component-renderer.interface';
 
 /**
@@ -66,6 +66,20 @@ export interface GridDataFetchResult<R> {
 }
 
 /**
+ * The information about the currently sorted column.
+ */
+export interface SortedColumn {
+    /**
+     * Whether the column is sorted normally or reversed.
+     */
+    reverse: boolean;
+    /**
+     * The name of the column that is sorted.
+     */
+    name: string;
+}
+
+/**
  * The current state of various features of the grid like filtering, sorting, pagination. This object is emitted as
  * part of the event {@link DatagridComponent.gridRefresh}. The handler then used this object to construct a query.
  * TODO: This interface is going to defined as part of working on the following tasks:
@@ -74,7 +88,12 @@ export interface GridDataFetchResult<R> {
  *  https://jira.eng.vmware.com/browse/VDUCC-20
  */
 // tslint:disable-next-line:no-empty-interface
-export interface GridState<R> {}
+export interface GridState<R> {
+    /**
+     * The currently sorted column in the datagrid.
+     */
+    sortColumn?: SortedColumn;
+}
 
 /**
  * For simplifying logic inside the HTML template to differentiate between different {@link GridColumn.renderer}
@@ -237,6 +256,20 @@ export class DatagridComponent<R> implements OnInit {
     ngOnInit(): void {
         this.isLoading = true;
         this.gridRefresh.emit({});
+    }
+
+    /**
+     * Called when the {@param state} of the Clarity datagrid changes.
+     */
+    gridStateChanged(state: ClrDatagridStateInterface): void {
+        const toEmit: GridState<R> = {};
+        if (state.sort && typeof state.sort.by === 'string') {
+            toEmit.sortColumn = {
+                name: state.sort.by,
+                reverse: state.sort.reverse,
+            };
+        }
+        this.gridRefresh.emit(toEmit);
     }
 
     isColumnHideable(column: GridColumn<R>): boolean {

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -87,8 +87,6 @@ export interface GridColumn<R> {
      */
     emptyColumnPlaceholder?: string;
 
-    sortDirection?: GridColumnSortDirection;
-
     /**
      * TODO: Should this be made to work with top level search on grids across all columns?
      *  The above to-do is going to be worked on as part of https://jira.eng.vmware.com/browse/VDUCC-27 and

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -92,6 +92,13 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Sorts the column at the given index.
+     */
+    sortColumn(index: number): void {
+        this.columns[index].nativeElement.click();
+    }
+
+    /**
      * Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that
      * subclasses should not return the DebugElement, they should return a string from a section of the HTML.
      *

--- a/projects/examples/src/components/datagrid/datagrid-sort.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-sort.example.component.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { GridDataFetchResult, GridColumn, GridState } from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+    someBool: boolean;
+}
+
+/**
+ * A component that holds an example of the sorting columns capability.
+ */
+@Component({
+    selector: 'vcd-datagrid-sort-example',
+    template: `
+        <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns"> </vcd-datagrid>
+    `,
+})
+export class DatagridSortExampleComponent {
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Column',
+            renderer: 'value',
+            queryFieldName: 'a',
+        },
+        {
+            displayName: 'Boolean',
+            renderer: 'someBool',
+            queryFieldName: 'b',
+        },
+    ];
+
+    refresh(eventData: GridState<Data>): void {
+        let data = [
+            { value: 'a', someBool: true },
+            { value: 'b', someBool: false },
+            { value: 'c', someBool: true },
+            { value: 'a', someBool: false },
+            { value: 'f', someBool: true },
+            { value: 'c', someBool: true },
+        ];
+        if (eventData.sortColumn) {
+            if (eventData.sortColumn.name === 'a') {
+                data = data.sort((a, b) => a.value.localeCompare(b.value));
+                if (eventData.sortColumn.reverse) {
+                    data = data.reverse();
+                }
+            }
+            if (eventData.sortColumn.name === 'b') {
+                data = data.sort((a, b) => (a.someBool === b.someBool ? 0 : a.someBool ? -1 : 1));
+                if (eventData.sortColumn.reverse) {
+                    data = data.reverse();
+                }
+            }
+        }
+        this.gridData = {
+            items: data,
+            totalItems: 2,
+            pageSize: 2,
+            page: 1,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-sort.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-sort.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DatagridModule } from '@vcd/ui-components';
+import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
+
+@NgModule({
+    declarations: [DatagridSortExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    exports: [DatagridSortExampleComponent],
+    entryComponents: [DatagridSortExampleComponent],
+})
+export class DatagridSortExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -14,6 +14,8 @@ import { DatagridCssClassesExampleModule } from './datagrid-css-classes.example.
 import { DatagridShowHideExampleModule } from './datagrid-show-hide.example.module';
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 import { DatagridDetailRowExampleModule } from './datagrid-detail-row.example.module';
+import { DatagridSortExampleModule } from './datagrid-sort.example.module';
+import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -40,6 +42,11 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Detail row datagrid example',
         },
+        {
+            component: DatagridSortExampleComponent,
+            forComponent: null,
+            title: 'Shows the sorting capability of the datagrid',
+        },
     ],
 });
 /**
@@ -51,6 +58,7 @@ Documentation.registerDocumentationEntry({
         DatagridCssClassesExampleModule,
         DatagridShowHideExampleModule,
         DatagridDetailRowExampleModule,
+        DatagridSortExampleModule,
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
# Description

Exposes information in the gridRefresh event that allows us to sort the columns of the datagrid on the server side. Only supports sorting by 1 column at a time. Supports both ascending and descending sorting. 

# Testing

Added a unit test that tests that a column can be both sorted ascending and descending. Also, added an example that shows a table with two columns and what happens when they are sorted.

![sort-columns](https://user-images.githubusercontent.com/7528512/74271252-8ec3ce80-4cda-11ea-8049-b0dc42729fef.gif)

# Known Errors

Due to a bug recently fixed in Clarity, when a column is sorted then another is sorted, an icon appears on both columns even though the table is only sorted by the later column. 