### PR TITLE
Build translations for examples in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,4 +112,4 @@ jobs:
               - npm run build-examples-doc
               - npm run generate-translations
               - ng deploy
-          if: branch = master AND repo = vmware/vmware-cloud-director-ui-components
+          if: branch = master AND repo = vmware/vmware-cloud-director-ui-components AND type != pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
               - npm run build-components-doc
               - npm run build-examples-doc
               - npm run generate-translations
+              - npm run generate-example-translations
               - npm run build:examples
 
         - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,3 +112,4 @@ jobs:
               - npm run build-examples-doc
               - npm run generate-translations
               - ng deploy
+          if: branch = master AND repo = vmware/vmware-cloud-director-ui-components


### PR DESCRIPTION
# Description

Outputs the i18n.json into the examples dist folder during the Travis stage.

# Testing

Built the app as described in the travis file and then served the examples app from a Python server and made sure the translations appeared correctly. 