### PR TITLE
Added pagination support

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -40,14 +40,14 @@
             </clr-dg-row-detail>
         </ng-container>
     </clr-dg-row>
-    <clr-dg-row *ngIf="this.pagination.pageSize === this.items.length"> </clr-dg-row>
+    <clr-dg-row *ngIf="sameItemsAsPageSize()"> </clr-dg-row>
 
     <clr-dg-footer>
         <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [(clrDgPageSize)]="this.pagination.pageSize">
             <clr-dg-page-size [clrPageSizeOptions]="this.pagination.pageSizeOptions">{{
                 paginationDropdownText
             }}</clr-dg-page-size>
-            {{ paginationCallback(paginationData.firstItem + 1, paginationData.lastItem + 1, totalItems) }}
+            {{ paginationCallbackWrapper(paginationData) }}
         </clr-dg-pagination>
     </clr-dg-footer>
 </clr-datagrid>

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,5 +1,5 @@
 <clr-datagrid [clrDgLoading]="isLoading" [ngClass]="this.clrDatagridCssClass" (clrDgRefresh)="gridStateChanged($event)">
-    <clr-dg-column *ngFor="let column of columnsConfig" [clrDgField]="column.queryFieldName">
+    <clr-dg-column *ngFor="let column of columnsConfig" [clrDgField]="column.queryFieldName" (clrDgSortOrderChange)="resetToPageOne()">
         <ng-container *ngIf="isColumnHideable(column); else notHideable">
             <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
                 column.displayName
@@ -36,5 +36,14 @@
             </clr-dg-row-detail>
         </ng-container>
     </clr-dg-row>
-    <clr-dg-footer> </clr-dg-footer>
+    <clr-dg-row *ngIf="this.pagination.pageSize === this.items.length"> </clr-dg-row>
+
+    <clr-dg-footer>
+        <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [(clrDgPageSize)]="this.pagination.pageSize">
+            <clr-dg-page-size [clrPageSizeOptions]="this.pagination.pageSizeOptions">{{
+                paginationText
+            }}</clr-dg-page-size>
+            {{ paginationCallback(paginationData.firstItem + 1, paginationData.lastItem + 1, totalItems) }}
+        </clr-dg-pagination>
+    </clr-dg-footer>
 </clr-datagrid>

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,5 +1,9 @@
 <clr-datagrid [clrDgLoading]="isLoading" [ngClass]="this.clrDatagridCssClass" (clrDgRefresh)="gridStateChanged($event)">
-    <clr-dg-column *ngFor="let column of columnsConfig" [clrDgField]="column.queryFieldName" (clrDgSortOrderChange)="resetToPageOne()">
+    <clr-dg-column
+        *ngFor="let column of columnsConfig"
+        [clrDgField]="column.queryFieldName"
+        (clrDgSortOrderChange)="resetToPageOne()"
+    >
         <ng-container *ngIf="isColumnHideable(column); else notHideable">
             <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
                 column.displayName
@@ -41,7 +45,7 @@
     <clr-dg-footer>
         <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [(clrDgPageSize)]="this.pagination.pageSize">
             <clr-dg-page-size [clrPageSizeOptions]="this.pagination.pageSizeOptions">{{
-                paginationText
+                paginationDropdownText
             }}</clr-dg-page-size>
             {{ paginationCallback(paginationData.firstItem + 1, paginationData.lastItem + 1, totalItems) }}
         </clr-dg-pagination>

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -433,7 +433,7 @@ describe('DatagridComponent', () => {
             [selectionType]="selectionType"
             (selectionChanged)="selectionChanged($event)"
             [paginationCallback]="paginationCallback"
-            [paginationText]="paginationText"
+            [paginationDropdownText]="paginationText"
         >
             <ng-template let-record="record"> DETAILS: {{ record.name }} </ng-template>
         </vcd-datagrid>

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -186,8 +186,6 @@ describe('DatagridComponent', () => {
                         this.finder.hostComponent.gridData = {
                             items: [mockData[0]],
                             totalItems: 2,
-                            pageSize: 2,
-                            page: 1,
                         };
                         this.finder.detectChanges();
                         expect(this.finder.hostComponent.getSelection()).toEqual([]);
@@ -202,8 +200,6 @@ describe('DatagridComponent', () => {
                         this.finder.hostComponent.gridData = {
                             items: [mockData[0]],
                             totalItems: 2,
-                            pageSize: 2,
-                            page: 1,
                         };
                         this.finder.detectChanges();
                         expect(this.finder.hostComponent.getSelection()).toEqual([mockData[0]]);
@@ -218,8 +214,6 @@ describe('DatagridComponent', () => {
                     this.finder.hostComponent.gridData = {
                         items: [mockData[1]],
                         totalItems: 2,
-                        pageSize: 2,
-                        page: 1,
                     };
                     this.finder.detectChanges();
                     expect(this.finder.hostComponent.getSelection()).toEqual([mockData[1]]);
@@ -238,8 +232,6 @@ describe('DatagridComponent', () => {
             this.finder.hostComponent.gridData = {
                 items: mockData,
                 totalItems: 2,
-                pageSize: 2,
-                page: 1,
             };
             this.finder.detectChanges();
             expect(this.clrGridWidget.component.loading).toBe(
@@ -443,8 +435,6 @@ export class HostWithDatagridComponent {
     gridData: GridDataFetchResult<MockRecord> = {
         items: mockData,
         totalItems: 150,
-        pageSize: 2,
-        page: 1,
     };
 
     @ViewChild(DatagridComponent, { static: false }) grid!: MockRecordDatagridComponent;

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -218,9 +218,16 @@ describe('DatagridComponent', () => {
                     this.finder.detectChanges();
                     expect(this.finder.hostComponent.getSelection()).toEqual([mockData[1]]);
                 });
+            });
 
-                it('displays the proper pagination information on page one', function(this: HasFinderAndGrid): void {
+            describe('@Input() paginationCallback', () => {
+                it('displays pagination callback information on page one', function(this: HasFinderAndGrid): void {
                     expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 10 of 150 items ');
+                });
+            });
+
+            describe('@Input() paginationDropdownText', () => {
+                it('displays the pagination dropdown information on page one', function(this: HasFinderAndGrid): void {
                     expect(this.clrGridWidget.getPaginationSizeSelectorText()).toEqual('Total Items102050100');
                 });
             });

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -56,14 +56,6 @@ export interface GridDataFetchResult<R> {
      * Total number of items
      */
     totalItems?: number;
-    /**
-     * Number of the page being indexed
-     */
-    page?: number;
-    /**
-     * Size of a page
-     */
-    pageSize?: number;
 }
 
 /**

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -191,7 +191,7 @@ export class DatagridComponent<R> implements OnInit {
     /**
      * The text placed next to the pagination number dropdown.
      */
-    @Input() paginationText = 'Rows per page';
+    @Input() paginationDropdownText = '';
 
     /**
      * Fired whenever the selection changes. The event data is array of rows selected. The array will contain only one

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -421,6 +421,21 @@ export class DatagridComponent<R> implements OnInit {
     isColumnHideable(column: GridColumn<R>): boolean {
         return column && column.hideable && column.hideable !== GridColumnHideable.Never;
     }
+
+    /**
+     * Says if the number of items matches the page size.
+     */
+    sameItemsAsPageSize(): boolean {
+        return this.pagination.pageSize === this.items.length;
+    }
+
+    /**
+     * Updates the pagination data and makes the callback.
+     */
+    paginationCallbackWrapper(paginationData: ClrDatagridPagination): string {
+        return this.paginationCallback(paginationData.firstItem + 1, paginationData.lastItem + 1, this.totalItems);
+    }
+
     /**
      * Defines the {@property columnsConfig} by adding extra property required for differentiating different kinds
      * of renderers which is required in the HTML template.

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -125,6 +125,27 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Gives the pagination description text.
+     */
+    getPaginationDescription(): string {
+        return this.findElement('.pagination-description').nativeElement.textContent;
+    }
+
+    /**
+     * Gives the text next to the pagination selector.
+     */
+    getPaginationSizeSelectorText(): string {
+        return this.findElement('clr-dg-page-size').nativeElement.textContent;
+    }
+
+    /**
+     * Clicks the next page button.
+     */
+    nextPage(): void {
+        this.click('.pagination-next');
+    }
+
+    /**
      * Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that
      * subclasses should not return the DebugElement, they should return a string from a section of the HTML.
      *

--- a/projects/examples/src/components/datagrid/datagrid-css-classes.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-css-classes.example.component.ts
@@ -51,8 +51,6 @@ export class DatagridCssClassesExampleComponent {
         this.gridData = {
             items: [{ value: 'warn' }, { value: 'error' }, { value: 'ok' }, { value: 'ok' }, { value: 'error' }],
             totalItems: 2,
-            pageSize: 2,
-            page: 1,
         };
     }
 

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
@@ -37,8 +37,6 @@ export class DatagridDetailRowExampleComponent {
         this.gridData = {
             items: [{ value: 'a' }, { value: 'b' }],
             totalItems: 2,
-            pageSize: 2,
-            page: 1,
         };
     }
 }

--- a/projects/examples/src/components/datagrid/datagrid-pagination-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-pagination-example.component.ts
@@ -1,0 +1,60 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { GridDataFetchResult, GridColumn, GridState } from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+}
+
+/**
+ * A component that holds an example of the pagination capability.
+ */
+@Component({
+    selector: 'vcd-datagrid-pagination-example',
+    template: `
+        <vcd-datagrid
+            [gridData]="gridData"
+            (gridRefresh)="refresh($event)"
+            [columns]="columns"
+            [pagination]="paginationInfo"
+        >
+        </vcd-datagrid>
+    `,
+})
+export class DatagridPaginationExampleComponent {
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    paginationInfo = {
+        pageSize: 2,
+        pageSizeOptions: [2, 20, 50, 100],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Column',
+            renderer: 'value',
+        },
+    ];
+
+    refresh(eventData: GridState<Data>): void {
+        const data: Data[] = [];
+        for (let i = 1; i < 155; i++) {
+            data.push({ value: String(i) });
+        }
+        this.gridData = {
+            items: data.slice(
+                (eventData.pagination.pageNumber - 1) * eventData.pagination.itemsPerPage,
+                eventData.pagination.pageNumber * eventData.pagination.itemsPerPage
+            ),
+            totalItems: data.length,
+            pageSize: 2,
+            page: 1,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-pagination-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-pagination-example.component.ts
@@ -53,8 +53,6 @@ export class DatagridPaginationExampleComponent {
                 eventData.pagination.pageNumber * eventData.pagination.itemsPerPage
             ),
             totalItems: data.length,
-            pageSize: 2,
-            page: 1,
         };
     }
 }

--- a/projects/examples/src/components/datagrid/datagrid-pagination-example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-pagination-example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DatagridModule } from '@vcd/ui-components';
+import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
+
+@NgModule({
+    declarations: [DatagridPaginationExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    exports: [DatagridPaginationExampleComponent],
+    entryComponents: [DatagridPaginationExampleComponent],
+})
+export class DatagridPagionationExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid-row-select.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-select.example.component.ts
@@ -17,17 +17,18 @@ interface Data {
 @Component({
     selector: 'vcd-datagrid-row-select-example',
     template: `
-    <button class="btn btn-primary" (click)="selectionType = GridSelectionType.Single">Single Select</button>
-    <button class="btn btn-primary" (click)="selectionType = GridSelectionType.Multi">Multi Select Select</button>
-    <button class="btn btn-primary" (click)="selectionType = GridSelectionType.None">No Select Select</button>
-    <button class="btn btn-primary" (click)="this.newData()">New Data</button>
-    <vcd-datagrid
-        [gridData]="gridData"
-        (gridRefresh)="refresh($event)"
-        [columns]="columns"
-        [selectionType]="selectionType"
-        (selectionChanged)="selectionChanged($event)"
-    ></vcd-datagrid>`,
+        <button class="btn btn-primary" (click)="selectionType = GridSelectionType.Single">Single Select</button>
+        <button class="btn btn-primary" (click)="selectionType = GridSelectionType.Multi">Multi Select Select</button>
+        <button class="btn btn-primary" (click)="selectionType = GridSelectionType.None">No Select Select</button>
+        <button class="btn btn-primary" (click)="this.newData()">New Data</button>
+        <vcd-datagrid
+            [gridData]="gridData"
+            (gridRefresh)="refresh($event)"
+            [columns]="columns"
+            [selectionType]="selectionType"
+            (selectionChanged)="selectionChanged($event)"
+        ></vcd-datagrid>
+    `,
 })
 export class DatagridRowSelectExampleComponent {
     selectionType = GridSelectionType.Multi;
@@ -52,8 +53,6 @@ export class DatagridRowSelectExampleComponent {
         this.gridData = {
             items: [{ href: 'a' }, { href: 'b' }, { href: 'c' }],
             totalItems: 2,
-            pageSize: 2,
-            page: 1,
         };
     }
 
@@ -61,8 +60,6 @@ export class DatagridRowSelectExampleComponent {
         this.gridData = {
             items: [{ href: 'a' }, { href: 'b' }, { href: 'd' }],
             totalItems: 2,
-            pageSize: 2,
-            page: 1,
         };
     }
 }

--- a/projects/examples/src/components/datagrid/datagrid-show-hide.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-show-hide.example.component.ts
@@ -50,8 +50,6 @@ export class DatagridShowHideExampleComponent {
         this.gridData = {
             items: [{ value: 'a' }, { value: 'b' }],
             totalItems: 2,
-            pageSize: 2,
-            page: 1,
         };
     }
 }

--- a/projects/examples/src/components/datagrid/datagrid-sort.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-sort.example.component.ts
@@ -64,8 +64,6 @@ export class DatagridSortExampleComponent {
         this.gridData = {
             items: data,
             totalItems: 2,
-            pageSize: 2,
-            page: 1,
         };
     }
 }

--- a/projects/examples/src/components/datagrid/datagrid-three-renderers.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-three-renderers.example.component.ts
@@ -79,8 +79,6 @@ export class DatagridThreeRenderersExampleComponent {
         this.gridData = {
             items: mockData,
             totalItems: 2,
-            pageSize: 2,
-            page: 1,
         };
     }
 }

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -18,6 +18,8 @@ import { DatagridSortExampleModule } from './datagrid-sort.example.module';
 import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
 import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
 import { DatagridRowSelectExampleModule } from './datagrid-row-select.example.module';
+import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
+import { DatagridPagionationExampleModule } from './datagrid-pagination-example.module';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -54,6 +56,11 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Select datagrid row example',
         },
+        {
+            component: DatagridPaginationExampleComponent,
+            forComponent: null,
+            title: 'Shows the pagination capability of the datagrid',
+        },
     ],
 });
 /**
@@ -66,7 +73,8 @@ Documentation.registerDocumentationEntry({
         DatagridShowHideExampleModule,
         DatagridDetailRowExampleModule,
         DatagridSortExampleModule,
-        DatagridRowSelectExampleModule
+        DatagridRowSelectExampleModule,
+        DatagridPagionationExampleModule,
     ],
 })
 export class DatagridExamplesModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -59,7 +59,7 @@ Documentation.registerDocumentationEntry({
         {
             component: DatagridPaginationExampleComponent,
             forComponent: null,
-            title: 'Shows the pagination capability of the datagrid',
+            title: 'Pagination functionality and text customization example',
         },
     ],
 });


### PR DESCRIPTION
# Description:

Adds support for pagination to the datagrid. Allows the user to input data for the pagination type and how it should be translated. Exposes the pagination information through the gridRefresh event. 

# Testing

Added unit tests that test the input properties and the output information from gridRefresh. Also, added an example that shows a massive grid and how the pagination interacts with it. 

# Example

![pagination](https://user-images.githubusercontent.com/7528512/74749083-9aae1400-5237-11ea-83f5-af0307c6980b.gif)
