### PR TITLE
Implemented grid height + magic pagination

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -121,10 +121,10 @@
 
     <clr-dg-footer>
         <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [clrDgPageSize]="this.pageSize">
+            <div>{{ paginationCallbackWrapper(paginationData) }}</div>
             <clr-dg-page-size [clrPageSizeOptions]="this.pageSizeOptions">{{
                 paginationDropdownText
             }}</clr-dg-page-size>
-            {{ paginationCallbackWrapper(paginationData) }}
         </clr-dg-pagination>
     </clr-dg-footer>
 </clr-datagrid>

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,5 +1,5 @@
 <clr-datagrid [clrDgLoading]="isLoading" [ngClass]="this.clrDatagridCssClass" (clrDgRefresh)="gridStateChanged($event)">
-    <clr-dg-action-bar *ngIf="buttonConfig">
+    <clr-dg-action-bar *ngIf="shouldShowActionBar()">
         <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">
             <button
                 class="btn"
@@ -37,7 +37,11 @@
     <clr-dg-column *ngIf="shouldDisplayButtonsOnRow()" [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()">
         Actions
     </clr-dg-column>
-    <clr-dg-column *ngFor="let column of columnsConfig" [clrDgField]="column.queryFieldName" (clrDgSortOrderChange)="resetToPageOne()">
+    <clr-dg-column
+        *ngFor="let column of columnsConfig"
+        [clrDgField]="column.queryFieldName"
+        (clrDgSortOrderChange)="resetToPageOne()"
+    >
         <ng-container *ngIf="isColumnHideable(column); else notHideable">
             <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
                 column.displayName
@@ -114,11 +118,10 @@
             </clr-dg-row-detail>
         </ng-container>
     </clr-dg-row>
-    <clr-dg-row *ngIf="sameItemsAsPageSize()"> </clr-dg-row>
 
     <clr-dg-footer>
-        <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [(clrDgPageSize)]="this.pagination.pageSize">
-            <clr-dg-page-size [clrPageSizeOptions]="this.pagination.pageSizeOptions">{{
+        <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [clrDgPageSize]="this.pageSize">
+            <clr-dg-page-size [clrPageSizeOptions]="this.pageSizeOptions">{{
                 paginationDropdownText
             }}</clr-dg-page-size>
             {{ paginationCallbackWrapper(paginationData) }}

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -237,7 +237,7 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 3 of 150 items ');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 3 of 150 items');
                     });
 
                     it('allows the user to set a custom row height with magic pagination ', function(this: HasFinderAndGrid): void {
@@ -249,7 +249,7 @@ describe('DatagridComponent', () => {
                             rowHeight: 100,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 1 of 150 items ');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 1 of 150 items');
                     });
 
                     it('uses default page size when height is not set with magic pagination ', function(this: HasFinderAndGrid): void {
@@ -258,7 +258,7 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 10 of 150 items ');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 10 of 150 items');
                     });
 
                     it('lets the user set rows per page', function(this: HasFinderAndGrid): void {
@@ -267,7 +267,7 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 100 of 150 items ');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 100 of 150 items');
                     });
 
                     it('creates a smaller page when buttons are present', function(this: HasFinderAndGrid): void {
@@ -294,14 +294,14 @@ describe('DatagridComponent', () => {
                             },
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 2 of 150 items ');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 2 of 150 items');
                     });
                 });
             });
 
             describe('@Input() paginationCallback', () => {
                 it('displays pagination callback information on page one', function(this: HasFinderAndGrid): void {
-                    expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 5 of 150 items ');
+                    expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 5 of 150 items');
                 });
             });
 

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component, ViewChild, TemplateRef, ContentChild } from '@angular/core';
-import { GridSelectionType } from './datagrid.component';
+import { GridSelectionType, PaginationConfiguration } from './datagrid.component';
 import { DatagridComponent, GridDataFetchResult, GridState } from './datagrid.component';
 import {
     GridColumn,
@@ -229,7 +229,7 @@ describe('DatagridComponent', () => {
 
             describe('@Input() pagination', () => {
                 describe('pageSize', () => {
-                    it('magic pagination finds the most rows that can fit in the set height', function(this: HasFinderAndGrid): void {
+                    it('finds the most rows that can fit in the set height with magic pagination ', function(this: HasFinderAndGrid): void {
                         this.finder.hostComponent.height = 200;
                         this.finder.detectChanges();
                         this.finder.hostComponent.pagination = {
@@ -240,13 +240,25 @@ describe('DatagridComponent', () => {
                         expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 3 of 150 items ');
                     });
 
-                    it('magic pagination does nothing when height is not set', function(this: HasFinderAndGrid): void {
+                    it('allows the user to set a custom row height with magic pagination ', function(this: HasFinderAndGrid): void {
+                        this.finder.hostComponent.height = 200;
+                        this.finder.detectChanges();
+                        this.finder.hostComponent.pagination = {
+                            pageSize: 'Magic',
+                            pageSizeOptions: [10],
+                            rowHeight: 100,
+                        };
+                        this.finder.detectChanges();
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 1 of 150 items ');
+                    });
+
+                    it('uses default page size when height is not set with magic pagination ', function(this: HasFinderAndGrid): void {
                         this.finder.hostComponent.pagination = {
                             pageSize: 'Magic',
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 5 of 150 items ');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(' 1 - 10 of 150 items ');
                     });
 
                     it('lets the user set rows per page', function(this: HasFinderAndGrid): void {
@@ -736,7 +748,7 @@ export class HostWithDatagridComponent {
 
     selectionType = GridSelectionType.None;
 
-    height: number | undefined = undefined;
+    height?: number = undefined;
 
     buttonConfig: ButtonConfig<MockRecord> = {
         globalButtons: [],
@@ -752,10 +764,7 @@ export class HostWithDatagridComponent {
 
     paginationText = 'Total Items';
 
-    pagination: {
-        pageSize: number | 'Magic';
-        pageSizeOptions: number[];
-    } = {
+    pagination: PaginationConfiguration = {
         pageSize: 5,
         pageSizeOptions: [5, 20, 50, 100],
     };

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -14,6 +14,8 @@ import {
     TrackByFunction,
     ContentChild,
     ElementRef,
+    AfterViewInit,
+    AfterViewChecked,
 } from '@angular/core';
 import { ClrDatagridFilter, ClrDatagrid, ClrDatagridStateInterface, ClrDatagridPagination } from '@clr/angular';
 import {
@@ -27,6 +29,26 @@ import {
 } from './interfaces/datagrid-column.interface';
 import { ContextualButton } from './interfaces/datagrid-column.interface';
 import { ComponentRendererSpec } from './interfaces/component-renderer.interface';
+
+/**
+ * The default number of items on a single page.
+ */
+const DEFAULT_SIZE = 5;
+
+/**
+ * The default items to show in the page size dropdown.
+ */
+const DEFAULT_SIZE_OPTIONS = [DEFAULT_SIZE, 20, 50, 100];
+
+/**
+ * The maximum allowed .datagrid-header element clientHeight in pixels.
+ */
+const MAX_HEADER_HEIGHT = 40;
+
+/**
+ * The default clr-dr-row element clientHeight in pixels.
+ */
+const ROW_HEIGHT = 37;
 
 /**
  * Different types of row selection on the grid
@@ -141,7 +163,7 @@ interface ColumnConfigInternal<R, T> extends GridColumn<R> {
     templateUrl: './datagrid.component.html',
     styleUrls: ['./datagrid.component.scss'],
 })
-export class DatagridComponent<R> implements OnInit {
+export class DatagridComponent<R> implements OnInit, AfterViewInit, AfterViewChecked {
     /**
      * Sets the configuration of columns on the grid and updates the {@link columnsConfig} array
      */
@@ -171,6 +193,8 @@ export class DatagridComponent<R> implements OnInit {
         this._selectionType = selectionType;
         this.clearSelectionInformation();
     }
+
+    ROW_HEIGHT = ROW_HEIGHT;
     ContextualButtonPosition = ContextualButtonPosition;
     GridColumnHideable = GridColumnHideable;
     private _columns: GridColumn<R>[];
@@ -218,6 +242,8 @@ export class DatagridComponent<R> implements OnInit {
         return this._buttonConfig;
     }
 
+    constructor(private component: ElementRef) {}
+
     /**
      * The stored button config where inactiveDisplayMode is always non-undefined.
      */
@@ -245,16 +271,9 @@ export class DatagridComponent<R> implements OnInit {
     emptyGridPlaceholder: string;
 
     /**
-     * Inline HTML that is passed with the record/rest item as context
-     *
-     * TODO: https://jira.eng.vmware.com/browse/VDUCC-18
-     */
-    expandableRowTemplate: TemplateRef<R>;
-
-    /**
      * The pagination information that the user should supply.
      */
-    @Input() pagination: {
+    @Input() set pagination(pagination: {
         /**
          * Available page size options in the dropdown
          */
@@ -266,21 +285,51 @@ export class DatagridComponent<R> implements OnInit {
          *
          * Magic: Auto calculates the size based on available height of the container
          */
-        // TODO: implement 'Magic'
-        pageSize: number; // | 'Magic';
+        pageSize: number | 'Magic';
+    }) {
+        this._pagination = pagination;
+        this.updatePagination();
+    }
+
+    get pagination(): {
+        /**
+         * Available page size options in the dropdown
+         */
+        pageSizeOptions: number[];
+
+        /**
+         * Number of items to be displayed on one page. As a result, the server will return a set of pages with the defined
+         * number of items per page(They can be smaller than the number here in case of last page, filtering etc.,)
+         *
+         * Magic: Auto calculates the size based on available height of the container
+         */
+        pageSize: number | 'Magic';
+    } {
+        return this._pagination;
+    }
+
+    _pagination: {
+        pageSizeOptions: number[];
+        pageSize: number | 'Magic';
     } = {
-        pageSize: 10,
-        pageSizeOptions: [10, 20, 50, 100],
+        pageSize: DEFAULT_SIZE,
+        pageSizeOptions: DEFAULT_SIZE_OPTIONS,
     };
 
     /**
-     * Desired height of the grid
-     *
-     * TODO: Should we provide this option for setting the grid height and also for auto grow of the height of the grid.
-     *  Also investigate if we can set this through CSS instead of an input
-     *  The above to-do is going to be worked as part of https://jira.eng.vmware.com/browse/VDUCC-25
+     * The page size to display.
      */
-    height: number;
+    pageSize = DEFAULT_SIZE;
+
+    /**
+     * The complete set of options to show the user.
+     */
+    pageSizeOptions = DEFAULT_SIZE_OPTIONS;
+
+    /**
+     * Desired height of the grid. If unspecificed, the grid fills the parent container.
+     */
+    @Input() height: number;
 
     /**
      * Loading indicator on the grid
@@ -347,6 +396,16 @@ export class DatagridComponent<R> implements OnInit {
      */
     @Input() paginationCallback(firstItem: number, lastItem: number, totalItems: number): string {
         return `${firstItem} - ${lastItem} of ${totalItems} rows`;
+    }
+
+    /**
+     * Says if the action bar has contents to show.
+     */
+    shouldShowActionBar(): boolean {
+        return (
+            this.buttonConfig.globalButtons.length !== 0 ||
+            this.buttonConfig.contextualButtonConfig.buttons.length !== 0
+        );
     }
 
     /**
@@ -422,11 +481,6 @@ export class DatagridComponent<R> implements OnInit {
      */
     @Input() clrDatarowCssClassGetter(row: R, index: number): string {
         return '';
-    }
-
-    ngOnInit(): void {
-        this.isLoading = true;
-        this.clearSelectionInformation();
     }
 
     private updateSelectedItems(): void {
@@ -511,21 +565,17 @@ export class DatagridComponent<R> implements OnInit {
     }
 
     /**
-     * Resets the pagination to page 1.
+     * Is the given column hideable?
      */
-    resetToPageOne(): void {
-        this.paginationComponent.currentPage = 1;
-    }
-
     isColumnHideable(column: GridColumn<R>): boolean {
         return column && column.hideable && column.hideable !== GridColumnHideable.Never;
     }
 
     /**
-     * Says if the number of items matches the page size.
+     * Resets the pagination to page 1.
      */
-    sameItemsAsPageSize(): boolean {
-        return this.pagination.pageSize === this.items.length;
+    resetToPageOne(): void {
+        this.paginationComponent.currentPage = 1;
     }
 
     /**
@@ -533,6 +583,61 @@ export class DatagridComponent<R> implements OnInit {
      */
     paginationCallbackWrapper(paginationData: ClrDatagridPagination): string {
         return this.paginationCallback(paginationData.firstItem + 1, paginationData.lastItem + 1, this.totalItems);
+    }
+
+    /**
+     * The number of rows in a single page.
+     */
+    private getPageSize(): number {
+        if (typeof this.pagination.pageSize === 'number') {
+            return this.pagination.pageSize;
+        } else if (this.pagination.pageSize === 'Magic' && this.height) {
+            return this.calculatePageSize();
+        } else {
+            return DEFAULT_SIZE;
+        }
+    }
+
+    /**
+     * Available page size options in the dropdown
+     */
+    private getPageSizeOptions(): number[] {
+        let options = this.pagination.pageSizeOptions.map(size => size);
+        if (options.indexOf(this.getPageSize()) === -1) {
+            options.push(this.getPageSize());
+            options = options.sort((a, b) => a - b);
+        }
+        return options;
+    }
+
+    /**
+     *  Calculates the pageSize from the available space in the datagrid body
+     */
+    private calculatePageSize(): number {
+        const grid = this.component.nativeElement;
+
+        const headerHeight = grid.querySelector('.datagrid-header').clientHeight;
+        const rowHeight = headerHeight > MAX_HEADER_HEIGHT ? ROW_HEIGHT : headerHeight;
+
+        // Substracting the height of the header, actionbar and footer
+        let availableHeight = this.height - headerHeight - rowHeight;
+        if (this.shouldShowActionBar()) {
+            availableHeight -= rowHeight;
+        }
+
+        // Calculate the pageSize by dividing the available height by the row height.
+        const pageSize = Math.floor(availableHeight / rowHeight);
+
+        // If the calculated pageSize is less than the default, set the pageSize to the default one.
+        return pageSize;
+    }
+
+    /**
+     * Updates the pagination information by recalculating pageSize if needed.
+     */
+    private updatePagination(): void {
+        this.pageSize = this.getPageSize();
+        this.pageSizeOptions = this.getPageSizeOptions();
     }
 
     /**
@@ -555,5 +660,19 @@ export class DatagridComponent<R> implements OnInit {
 
             return columnConfig;
         });
+    }
+
+    ngOnInit(): void {
+        this.isLoading = true;
+        this.clearSelectionInformation();
+    }
+
+    ngAfterViewInit(): void {
+        this.updatePagination();
+    }
+
+    ngAfterViewChecked(): void {
+        this.component.nativeElement.querySelector('clr-datagrid').style =
+            'height: ' + (this.height ? this.height + 'px' : '100%');
     }
 }

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -305,7 +305,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit, AfterViewChe
         return this._pagination;
     }
 
-    _pagination: PaginationConfiguration = {
+    private _pagination: PaginationConfiguration = {
         pageSize: DEFAULT_SIZE,
         pageSizeOptions: DEFAULT_SIZE_OPTIONS,
     };

--- a/projects/components/src/datagrid/datagrid.module.ts
+++ b/projects/components/src/datagrid/datagrid.module.ts
@@ -16,13 +16,13 @@ import { BoldTextRendererComponent } from './renderers/bold-text-renderer.compon
 import { RouterModule } from '@angular/router';
 import { CliptextModule } from '../cliptext/cliptext.module';
 
-const directives = [DatagridComponent, ComponentRendererOutletDirective];
+const directives = [ComponentRendererOutletDirective];
 const pipes = [FunctionRendererPipe];
 const renderers = [BoldTextRendererComponent, LinkedTextRendererComponent];
 
 @NgModule({
     imports: [CommonModule, ClarityModule, RouterModule, PipesModule, ReactiveFormsModule, CliptextModule],
-    declarations: [...directives, ...renderers, ...pipes],
+    declarations: [DatagridComponent, ...directives, ...renderers, ...pipes],
     providers: [],
     exports: [DatagridComponent, ...renderers],
     entryComponents: [...renderers],

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -174,6 +174,14 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Gives the height CSS of this clr-datagrid.
+     */
+    getGridHeight(): string {
+        const datagrid = this.findElement(ClrDatagridWidgetObject.tagName);
+        return this.root.nativeElement.style.height;
+    }
+
+    /**
      * Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that
      * subclasses should not return the DebugElement, they should return a string from a section of the HTML.
      *

--- a/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { GridDataFetchResult, GridColumn, GridState } from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+}
+
+/**
+ * A component that holds an example of setting the height on the datagrid.
+ */
+@Component({
+    selector: 'vcd-datagrid-height-example',
+    template: `
+        <div style="height:300px">
+            <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns"> </vcd-datagrid>
+        </div>
+        <div style="height:300px">
+            <vcd-datagrid
+                [gridData]="gridData"
+                (gridRefresh)="refresh($event)"
+                [columns]="columns"
+                [height]="150"
+                [pagination]="pagination"
+            >
+            </vcd-datagrid>
+            <h3>Ends Here!</h3>
+        </div>
+    `,
+})
+export class DatagridHeightExampleComponent {
+    pagination = {
+        pageSize: 'Magic',
+        pageSizeOptions: [10],
+    };
+
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Column',
+            renderer: 'value',
+        },
+    ];
+
+    refresh(eventData: GridState<Data>): void {
+        this.gridData = {
+            items: [{ value: 'a' }, { value: 'b' }],
+            totalItems: 2,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { GridDataFetchResult, GridColumn, GridState } from '@vcd/ui-components';
+import { GridDataFetchResult, GridColumn, GridState, PaginationConfiguration } from '@vcd/ui-components';
 
 interface Data {
     value: string;
@@ -33,7 +33,7 @@ interface Data {
     `,
 })
 export class DatagridHeightExampleComponent {
-    pagination = {
+    pagination: PaginationConfiguration = {
         pageSize: 'Magic',
         pageSizeOptions: [10],
     };

--- a/projects/examples/src/components/datagrid/datagrid-height.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DatagridModule } from '@vcd/ui-components';
+import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
+
+@NgModule({
+    declarations: [DatagridHeightExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    exports: [DatagridHeightExampleComponent],
+    entryComponents: [DatagridHeightExampleComponent],
+})
+export class DatagridHeightExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid-pagination-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-pagination-example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { GridDataFetchResult, GridColumn, GridState } from '@vcd/ui-components';
+import { GridDataFetchResult, GridColumn, GridState, PaginationConfiguration } from '@vcd/ui-components';
 
 interface Data {
     value: string;
@@ -30,7 +30,7 @@ export class DatagridPaginationExampleComponent {
         items: [],
     };
 
-    paginationInfo = {
+    paginationInfo: PaginationConfiguration = {
         pageSize: 2,
         pageSizeOptions: [2, 20, 50, 100],
     };

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -22,6 +22,8 @@ import { DatagridPaginationExampleComponent } from './datagrid-pagination-exampl
 import { DatagridPagionationExampleModule } from './datagrid-pagination-example.module';
 import { DatagridLinkExampleModule } from './datagrid-link.example.module';
 import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
+import { DatagridHeightExampleModule } from './datagrid-height.example.module';
+import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -68,6 +70,11 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Links from Datagrid Example',
         },
+        {
+            component: DatagridHeightExampleComponent,
+            forComponent: null,
+            title: 'Setting height on the datagrid.',
+        },
     ],
 });
 /**
@@ -82,7 +89,8 @@ Documentation.registerDocumentationEntry({
         DatagridSortExampleModule,
         DatagridRowSelectExampleModule,
         DatagridPagionationExampleModule,
-        DatagridLinkExampleModule
+        DatagridLinkExampleModule,
+        DatagridHeightExampleModule,
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
# Description:

Allows the user to set the desired height of their datagrid. If the height is set, the datagrid (all parts included) will be limited to the given height. If the height is not set, the datagrid will fill to expand the parent. If the parents height is not fixed, the datagrid will grow to the necessary size.

Also, added the "Magic" page size option. This will calculate the optimal page size given the height of the datagrid. If the height is not set, it will not attempt to calculate the page size, and will instead default to 5.

# Testing:

Added unit tests to test both the grid height input and the "Magic" pagination setting. Also, added an example to show the datagrid filling up the whole parent container, and an example showing the datagrid being limited to it's set height and calculating the correct page size amount.

<img width="1327" alt="Screen Shot 2020-03-02 at 3 15 30 PM" src="https://user-images.githubusercontent.com/7528512/75715792-ff3b8b00-5c9b-11ea-8a0d-4aeff1aedd45.png">
