### PR TITLE
Fixed deployment step for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
               - npm run build-examples-doc
               - npm run generate-translations
               - npm run generate-example-translations
-              - npm run build:examples
+              - npm run build:examples-prod
 
         - stage: test
           name: Unit tests
@@ -108,8 +108,5 @@ jobs:
         - stage: deploy
           name: Deploying to Github pages
           script:
-              - npm run build-components-doc
-              - npm run build-examples-doc
-              - npm run generate-translations
-              - ng deploy
+              - ng deploy --no-build
           if: branch = master AND repo = vmware/vmware-cloud-director-ui-components AND type != pull_request

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "//": "Requires running build: doc-lib",
     "start": "npm run build:i18n; npm run build:doc-lib; npm run build:components; npm run build:doc-lib:scripts-dev; npm run build-components-doc; npm run generate-example-translations; npm run build-examples-doc; ng serve",
     "build:examples": "ng build examples",
+    "build:examples-prod": "ng build examples --prod=true --base-href=/vmware-cloud-director-ui-components/",
     "build:examples-aot": "ng build examples --aot=true",
     "build:components": "ng build components",
     "postbuild:components": "npm run generate-translations; cp projects/components/src/assets/i18n.json dist/components/i18n.json",


### PR DESCRIPTION
# Description

Fixes the deployment process in Travis to rely on the build process rather than rebuilding in the deployment step. This allows steps like `generate-example-translations` and `build-components-doc` to only happen once.

# Testing

Changed the destination repo to point to my fork, and ran the build through travis. It deployed correctly to https://ryan-bradford.github.io/vmware-cloud-director-ui-components. 

Signed-off-by: Ryan Bradford <rbradford@vmware.com>