### PR TITLE
Added action buttons to the datagrid

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,9 +1,43 @@
 <clr-datagrid [clrDgLoading]="isLoading" [ngClass]="this.clrDatagridCssClass" (clrDgRefresh)="gridStateChanged($event)">
-    <clr-dg-column
-        *ngFor="let column of columnsConfig"
-        [clrDgField]="column.queryFieldName"
-        (clrDgSortOrderChange)="resetToPageOne()"
-    >
+    <clr-dg-action-bar *ngIf="buttonConfig">
+        <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">
+            <button
+                class="btn"
+                [ngClass]="button.class"
+                *ngIf="isButtonShown(button)"
+                (click)="button.handler()"
+                [disabled]="isButtonDisabled(button, button.isActive())"
+            >
+                <ng-container>{{ button.label }}</ng-container>
+            </button>
+        </div>
+
+        <ng-container *ngIf="shouldDisplayButtonsOnTop()">
+            <div class="btn-group" *ngIf="this.getFeaturedButtons().length !== 0">
+                <button
+                    *ngFor="let button of this.getFeaturedButtons()"
+                    type="button"
+                    class="btn btn-icon"
+                    (click)="button.handler(datagridSelection)"
+                    [disabled]="isButtonDisabled(button, button.isActive(datagridSelection))"
+                >
+                    <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
+                        <clr-icon [attr.shape]="button.icon"></clr-icon>
+                        <span class="tooltip-content">{{ button.label }}</span>
+                    </a>
+                </button>
+                <ng-container *ngTemplateOutlet="dropdown"></ng-container>
+            </div>
+            <ng-container *ngIf="this.getFeaturedButtons().length === 0">
+                <ng-container *ngTemplateOutlet="dropdown"></ng-container>
+            </ng-container>
+        </ng-container>
+    </clr-dg-action-bar>
+
+    <clr-dg-column *ngIf="shouldDisplayButtonsOnRow()" [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()">
+        Actions
+    </clr-dg-column>
+    <clr-dg-column *ngFor="let column of columnsConfig" [clrDgField]="column.queryFieldName" (clrDgSortOrderChange)="resetToPageOne()">
         <ng-container *ngIf="isColumnHideable(column); else notHideable">
             <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
                 column.displayName
@@ -18,6 +52,46 @@
         [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
         [clrDgItem]="restItem"
     >
+        <clr-dg-cell
+            *ngIf="shouldDisplayButtonsOnRow()"
+            class="action-button-cell"
+            [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()"
+        >
+            <div class="btn-group action-button-group">
+                <button
+                    class="btn btn-icon action-button"
+                    *ngFor="let button of this.getFeaturedButtons(restItem)"
+                    (click)="button.handler([restItem])"
+                    [disabled]="isButtonDisabled(button, button.isActive([restItem]))"
+                >
+                    <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
+                        <clr-icon size="1em" [attr.shape]="button.icon" class="action-icon"></clr-icon>
+                        <span class="tooltip-content">{{ button.label }}</span>
+                    </a>
+                </button>
+                <clr-dropdown
+                    class="btn-group-overflow open action-button"
+                    *ngIf="buttonConfig.contextualButtonConfig.buttons.length !== 0"
+                >
+                    <button class="btn action-button dropdown-small" clrDropdownTrigger>
+                        <clr-icon shape="ellipsis-horizontal action-icon"></clr-icon>
+                    </button>
+                    <clr-dropdown-menu class="dropdown-menu" *clrIfOpen>
+                        <ng-container *ngFor="let button of buttonConfig.contextualButtonConfig.buttons">
+                            <button
+                                class="btn"
+                                [ngClass]="button.class"
+                                [disabled]="!button.isActive([restItem])"
+                                (click)="button.handler([restItem])"
+                            >
+                                {{ button.label }}
+                            </button>
+                        </ng-container>
+                    </clr-dropdown-menu>
+                </clr-dropdown>
+            </div>
+        </clr-dg-cell>
+
         <clr-dg-cell *ngFor="let column of columnsConfig">
             <!-- Default renderer -->
             <ng-container *ngIf="column.fieldName">{{ restItem | nestedProperty: column.fieldName }}</ng-container>
@@ -51,3 +125,22 @@
         </clr-dg-pagination>
     </clr-dg-footer>
 </clr-datagrid>
+
+<ng-template #dropdown>
+    <clr-dropdown class="btn-group-overflow open" *ngIf="hasContextualButtons()">
+        <button class="btn dropdown-toggle dropdown-small" clrDropdownTrigger>
+            <clr-icon shape="ellipsis-horizontal"></clr-icon>
+        </button>
+        <clr-dropdown-menu class="dropdown-menu" *clrIfOpen>
+            <button
+                *ngFor="let button of buttonConfig.contextualButtonConfig.buttons"
+                class="btn"
+                [ngClass]="button.class"
+                [disabled]="!button.isActive(this.datagridSelection)"
+                (click)="button.handler(this.datagridSelection)"
+            >
+                {{ button.label }}
+            </button>
+        </clr-dropdown-menu>
+    </clr-dropdown>
+</ng-template>

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -3,16 +3,42 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-.action-button-col {
-    padding-top: 5px;
-    padding-bottom: 5px;
+// The amount of padding that should be placed above and below a button group.
+$PADDING: 5px;
+// How wide a single button should be.
+$BUTTON_WIDTH: 50px;
+
+$supported-buttons: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+
+@each $num in $supported-buttons {
+    .buttons-#{$num} {
+        flex: 0 0 auto;
+        min-width: #{$BUTTON_WIDTH * ($num + 1.5)} !important;
+        max-width: 400px;
+        padding-left: #{$BUTTON_WIDTH/4};
+    }
+}
+
+.action-button-cell {
+    padding-top: $PADDING;
+    padding-bottom: $PADDING;
+}
+
+.action-button-group {
+    height: 100%;
+    margin-bottom: #{$PADDING * -2};
 }
 
 .action-button {
     height: 100%;
-    margin-bottom: -10px;
+    margin-bottom: #{$PADDING * -2};
+    width: $BUTTON_WIDTH !important;
+}
+
+.dropdown-small {
+    min-width: unset;
 }
 
 .action-icon {
-    margin-bottom: 10px;
+    margin-bottom: $PADDING;
 }

--- a/projects/components/src/datagrid/datagrid.module.ts
+++ b/projects/components/src/datagrid/datagrid.module.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { LinkedTextRendererComponent } from './renderers/linked-text-renderer.component';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ClarityModule } from '@clr/angular';
@@ -12,14 +13,15 @@ import { PipesModule } from '../common/pipes/pipes.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FunctionRendererPipe } from './pipes/function-renderer.pipe';
 import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterModule } from '@angular/router';
+import { CliptextModule } from '../cliptext/cliptext.module';
 
 const directives = [DatagridComponent, ComponentRendererOutletDirective];
 const pipes = [FunctionRendererPipe];
-const renderers = [BoldTextRendererComponent];
+const renderers = [BoldTextRendererComponent, LinkedTextRendererComponent];
 
 @NgModule({
-    imports: [CommonModule, ClarityModule, PipesModule, ReactiveFormsModule, BrowserAnimationsModule],
+    imports: [CommonModule, ClarityModule, RouterModule, PipesModule, ReactiveFormsModule, CliptextModule],
     declarations: [...directives, ...renderers, ...pipes],
     providers: [],
     exports: [DatagridComponent, ...renderers],

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -33,12 +33,143 @@ export enum GridColumnSortDirection {
 }
 
 /**
+ * The ways buttons should be displayed when they are inactive.
+ */
+export enum InactiveButtonDisplayMode {
+    Hide = 'HIDE',
+    Disable = 'Disable',
+}
+
+/**
  * Column renderer as a function. Defined in calling component when the cell value is calculated from different
  * properties.
  * @param record The record for the row being rendered
  * @return The string to be displayed for that cell
  */
 export type FunctionRenderer<T> = (record: T) => string;
+
+/**
+ * A generic interface for a button that can be displayed on the grid.
+ */
+export interface Button<R> {
+    /**
+     * The translated text of the button.
+     */
+    label: string;
+    /**
+     * The css class the button should have.
+     */
+    class?: string;
+    /**
+     * The way this button should be shown when inactive.
+     * Overrides {@link ButtonConfig.inactiveDisplayMode}.
+     */
+    inactiveDisplayMode?: InactiveButtonDisplayMode;
+    /**
+     * The function that is called when the button is pressed.
+     *
+     * @param entity the currently selected entities.
+     */
+    handler: (rec?: R[]) => void;
+    /**
+     * The function that is called to determine if the button should be displayed.
+     *
+     * @param entity the currently selected entities.
+     */
+    isActive: (rec?: R[]) => boolean;
+}
+
+/**
+ * A type of button whose displayability does not depend on the selected entity.
+ */
+export interface GlobalButton<R> extends Button<R> {
+    /**
+     * The function that is called when the button is pressed.
+     */
+    handler: () => void;
+    /**
+     * The function that is called to determine if the button should be displayed.
+     */
+    isActive: () => boolean;
+}
+
+/**
+ * A type of button whose displayability dependends on the selected entity.
+ */
+export interface ContextualButton<R> extends Button<R> {
+    /**
+     * The function that is called when the button is pressed.
+     *
+     * @param entity the currently selected entities.
+     */
+    handler: (entity: R[]) => void;
+    /**
+     * The function that is called to determine if the button should be displayed.
+     *
+     * @param entity the currently selected entities.
+     */
+    isActive: (rec: R[]) => boolean;
+    /**
+     * The ID of this button that is unique among buttons passed to the grid.
+     */
+    id: string;
+    /**
+     * The Clarity icon of the contextual button that is displayed if the button is featured.
+     */
+    icon: string;
+}
+
+/**
+ * An enum that describes where the contextual buttons should display.
+ */
+export enum ContextualButtonPosition {
+    TOP = 'TOP',
+    ROW = 'ROW',
+}
+
+/**
+ * A configuration that descibes all the information about the contextual buttons.
+ */
+export interface ContextualButtonConfig<R> {
+    /**
+     * A list of all the contextual buttons.
+     */
+    buttons: ContextualButton<R>[];
+    /**
+     * An ordered list of {@link ContextualButton.id}s of buttons that should be in a featured position.
+     *
+     * Only non-hidden buttons will be shown.
+     */
+    featured: string[];
+    /**
+     * How many buttons should display on the featured section.
+     *
+     * Used when you want to set a limit on the number of featured buttons shown.
+     */
+    featuredCount: number;
+    /**
+     * Where the buttons should display on the grid.
+     */
+    position: ContextualButtonPosition;
+}
+
+/**
+ * The configuration object that describes the type of buttons to put on the top of the grid.
+ */
+export interface ButtonConfig<R> {
+    /**
+     * The buttons whose displayability does not depend on the selected entity.
+     */
+    globalButtons: GlobalButton<R>[];
+    /**
+     * The buttons whose displayability depends on the selected entity.
+     */
+    contextualButtonConfig: ContextualButtonConfig<R>;
+    /**
+     * The way buttons should be shown when inactive.
+     */
+    inactiveDisplayMode?: InactiveButtonDisplayMode;
+}
 
 /**
  * Configuration object defined in the caller. This contains properties for the column header (text, filtering,

--- a/projects/components/src/datagrid/renderers/index.ts
+++ b/projects/components/src/datagrid/renderers/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './bold-text-renderer.component';
+export * from './linked-text-renderer.component';

--- a/projects/components/src/datagrid/renderers/linked-text-renderer.component.ts
+++ b/projects/components/src/datagrid/renderers/linked-text-renderer.component.ts
@@ -1,0 +1,89 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, Input } from '@angular/core';
+import { ComponentRenderer } from '../interfaces/component-renderer.interface';
+
+/**
+ * {@link ComponentRenderer.config} type that the {@link LinkedTextRendererComponent} can understand
+ */
+export interface LinkedTextRendererConfig {
+    /**
+     * Text to be displayed as the anchor text
+     */
+    text: string;
+    /**
+     * Where the text should link to
+     */
+    textLink: string;
+    /**
+     * The cross-site link that the text should point to
+     */
+    // TODO: implement this functionality. See vcdCrossSiteLink.
+    popoutLink?: string;
+    /**
+     * The tooltip text of the offiste link.
+     */
+    popoutLinkTooltip?: string;
+}
+
+/**
+ * A {@link ComponentRenderer} component that is used for rendering a linked piece of text that also has an offsite link.
+ *
+ * @example Example usage with RendererSpec:
+ *     columns: GridColumn<MockRecord>[] = [
+ *       {
+ *         displayName: 'Component Renderer',
+ *         renderer: RendererSpec(
+ *           LinkedTextRendererComponent,
+ *           (record: MockRecord) => ({text: record.name, onsiteLink: './url'})
+ *         )
+ *       }
+ *     ];
+ */
+@Component({
+    template: `
+        <div class="flex-container">
+            <div class="with-margin-right text-truncate">
+                <a [routerLink]="config.textLink">
+                    <vcd-cliptext>
+                        {{ config.text }}
+                    </vcd-cliptext>
+                </a>
+            </div>
+            <clr-tooltip class="without-flex" *ngIf="config.popoutLink">
+                <span clrTooltipTrigger>
+                    <a [target]="'_blank'">
+                        <clr-icon shape="pop-out"></clr-icon>
+                    </a>
+                </span>
+                <ng-container *ngIf="config.popoutLinkTooltip">
+                    <clr-tooltip-content *clrIfOpen [clrPosition]="'top-right'" [clrSize]="'md'">
+                        <span>{{ config.popoutLinkTooltip }}</span>
+                    </clr-tooltip-content>
+                </ng-container>
+            </clr-tooltip>
+        </div>
+    `,
+    styles: [
+        `
+            .without-flex {
+                flex: none;
+            }
+
+            .flex-container {
+                display: flex;
+            }
+
+            .with-margin-right {
+                margin-right: auto;
+            }
+        `,
+    ],
+})
+export class LinkedTextRendererComponent implements ComponentRenderer<LinkedTextRendererConfig> {
+    @Input()
+    config: LinkedTextRendererConfig;
+}

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -146,6 +146,34 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Gives a list of the labels of the displayed action buttons at the top of the grid.
+     */
+    getTopPositionedButtons(): string[] {
+        return this.findElements('clr-dg-action-bar button').map(button => button.nativeElement.textContent);
+    }
+
+    /**
+     * Gives the class of the cell that holds the row buttons.
+     */
+    getRowButtonContainerClass(rowIndex: number): string[] {
+        return Object.keys(this.findElement(`.action-button-cell`, this.rows[rowIndex]).classes);
+    }
+
+    /**
+     * Presses the button at the given {@param index} on the top of the grid.
+     */
+    pressTopButton(index: number): void {
+        this.click(`clr-dg-action-bar button:nth-of-type(${index + 1})`);
+    }
+
+    /**
+     * Presses the button at the given {@param buttonIndex} at the row at the given {@param rowIndex}.
+     */
+    pressButtonAtRow(buttonIndex: number, rowIndex: number): void {
+        this.click(`.action-button-group button:nth-of-type(${buttonIndex + 1})`, this.rows[rowIndex]);
+    }
+
+    /**
      * Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that
      * subclasses should not return the DebugElement, they should return a string from a section of the HTML.
      *

--- a/projects/examples/src/assets/our-translations.json
+++ b/projects/examples/src/assets/our-translations.json
@@ -1,7 +1,7 @@
 {
     "en": {
-        "data-exporter.title": "CUSTOMIZATION!!",
-        "app.title": "Title"
+        "data-exporter.title": "Data Exporter!!",
+        "app.title": "VCD UI Common Components"
     },
     "gr": {
         "select.all": "Wählen Sie Alle",

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -1,0 +1,133 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import {
+    GridDataFetchResult,
+    GridColumn,
+    GridState,
+    ButtonConfig,
+    GridSelectionType,
+    ContextualButtonPosition,
+    InactiveButtonDisplayMode,
+} from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+    paused: boolean;
+}
+
+/**
+ * A component that holds an example of the show/hide columns capability.
+ */
+@Component({
+    selector: 'vcd-datagrid-link-example',
+    template: `
+        <button (click)="this.changeButtonLocation()" class="btn btn-primary">Change Link Location</button><br />
+        <vcd-datagrid
+            [gridData]="gridData"
+            (gridRefresh)="refresh($event)"
+            [columns]="columns"
+            [buttonConfig]="buttonConfig"
+            [selectionType]="selectionType"
+        ></vcd-datagrid>
+    `,
+})
+export class DatagridLinkExampleComponent {
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Some Value',
+            renderer: 'value',
+        },
+    ];
+
+    buttonConfig: ButtonConfig<Data> = {
+        globalButtons: [
+            {
+                label: 'Add',
+                handler: () => {
+                    console.log('Adding stuff!');
+                },
+                isActive: () => true,
+            },
+            {
+                label: 'Delete All',
+                handler: () => {
+                    console.log('Deleting stuff!');
+                },
+                isActive: () => false,
+            },
+        ],
+        contextualButtonConfig: {
+            buttons: [
+                {
+                    label: 'Start',
+                    handler: (rec: Data[]) => {
+                        console.log('Starting ' + rec[0].value);
+                        rec[0].paused = false;
+                    },
+                    isActive: (rec: Data[]) => rec.length === 1 && rec[0].paused,
+                    id: 'a',
+                    icon: 'play',
+                    inactiveDisplayMode: InactiveButtonDisplayMode.Hide,
+                },
+                {
+                    label: 'Stop',
+                    handler: (rec: Data[]) => {
+                        console.log('Stopping ' + rec[0].value);
+                        rec[0].paused = true;
+                    },
+                    isActive: (rec: Data[]) => rec.length === 1 && !rec[0].paused,
+                    id: 'b',
+                    icon: 'pause',
+                    inactiveDisplayMode: InactiveButtonDisplayMode.Hide,
+                },
+                {
+                    label: 'Anythign',
+                    handler: (rec: Data[]) => {
+                        console.log('Adding ' + rec[0].value);
+                    },
+                    isActive: (rec: Data[]) => rec.length === 1 && rec[0].value === 'a',
+                    id: 'c',
+                    icon: 'warn',
+                },
+            ],
+            featuredCount: 3,
+            featured: ['a', 'b', 'c'],
+            position: ContextualButtonPosition.TOP,
+        },
+        inactiveDisplayMode: InactiveButtonDisplayMode.Disable,
+    };
+
+    selectionType = GridSelectionType.Single;
+
+    changeButtonLocation(): void {
+        if (this.buttonConfig.contextualButtonConfig.position === ContextualButtonPosition.TOP) {
+            this.buttonConfig.contextualButtonConfig.position = ContextualButtonPosition.ROW;
+            this.selectionType = GridSelectionType.None;
+        } else {
+            this.buttonConfig.contextualButtonConfig.position = ContextualButtonPosition.TOP;
+            this.selectionType = GridSelectionType.Single;
+        }
+    }
+
+    refresh(eventData: GridState<Data>): void {
+        this.gridData = {
+            items: [
+                { value: 'a', paused: false },
+                { value: 'b', paused: true },
+                { value: 'a', paused: true },
+                { value: 'b', paused: true },
+                { value: 'a', paused: false },
+                { value: 'b', paused: true },
+            ],
+            totalItems: 2,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-link.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DatagridModule } from '@vcd/ui-components';
+import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
+
+@NgModule({
+    declarations: [DatagridLinkExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    exports: [DatagridLinkExampleComponent],
+    entryComponents: [DatagridLinkExampleComponent],
+})
+export class DatagridLinkExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -20,6 +20,8 @@ import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example
 import { DatagridRowSelectExampleModule } from './datagrid-row-select.example.module';
 import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
 import { DatagridPagionationExampleModule } from './datagrid-pagination-example.module';
+import { DatagridLinkExampleModule } from './datagrid-link.example.module';
+import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -61,6 +63,11 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Pagination functionality and text customization example',
         },
+        {
+            component: DatagridLinkExampleComponent,
+            forComponent: null,
+            title: 'Links from Datagrid Example',
+        },
     ],
 });
 /**
@@ -75,6 +82,7 @@ Documentation.registerDocumentationEntry({
         DatagridSortExampleModule,
         DatagridRowSelectExampleModule,
         DatagridPagionationExampleModule,
+        DatagridLinkExampleModule
     ],
 })
 export class DatagridExamplesModule {}

--- a/tslint.json
+++ b/tslint.json
@@ -118,6 +118,7 @@
     "no-string-based-set-immediate": true,
     "no-string-based-set-interval": true,
     "no-string-based-set-timeout": true,
-    "no-eval": true
+    "no-eval": true,
+    "semicolon": [true, "always", "strict-bound-class-methods"]
   }
 }


### PR DESCRIPTION
# Description

Adds action buttons to the datagrid. There are two types of buttons - 

1. Global Buttons, which always appear at the top of the datagrid and whose visibility does not depend on the row currently selected.
2. Contextual buttons, which can appear either at the top of the grid or next to each row, and whose visibility does depend on the row(s) currently selected.

There are also various options for visibility:

1. Hide: When the button is inactive, it will not be shown anywhere.
2. Disable: when the button is inactive, it will be shown as disabled.

Exception: in the dropdown, all buttons will always be shown (just potentially disabled).

# Testing

Added an example that shows all features of the buttons in action. Also, added unit tests that test the features as described above. 
![button-links](https://user-images.githubusercontent.com/7528512/74865229-d2dc5200-531e-11ea-815f-ca851548f5cf.gif)



