### PR TITLE
Allows the user to set a header on the datagrid

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,134 +1,141 @@
-<h3 *ngIf="this.header">{{ header }}</h3>
-<clr-datagrid [clrDgLoading]="isLoading" [ngClass]="this.clrDatagridCssClass" (clrDgRefresh)="gridStateChanged($event)">
-    <clr-dg-action-bar *ngIf="shouldShowActionBar()">
-        <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">
-            <button
-                class="btn"
-                [ngClass]="button.class"
-                *ngIf="isButtonShown(button)"
-                (click)="button.handler()"
-                [disabled]="isButtonDisabled(button, button.isActive())"
-            >
-                <ng-container>{{ button.label }}</ng-container>
-            </button>
-        </div>
-
-        <ng-container *ngIf="shouldDisplayButtonsOnTop()">
-            <div class="btn-group" *ngIf="this.getFeaturedButtons().length !== 0">
+<div class="vcd-datagrid">
+    <h3 *ngIf="this.header" class="vcd-header">{{ header }}</h3>
+    <clr-datagrid
+        [clrDgLoading]="isLoading"
+        [ngClass]="this.clrDatagridCssClass"
+        (clrDgRefresh)="gridStateChanged($event)"
+        class="clr-datagrid"
+    >
+        <clr-dg-action-bar *ngIf="shouldShowActionBar()">
+            <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">
                 <button
-                    *ngFor="let button of this.getFeaturedButtons()"
-                    type="button"
-                    class="btn btn-icon"
-                    (click)="button.handler(datagridSelection)"
-                    [disabled]="isButtonDisabled(button, button.isActive(datagridSelection))"
+                    class="btn"
+                    [ngClass]="button.class"
+                    *ngIf="isButtonShown(button)"
+                    (click)="button.handler()"
+                    [disabled]="isButtonDisabled(button, button.isActive())"
                 >
-                    <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
-                        <clr-icon [attr.shape]="button.icon"></clr-icon>
-                        <span class="tooltip-content">{{ button.label }}</span>
-                    </a>
+                    <ng-container>{{ button.label }}</ng-container>
                 </button>
-                <ng-container *ngTemplateOutlet="dropdown"></ng-container>
             </div>
-            <ng-container *ngIf="this.getFeaturedButtons().length === 0">
-                <ng-container *ngTemplateOutlet="dropdown"></ng-container>
-            </ng-container>
-        </ng-container>
-    </clr-dg-action-bar>
 
-    <clr-dg-column *ngIf="shouldDisplayButtonsOnRow()" [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()">
-        Actions
-    </clr-dg-column>
-    <clr-dg-column
-        *ngFor="let column of columnsConfig"
-        [clrDgField]="column.queryFieldName"
-        (clrDgSortOrderChange)="resetToPageOne()"
-    >
-        <ng-container *ngIf="isColumnHideable(column); else notHideable">
-            <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
-                column.displayName
-            }}</ng-container>
-        </ng-container>
-        <ng-template #notHideable>{{ column.displayName }}</ng-template>
-    </clr-dg-column>
-
-    <clr-dg-row
-        *ngFor="let restItem of items; let i = index"
-        [ngForTrackBy]="trackBy"
-        [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
-        [clrDgItem]="restItem"
-    >
-        <clr-dg-cell
-            *ngIf="shouldDisplayButtonsOnRow()"
-            class="action-button-cell"
-            [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()"
-        >
-            <div class="btn-group action-button-group">
-                <button
-                    class="btn btn-icon action-button"
-                    *ngFor="let button of this.getFeaturedButtons(restItem)"
-                    (click)="button.handler([restItem])"
-                    [disabled]="isButtonDisabled(button, button.isActive([restItem]))"
-                >
-                    <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
-                        <clr-icon size="1em" [attr.shape]="button.icon" class="action-icon"></clr-icon>
-                        <span class="tooltip-content">{{ button.label }}</span>
-                    </a>
-                </button>
-                <clr-dropdown
-                    class="btn-group-overflow open action-button"
-                    *ngIf="buttonConfig.contextualButtonConfig.buttons.length !== 0"
-                >
-                    <button class="btn action-button dropdown-small" clrDropdownTrigger>
-                        <clr-icon shape="ellipsis-horizontal action-icon"></clr-icon>
+            <ng-container *ngIf="shouldDisplayButtonsOnTop()">
+                <div class="btn-group" *ngIf="this.getFeaturedButtons().length !== 0">
+                    <button
+                        *ngFor="let button of this.getFeaturedButtons()"
+                        type="button"
+                        class="btn btn-icon"
+                        (click)="button.handler(datagridSelection)"
+                        [disabled]="isButtonDisabled(button, button.isActive(datagridSelection))"
+                    >
+                        <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
+                            <clr-icon [attr.shape]="button.icon"></clr-icon>
+                            <span class="tooltip-content">{{ button.label }}</span>
+                        </a>
                     </button>
-                    <clr-dropdown-menu class="dropdown-menu" *clrIfOpen>
-                        <ng-container *ngFor="let button of buttonConfig.contextualButtonConfig.buttons">
-                            <button
-                                class="btn"
-                                [ngClass]="button.class"
-                                [disabled]="!button.isActive([restItem])"
-                                (click)="button.handler([restItem])"
-                            >
-                                {{ button.label }}
-                            </button>
-                        </ng-container>
-                    </clr-dropdown-menu>
-                </clr-dropdown>
-            </div>
-        </clr-dg-cell>
+                    <ng-container *ngTemplateOutlet="dropdown"></ng-container>
+                </div>
+                <ng-container *ngIf="this.getFeaturedButtons().length === 0">
+                    <ng-container *ngTemplateOutlet="dropdown"></ng-container>
+                </ng-container>
+            </ng-container>
+        </clr-dg-action-bar>
 
-        <clr-dg-cell *ngFor="let column of columnsConfig">
-            <!-- Default renderer -->
-            <ng-container *ngIf="column.fieldName">{{ restItem | nestedProperty: column.fieldName }}</ng-container>
+        <clr-dg-column *ngIf="shouldDisplayButtonsOnRow()" [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()">
+            Actions
+        </clr-dg-column>
+        <clr-dg-column
+            *ngFor="let column of columnsConfig"
+            [clrDgField]="column.queryFieldName"
+            (clrDgSortOrderChange)="resetToPageOne()"
+        >
+            <ng-container *ngIf="isColumnHideable(column); else notHideable">
+                <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
+                    column.displayName
+                }}</ng-container>
+            </ng-container>
+            <ng-template #notHideable>{{ column.displayName }}</ng-template>
+        </clr-dg-column>
 
-            <!-- Renderer is a function -->
-            <ng-container *ngIf="column.fieldRenderer">{{
-                restItem | functionRenderer: column.fieldRenderer
-            }}</ng-container>
-
-            <!-- Renderer is a componentRenderer -->
-            <ng-template
-                *ngIf="column.fieldColumnRendererSpec"
-                [vcdComponentRendererOutlet]="{ rendererSpec: column.fieldColumnRendererSpec, context: restItem }"
+        <clr-dg-row
+            *ngFor="let restItem of items; let i = index"
+            [ngForTrackBy]="trackBy"
+            [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
+            [clrDgItem]="restItem"
+        >
+            <clr-dg-cell
+                *ngIf="shouldDisplayButtonsOnRow()"
+                class="action-button-cell"
+                [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()"
             >
-            </ng-template>
-        </clr-dg-cell>
-        <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="detailTemplate !== undefined">
-            <clr-dg-row-detail *clrIfExpanded>
-                <ng-content *ngTemplateOutlet="detailTemplate; context: { record: restItem }"> </ng-content>
-            </clr-dg-row-detail>
-        </ng-container>
-    </clr-dg-row>
+                <div class="btn-group action-button-group">
+                    <button
+                        class="btn btn-icon action-button"
+                        *ngFor="let button of this.getFeaturedButtons(restItem)"
+                        (click)="button.handler([restItem])"
+                        [disabled]="isButtonDisabled(button, button.isActive([restItem]))"
+                    >
+                        <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
+                            <clr-icon size="1em" [attr.shape]="button.icon" class="action-icon"></clr-icon>
+                            <span class="tooltip-content">{{ button.label }}</span>
+                        </a>
+                    </button>
+                    <clr-dropdown
+                        class="btn-group-overflow open action-button"
+                        *ngIf="buttonConfig.contextualButtonConfig.buttons.length !== 0"
+                    >
+                        <button class="btn action-button dropdown-small" clrDropdownTrigger>
+                            <clr-icon shape="ellipsis-horizontal action-icon"></clr-icon>
+                        </button>
+                        <clr-dropdown-menu class="dropdown-menu" *clrIfOpen>
+                            <ng-container *ngFor="let button of buttonConfig.contextualButtonConfig.buttons">
+                                <button
+                                    class="btn"
+                                    [ngClass]="button.class"
+                                    [disabled]="!button.isActive([restItem])"
+                                    (click)="button.handler([restItem])"
+                                >
+                                    {{ button.label }}
+                                </button>
+                            </ng-container>
+                        </clr-dropdown-menu>
+                    </clr-dropdown>
+                </div>
+            </clr-dg-cell>
 
-    <clr-dg-footer>
-        <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [clrDgPageSize]="this.pageSize">
-            <div>{{ paginationCallbackWrapper(paginationData) }}</div>
-            <clr-dg-page-size [clrPageSizeOptions]="this.pageSizeOptions">{{
-                paginationDropdownText
-            }}</clr-dg-page-size>
-        </clr-dg-pagination>
-    </clr-dg-footer>
-</clr-datagrid>
+            <clr-dg-cell *ngFor="let column of columnsConfig">
+                <!-- Default renderer -->
+                <ng-container *ngIf="column.fieldName">{{ restItem | nestedProperty: column.fieldName }}</ng-container>
+
+                <!-- Renderer is a function -->
+                <ng-container *ngIf="column.fieldRenderer">{{
+                    restItem | functionRenderer: column.fieldRenderer
+                }}</ng-container>
+
+                <!-- Renderer is a componentRenderer -->
+                <ng-template
+                    *ngIf="column.fieldColumnRendererSpec"
+                    [vcdComponentRendererOutlet]="{ rendererSpec: column.fieldColumnRendererSpec, context: restItem }"
+                >
+                </ng-template>
+            </clr-dg-cell>
+            <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="detailTemplate !== undefined">
+                <clr-dg-row-detail *clrIfExpanded>
+                    <ng-content *ngTemplateOutlet="detailTemplate; context: { record: restItem }"> </ng-content>
+                </clr-dg-row-detail>
+            </ng-container>
+        </clr-dg-row>
+
+        <clr-dg-footer>
+            <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [clrDgPageSize]="this.pageSize">
+                <div>{{ paginationCallbackWrapper(paginationData) }}</div>
+                <clr-dg-page-size [clrPageSizeOptions]="this.pageSizeOptions">{{
+                    paginationDropdownText
+                }}</clr-dg-page-size>
+            </clr-dg-pagination>
+        </clr-dg-footer>
+    </clr-datagrid>
+</div>
 
 <ng-template #dropdown>
     <clr-dropdown class="btn-group-overflow open" *ngIf="hasContextualButtons()">

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,3 +1,4 @@
+<h3 *ngIf="this.header">{{ header }}</h3>
 <clr-datagrid [clrDgLoading]="isLoading" [ngClass]="this.clrDatagridCssClass" (clrDgRefresh)="gridStateChanged($event)">
     <clr-dg-action-bar *ngIf="shouldShowActionBar()">
         <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,9 +1,8 @@
 <h3 *ngIf="this.header" class="vcd-header">{{ header }}</h3>
 <clr-datagrid
     [clrDgLoading]="isLoading"
-    [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent']"
+    [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent-grid']"
     (clrDgRefresh)="gridStateChanged($event)"
-    class="clr-datagrid"
 >
     <clr-dg-action-bar *ngIf="shouldShowActionBar()">
         <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,141 +1,139 @@
-<div class="vcd-datagrid">
-    <h3 *ngIf="this.header" class="vcd-header">{{ header }}</h3>
-    <clr-datagrid
-        [clrDgLoading]="isLoading"
-        [ngClass]="this.clrDatagridCssClass"
-        (clrDgRefresh)="gridStateChanged($event)"
-        class="clr-datagrid"
-    >
-        <clr-dg-action-bar *ngIf="shouldShowActionBar()">
-            <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">
-                <button
-                    class="btn"
-                    [ngClass]="button.class"
-                    *ngIf="isButtonShown(button)"
-                    (click)="button.handler()"
-                    [disabled]="isButtonDisabled(button, button.isActive())"
-                >
-                    <ng-container>{{ button.label }}</ng-container>
-                </button>
-            </div>
-
-            <ng-container *ngIf="shouldDisplayButtonsOnTop()">
-                <div class="btn-group" *ngIf="this.getFeaturedButtons().length !== 0">
-                    <button
-                        *ngFor="let button of this.getFeaturedButtons()"
-                        type="button"
-                        class="btn btn-icon"
-                        (click)="button.handler(datagridSelection)"
-                        [disabled]="isButtonDisabled(button, button.isActive(datagridSelection))"
-                    >
-                        <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
-                            <clr-icon [attr.shape]="button.icon"></clr-icon>
-                            <span class="tooltip-content">{{ button.label }}</span>
-                        </a>
-                    </button>
-                    <ng-container *ngTemplateOutlet="dropdown"></ng-container>
-                </div>
-                <ng-container *ngIf="this.getFeaturedButtons().length === 0">
-                    <ng-container *ngTemplateOutlet="dropdown"></ng-container>
-                </ng-container>
-            </ng-container>
-        </clr-dg-action-bar>
-
-        <clr-dg-column *ngIf="shouldDisplayButtonsOnRow()" [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()">
-            Actions
-        </clr-dg-column>
-        <clr-dg-column
-            *ngFor="let column of columnsConfig"
-            [clrDgField]="column.queryFieldName"
-            (clrDgSortOrderChange)="resetToPageOne()"
-        >
-            <ng-container *ngIf="isColumnHideable(column); else notHideable">
-                <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
-                    column.displayName
-                }}</ng-container>
-            </ng-container>
-            <ng-template #notHideable>{{ column.displayName }}</ng-template>
-        </clr-dg-column>
-
-        <clr-dg-row
-            *ngFor="let restItem of items; let i = index"
-            [ngForTrackBy]="trackBy"
-            [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
-            [clrDgItem]="restItem"
-        >
-            <clr-dg-cell
-                *ngIf="shouldDisplayButtonsOnRow()"
-                class="action-button-cell"
-                [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()"
+<h3 *ngIf="this.header" class="vcd-header">{{ header }}</h3>
+<clr-datagrid
+    [clrDgLoading]="isLoading"
+    [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent']"
+    (clrDgRefresh)="gridStateChanged($event)"
+    class="clr-datagrid"
+>
+    <clr-dg-action-bar *ngIf="shouldShowActionBar()">
+        <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">
+            <button
+                class="btn"
+                [ngClass]="button.class"
+                *ngIf="isButtonShown(button)"
+                (click)="button.handler()"
+                [disabled]="isButtonDisabled(button, button.isActive())"
             >
-                <div class="btn-group action-button-group">
-                    <button
-                        class="btn btn-icon action-button"
-                        *ngFor="let button of this.getFeaturedButtons(restItem)"
-                        (click)="button.handler([restItem])"
-                        [disabled]="isButtonDisabled(button, button.isActive([restItem]))"
-                    >
-                        <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
-                            <clr-icon size="1em" [attr.shape]="button.icon" class="action-icon"></clr-icon>
-                            <span class="tooltip-content">{{ button.label }}</span>
-                        </a>
-                    </button>
-                    <clr-dropdown
-                        class="btn-group-overflow open action-button"
-                        *ngIf="buttonConfig.contextualButtonConfig.buttons.length !== 0"
-                    >
-                        <button class="btn action-button dropdown-small" clrDropdownTrigger>
-                            <clr-icon shape="ellipsis-horizontal action-icon"></clr-icon>
-                        </button>
-                        <clr-dropdown-menu class="dropdown-menu" *clrIfOpen>
-                            <ng-container *ngFor="let button of buttonConfig.contextualButtonConfig.buttons">
-                                <button
-                                    class="btn"
-                                    [ngClass]="button.class"
-                                    [disabled]="!button.isActive([restItem])"
-                                    (click)="button.handler([restItem])"
-                                >
-                                    {{ button.label }}
-                                </button>
-                            </ng-container>
-                        </clr-dropdown-menu>
-                    </clr-dropdown>
-                </div>
-            </clr-dg-cell>
+                <ng-container>{{ button.label }}</ng-container>
+            </button>
+        </div>
 
-            <clr-dg-cell *ngFor="let column of columnsConfig">
-                <!-- Default renderer -->
-                <ng-container *ngIf="column.fieldName">{{ restItem | nestedProperty: column.fieldName }}</ng-container>
-
-                <!-- Renderer is a function -->
-                <ng-container *ngIf="column.fieldRenderer">{{
-                    restItem | functionRenderer: column.fieldRenderer
-                }}</ng-container>
-
-                <!-- Renderer is a componentRenderer -->
-                <ng-template
-                    *ngIf="column.fieldColumnRendererSpec"
-                    [vcdComponentRendererOutlet]="{ rendererSpec: column.fieldColumnRendererSpec, context: restItem }"
+        <ng-container *ngIf="shouldDisplayButtonsOnTop()">
+            <div class="btn-group" *ngIf="this.getFeaturedButtons().length !== 0">
+                <button
+                    *ngFor="let button of this.getFeaturedButtons()"
+                    type="button"
+                    class="btn btn-icon"
+                    (click)="button.handler(datagridSelection)"
+                    [disabled]="isButtonDisabled(button, button.isActive(datagridSelection))"
                 >
-                </ng-template>
-            </clr-dg-cell>
-            <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="detailTemplate !== undefined">
-                <clr-dg-row-detail *clrIfExpanded>
-                    <ng-content *ngTemplateOutlet="detailTemplate; context: { record: restItem }"> </ng-content>
-                </clr-dg-row-detail>
+                    <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
+                        <clr-icon [attr.shape]="button.icon"></clr-icon>
+                        <span class="tooltip-content">{{ button.label }}</span>
+                    </a>
+                </button>
+                <ng-container *ngTemplateOutlet="dropdown"></ng-container>
+            </div>
+            <ng-container *ngIf="this.getFeaturedButtons().length === 0">
+                <ng-container *ngTemplateOutlet="dropdown"></ng-container>
             </ng-container>
-        </clr-dg-row>
+        </ng-container>
+    </clr-dg-action-bar>
 
-        <clr-dg-footer>
-            <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [clrDgPageSize]="this.pageSize">
-                <div>{{ paginationCallbackWrapper(paginationData) }}</div>
-                <clr-dg-page-size [clrPageSizeOptions]="this.pageSizeOptions">{{
-                    paginationDropdownText
-                }}</clr-dg-page-size>
-            </clr-dg-pagination>
-        </clr-dg-footer>
-    </clr-datagrid>
-</div>
+    <clr-dg-column *ngIf="shouldDisplayButtonsOnRow()" [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()">
+        Actions
+    </clr-dg-column>
+    <clr-dg-column
+        *ngFor="let column of columnsConfig"
+        [clrDgField]="column.queryFieldName"
+        (clrDgSortOrderChange)="resetToPageOne()"
+    >
+        <ng-container *ngIf="isColumnHideable(column); else notHideable">
+            <ng-container *clrDgHideableColumn="{ hidden: column.hideable === GridColumnHideable.Hidden }">{{
+                column.displayName
+            }}</ng-container>
+        </ng-container>
+        <ng-template #notHideable>{{ column.displayName }}</ng-template>
+    </clr-dg-column>
+
+    <clr-dg-row
+        *ngFor="let restItem of items; let i = index"
+        [ngForTrackBy]="trackBy"
+        [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
+        [clrDgItem]="restItem"
+    >
+        <clr-dg-cell
+            *ngIf="shouldDisplayButtonsOnRow()"
+            class="action-button-cell"
+            [ngClass]="'buttons-' + this.getMaxFeaturedButtonsOnRow()"
+        >
+            <div class="btn-group action-button-group">
+                <button
+                    class="btn btn-icon action-button"
+                    *ngFor="let button of this.getFeaturedButtons(restItem)"
+                    (click)="button.handler([restItem])"
+                    [disabled]="isButtonDisabled(button, button.isActive([restItem]))"
+                >
+                    <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
+                        <clr-icon size="1em" [attr.shape]="button.icon" class="action-icon"></clr-icon>
+                        <span class="tooltip-content">{{ button.label }}</span>
+                    </a>
+                </button>
+                <clr-dropdown
+                    class="btn-group-overflow open action-button"
+                    *ngIf="buttonConfig.contextualButtonConfig.buttons.length !== 0"
+                >
+                    <button class="btn action-button dropdown-small" clrDropdownTrigger>
+                        <clr-icon shape="ellipsis-horizontal action-icon"></clr-icon>
+                    </button>
+                    <clr-dropdown-menu class="dropdown-menu" *clrIfOpen>
+                        <ng-container *ngFor="let button of buttonConfig.contextualButtonConfig.buttons">
+                            <button
+                                class="btn"
+                                [ngClass]="button.class"
+                                [disabled]="!button.isActive([restItem])"
+                                (click)="button.handler([restItem])"
+                            >
+                                {{ button.label }}
+                            </button>
+                        </ng-container>
+                    </clr-dropdown-menu>
+                </clr-dropdown>
+            </div>
+        </clr-dg-cell>
+
+        <clr-dg-cell *ngFor="let column of columnsConfig">
+            <!-- Default renderer -->
+            <ng-container *ngIf="column.fieldName">{{ restItem | nestedProperty: column.fieldName }}</ng-container>
+
+            <!-- Renderer is a function -->
+            <ng-container *ngIf="column.fieldRenderer">{{
+                restItem | functionRenderer: column.fieldRenderer
+            }}</ng-container>
+
+            <!-- Renderer is a componentRenderer -->
+            <ng-template
+                *ngIf="column.fieldColumnRendererSpec"
+                [vcdComponentRendererOutlet]="{ rendererSpec: column.fieldColumnRendererSpec, context: restItem }"
+            >
+            </ng-template>
+        </clr-dg-cell>
+        <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="detailTemplate !== undefined">
+            <clr-dg-row-detail *clrIfExpanded>
+                <ng-content *ngTemplateOutlet="detailTemplate; context: { record: restItem }"> </ng-content>
+            </clr-dg-row-detail>
+        </ng-container>
+    </clr-dg-row>
+
+    <clr-dg-footer>
+        <clr-dg-pagination #paginationData [clrDgTotalItems]="totalItems" [clrDgPageSize]="this.pageSize">
+            <div>{{ paginationCallbackWrapper(paginationData) }}</div>
+            <clr-dg-page-size [clrPageSizeOptions]="this.pageSizeOptions">{{
+                paginationDropdownText
+            }}</clr-dg-page-size>
+        </clr-dg-pagination>
+    </clr-dg-footer>
+</clr-datagrid>
 
 <ng-template #dropdown>
     <clr-dropdown class="btn-group-overflow open" *ngIf="hasContextualButtons()">

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -27,10 +27,15 @@ $supported-buttons: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
     }
 }
 
-.fill-parent {
+// The height properties need to be marked as important because of a bug in Clarity
+// where when the page size is the same as the number of items in the datagrid
+// the datagrid height will get set to 0
+
+.fill-parent-grid {
     flex: 1;
     display: flex;
     flex-direction: column;
+    height: unset !important;
 }
 
 .set-height {

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -19,6 +19,19 @@ $supported-buttons: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
     }
 }
 
+.vcd-datagrid {
+    flex-direction: column;
+    display: flex;
+}
+
+.clr-datagrid {
+    flex: 1 1 auto;
+}
+
+.vcd-header {
+    flex: 0 1 auto;
+}
+
 .action-button-cell {
     padding-top: $PADDING;
     padding-bottom: $PADDING;

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -19,13 +19,22 @@ $supported-buttons: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
     }
 }
 
-.vcd-datagrid {
-    flex-direction: column;
-    display: flex;
+:host {
+    &.fill-parent {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+    }
 }
 
-.clr-datagrid {
-    flex: 1 1 auto;
+.fill-parent {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.set-height {
+    height: var(--datagrid-height) !important;
 }
 
 .vcd-header {

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -669,6 +669,23 @@ describe('DatagridComponent', () => {
                 });
             });
         });
+
+        describe('@Input() header', () => {
+            it('shows the header if set and allows it to be changed', function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.header = 'Some Header!';
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.getGridHeader()).toEqual('Some Header!');
+                this.finder.hostComponent.header = 'Some Other Header!';
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.getGridHeader()).toEqual('Some Other Header!');
+            });
+
+            it('does not show a header when none is set', function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.header = undefined;
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.getGridHeader()).toEqual(undefined);
+            });
+        });
     });
 
     describe('Column Renderers', () => {
@@ -728,6 +745,7 @@ describe('DatagridComponent', () => {
             [pagination]="pagination"
             [buttonConfig]="buttonConfig"
             [height]="height"
+            [header]="header"
         >
             <ng-template let-record="record"> DETAILS: {{ record.name }} </ng-template>
         </vcd-datagrid>
@@ -749,6 +767,8 @@ export class HostWithDatagridComponent {
     selectionType = GridSelectionType.None;
 
     height?: number = undefined;
+
+    header?: string = undefined;
 
     buttonConfig: ButtonConfig<MockRecord> = {
         globalButtons: [],

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -315,13 +315,26 @@ describe('DatagridComponent', () => {
                 it('defaults to parent height when height is not set', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridHeight()).toEqual('100%');
+                    expect(this.clrGridWidget.getGridContainerHeight()).toEqual('100%');
+                    expect(this.clrGridWidget.getGridHeight()).toEqual('unset');
                 });
 
                 it('uses the given height when height is set', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.height = 200;
                     this.finder.detectChanges();
+                    expect(this.clrGridWidget.getGridContainerHeight()).toEqual('unset');
                     expect(this.clrGridWidget.getGridHeight()).toEqual('200px');
+                });
+
+                it('allows the height to be dynamically changed', function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.height = 200;
+                    this.finder.detectChanges();
+                    expect(this.clrGridWidget.getGridContainerHeight()).toEqual('unset');
+                    expect(this.clrGridWidget.getGridHeight()).toEqual('200px');
+                    this.finder.hostComponent.height = undefined;
+                    this.finder.detectChanges();
+                    expect(this.clrGridWidget.getGridContainerHeight()).toEqual('100%');
+                    expect(this.clrGridWidget.getGridHeight()).toEqual('unset');
                 });
             });
         });

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -315,25 +315,23 @@ describe('DatagridComponent', () => {
                 it('defaults to parent height when height is not set', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridContainerHeight()).toEqual('100%');
+                    expect(this.clrGridWidget.getGridContainerClasses()).toContain('fill-parent');
                     expect(this.clrGridWidget.getGridHeight()).toEqual('unset');
                 });
 
                 it('uses the given height when height is set', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridContainerHeight()).toEqual('unset');
                     expect(this.clrGridWidget.getGridHeight()).toEqual('200px');
                 });
 
                 it('allows the height to be dynamically changed', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridContainerHeight()).toEqual('unset');
                     expect(this.clrGridWidget.getGridHeight()).toEqual('200px');
                     this.finder.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridContainerHeight()).toEqual('100%');
+                    expect(this.clrGridWidget.getGridContainerClasses()).toContain('fill-parent');
                     expect(this.clrGridWidget.getGridHeight()).toEqual('unset');
                 });
             });

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -315,24 +315,24 @@ describe('DatagridComponent', () => {
                 it('defaults to parent height when height is not set', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridContainerClasses()).toContain('fill-parent');
-                    expect(this.clrGridWidget.getGridHeight()).toEqual('unset');
+                    expect(this.clrGridWidget.gridContainerClasses).toContain('fill-parent');
+                    expect(this.clrGridWidget.gridHeight).toEqual('unset');
                 });
 
                 it('uses the given height when height is set', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridHeight()).toEqual('200px');
+                    expect(this.clrGridWidget.gridHeight).toEqual('200px');
                 });
 
                 it('allows the height to be dynamically changed', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridHeight()).toEqual('200px');
+                    expect(this.clrGridWidget.gridHeight).toEqual('200px');
                     this.finder.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getGridContainerClasses()).toContain('fill-parent');
-                    expect(this.clrGridWidget.getGridHeight()).toEqual('unset');
+                    expect(this.clrGridWidget.gridContainerClasses).toContain('fill-parent');
+                    expect(this.clrGridWidget.gridHeight).toEqual('unset');
                 });
             });
         });
@@ -685,16 +685,16 @@ describe('DatagridComponent', () => {
             it('shows the header if set and allows it to be changed', function(this: HasFinderAndGrid): void {
                 this.finder.hostComponent.header = 'Some Header!';
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getGridHeader()).toEqual('Some Header!');
+                expect(this.clrGridWidget.gridHeader).toEqual('Some Header!');
                 this.finder.hostComponent.header = 'Some Other Header!';
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getGridHeader()).toEqual('Some Other Header!');
+                expect(this.clrGridWidget.gridHeader).toEqual('Some Other Header!');
             });
 
             it('does not show a header when none is set', function(this: HasFinderAndGrid): void {
                 this.finder.hostComponent.header = undefined;
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getGridHeader()).toEqual(undefined);
+                expect(this.clrGridWidget.gridHeader).toEqual(undefined);
             });
         });
     });
@@ -777,9 +777,9 @@ export class HostWithDatagridComponent {
 
     selectionType = GridSelectionType.None;
 
-    height?: number = undefined;
+    height?: number;
 
-    header?: string = undefined;
+    header?: string;
 
     buttonConfig: ButtonConfig<MockRecord> = {
         globalButtons: [],

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -189,6 +189,12 @@ interface ColumnConfigInternal<R, T> extends GridColumn<R> {
 })
 export class DatagridComponent<R> implements OnInit, AfterViewInit, AfterViewChecked {
     /**
+     * A optional string to be displayed above the grid.
+     */
+    @Input()
+    header?: string;
+
+    /**
      * Sets the configuration of columns on the grid and updates the {@link columnsConfig} array
      */
     @Input()

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -16,6 +16,7 @@ import {
     ElementRef,
     AfterViewInit,
     AfterViewChecked,
+    HostBinding,
 } from '@angular/core';
 import { ClrDatagridFilter, ClrDatagrid, ClrDatagridStateInterface, ClrDatagridPagination } from '@clr/angular';
 import {
@@ -187,7 +188,7 @@ interface ColumnConfigInternal<R, T> extends GridColumn<R> {
     templateUrl: './datagrid.component.html',
     styleUrls: ['./datagrid.component.scss'],
 })
-export class DatagridComponent<R> implements OnInit, AfterViewInit, AfterViewChecked {
+export class DatagridComponent<R> implements OnInit, AfterViewInit {
     /**
      * A optional string to be displayed above the grid.
      */
@@ -329,7 +330,26 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit, AfterViewChe
     /**
      * Desired height of the grid. If unspecificed, the grid fills the parent container.
      */
-    @Input() height: number;
+    @Input() set height(height: number) {
+        this._height = height;
+        if (this.height) {
+            this.node.nativeElement
+                .querySelector('clr-datagrid')
+                .style.setProperty('--datagrid-height', this.height + 'px');
+        } else {
+            this.node.nativeElement.querySelector('clr-datagrid').style.setProperty('--datagrid-height', 'unset');
+        }
+    }
+
+    get height(): number {
+        return this._height;
+    }
+
+    private _height: number;
+
+    @HostBinding('class.fill-parent') get fillParent(): boolean {
+        return this.height === undefined;
+    }
 
     /**
      * Loading indicator on the grid
@@ -669,15 +689,5 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit, AfterViewChe
 
     ngAfterViewInit(): void {
         this.updatePagination();
-    }
-
-    ngAfterViewChecked(): void {
-        if (this.height) {
-            this.node.nativeElement.querySelector('clr-datagrid').style.height = this.height + 'px';
-            this.node.nativeElement.querySelector('.vcd-datagrid').style.height = 'unset';
-        } else {
-            this.node.nativeElement.querySelector('clr-datagrid').style.height = 'unset';
-            this.node.nativeElement.querySelector('.vcd-datagrid').style.height = '100%';
-        }
     }
 }

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -15,7 +15,6 @@ import {
     ContentChild,
     ElementRef,
     AfterViewInit,
-    AfterViewChecked,
     HostBinding,
 } from '@angular/core';
 import { ClrDatagridFilter, ClrDatagrid, ClrDatagridStateInterface, ClrDatagridPagination } from '@clr/angular';
@@ -328,17 +327,12 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
     pageSizeOptions = DEFAULT_SIZE_OPTIONS;
 
     /**
-     * Desired height of the grid. If unspecificed, the grid fills the parent container.
+     * Desired height of the grid in pixels. If unspecificed, the grid fills the parent container.
      */
     @Input() set height(height: number) {
         this._height = height;
-        if (this.height) {
-            this.node.nativeElement
-                .querySelector('clr-datagrid')
-                .style.setProperty('--datagrid-height', this.height + 'px');
-        } else {
-            this.node.nativeElement.querySelector('clr-datagrid').style.setProperty('--datagrid-height', 'unset');
-        }
+        const heightCssValue = this.height ? `${this.height}px` : 'unset';
+        this.node.nativeElement.style.setProperty('--datagrid-height', heightCssValue);
     }
 
     get height(): number {
@@ -347,7 +341,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
 
     private _height: number;
 
-    @HostBinding('class.fill-parent') get fillParent(): boolean {
+    @HostBinding('class.fill-parent') get shouldFillParent(): boolean {
         return this.height === undefined;
     }
 

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -672,7 +672,12 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit, AfterViewChe
     }
 
     ngAfterViewChecked(): void {
-        this.node.nativeElement.querySelector('clr-datagrid').style =
-            'height: ' + (this.height ? this.height + 'px' : '100%');
+        if (this.height) {
+            this.node.nativeElement.querySelector('clr-datagrid').style.height = this.height + 'px';
+            this.node.nativeElement.querySelector('.vcd-datagrid').style.height = 'unset';
+        } else {
+            this.node.nativeElement.querySelector('clr-datagrid').style.height = 'unset';
+            this.node.nativeElement.querySelector('.vcd-datagrid').style.height = '100%';
+        }
     }
 }

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -177,15 +177,14 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
      * Gives the height CSS of this clr-datagrid.
      */
     getGridHeight(): string {
-        const datagrid = this.findElement(ClrDatagridWidgetObject.tagName);
-        return this.root.nativeElement.style.height;
+        return this.root.nativeElement.style.getPropertyValue('--datagrid-height');
     }
 
     /**
      * Gives the height of the grids container.
      */
-    getGridContainerHeight(): string {
-        return this.root.parent.nativeElement.style.height;
+    getGridContainerClasses(): string[] {
+        return Object.keys(this.root.parent.classes);
     }
 
     /**

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -182,6 +182,14 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Gives the header above the grid.
+     */
+    getGridHeader(): string | undefined {
+        const headerElement = this.root.nativeElement.previousSibling;
+        return headerElement.nodeType !== 8 ? headerElement.textContent : undefined;
+    }
+
+    /**
      * Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that
      * subclasses should not return the DebugElement, they should return a string from a section of the HTML.
      *

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -176,21 +176,21 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     /**
      * Gives the height CSS of this clr-datagrid.
      */
-    getGridHeight(): string {
-        return this.root.nativeElement.style.getPropertyValue('--datagrid-height');
+    get gridHeight(): string {
+        return this.root.parent.nativeElement.style.getPropertyValue('--datagrid-height');
     }
 
     /**
      * Gives the height of the grids container.
      */
-    getGridContainerClasses(): string[] {
+    get gridContainerClasses(): string[] {
         return Object.keys(this.root.parent.classes);
     }
 
     /**
      * Gives the header above the grid.
      */
-    getGridHeader(): string | undefined {
+    get gridHeader(): string | undefined {
         const headerElement = this.root.nativeElement.previousSibling;
         return headerElement.nodeType !== 8 ? headerElement.textContent : undefined;
     }

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -182,6 +182,13 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Gives the height of the grids container.
+     */
+    getGridContainerHeight(): string {
+        return this.root.parent.nativeElement.style.height;
+    }
+
+    /**
      * Gives the header above the grid.
      */
     getGridHeader(): string | undefined {

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
@@ -11,7 +11,7 @@ interface Data {
 }
 
 /**
- * Shows a expandable detail template within the rows.
+ * Shows an expandable detail template within the rows.
  */
 @Component({
     selector: 'vcd-datagrid-show-hide-example',

--- a/projects/examples/src/components/datagrid/datagrid-header.example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-header.example.component.html
@@ -1,0 +1,2 @@
+<vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns" [header]="header">
+</vcd-datagrid>

--- a/projects/examples/src/components/datagrid/datagrid-header.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-header.example.component.ts
@@ -15,10 +15,7 @@ interface Data {
  */
 @Component({
     selector: 'vcd-datagrid-header-example',
-    template: `
-        <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns" [header]="header">
-        </vcd-datagrid>
-    `,
+    templateUrl: './datagrid-header.example.component.html',
 })
 export class DatagridHeaderExampleComponent {
     gridData: GridDataFetchResult<Data> = {

--- a/projects/examples/src/components/datagrid/datagrid-header.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-header.example.component.ts
@@ -11,17 +11,16 @@ interface Data {
 }
 
 /**
- * Shows a expandable detail template within the rows.
+ * Shows the capability of the datagrid to put a header on the top.
  */
 @Component({
-    selector: 'vcd-datagrid-show-hide-example',
+    selector: 'vcd-datagrid-header-example',
     template: `
-        <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns">
-            <ng-template let-record="record"> DETAILS: {{ record.value }} </ng-template>
+        <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns" [header]="header">
         </vcd-datagrid>
     `,
 })
-export class DatagridDetailRowExampleComponent {
+export class DatagridHeaderExampleComponent {
     gridData: GridDataFetchResult<Data> = {
         items: [],
     };
@@ -32,6 +31,8 @@ export class DatagridDetailRowExampleComponent {
             renderer: 'value',
         },
     ];
+
+    header = 'Some Header!';
 
     refresh(eventData: GridState<Data>): void {
         this.gridData = {

--- a/projects/examples/src/components/datagrid/datagrid-header.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-header.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DatagridModule } from '@vcd/ui-components';
+import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
+
+@NgModule({
+    declarations: [DatagridHeaderExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    exports: [DatagridHeaderExampleComponent],
+    entryComponents: [DatagridHeaderExampleComponent],
+})
+export class DatagridHeaderExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid-height.example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.component.html
@@ -1,0 +1,15 @@
+<div class="fixed-height">
+    <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns" [header]="'Fill Parent'">
+    </vcd-datagrid>
+</div>
+<div class="fixed-height">
+    <vcd-datagrid
+        [gridData]="gridData"
+        (gridRefresh)="refresh($event)"
+        [columns]="columns"
+        [height]="150"
+        [pagination]="pagination"
+    >
+    </vcd-datagrid>
+    <h3>Ends Here!</h3>
+</div>

--- a/projects/examples/src/components/datagrid/datagrid-height.example.component.scss
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.component.scss
@@ -1,0 +1,10 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+.fixed-height {
+    height: 300px;
+    flex-direction: column;
+    display: flex;
+}

--- a/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
@@ -17,7 +17,13 @@ interface Data {
     selector: 'vcd-datagrid-height-example',
     template: `
         <div style="height:300px">
-            <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns"> </vcd-datagrid>
+            <vcd-datagrid
+                [gridData]="gridData"
+                (gridRefresh)="refresh($event)"
+                [columns]="columns"
+                [header]="'Fill Parent'"
+            >
+            </vcd-datagrid>
         </div>
         <div style="height:300px">
             <vcd-datagrid

--- a/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
@@ -16,7 +16,11 @@ interface Data {
 @Component({
     selector: 'vcd-datagrid-height-example',
     template: `
-        <div style="height:300px">
+        <div
+            style="height:300px;
+                    flex-direction: column;
+                    display: flex;"
+        >
             <vcd-datagrid
                 [gridData]="gridData"
                 (gridRefresh)="refresh($event)"
@@ -25,7 +29,11 @@ interface Data {
             >
             </vcd-datagrid>
         </div>
-        <div style="height:300px">
+        <div
+            style="height:300px;
+                    flex-direction: column;
+                    display: flex;"
+        >
             <vcd-datagrid
                 [gridData]="gridData"
                 (gridRefresh)="refresh($event)"

--- a/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
@@ -12,39 +12,14 @@ interface Data {
 
 /**
  * A component that holds an example of setting the height on the datagrid.
+ *
+ * The parent of the grid must use CSS of `display: flex; flex-direction: column`
+ * if you want the grid to fill the height of the parent.
  */
 @Component({
     selector: 'vcd-datagrid-height-example',
-    template: `
-        <div
-            style="height:300px;
-                    flex-direction: column;
-                    display: flex;"
-        >
-            <vcd-datagrid
-                [gridData]="gridData"
-                (gridRefresh)="refresh($event)"
-                [columns]="columns"
-                [header]="'Fill Parent'"
-            >
-            </vcd-datagrid>
-        </div>
-        <div
-            style="height:300px;
-                    flex-direction: column;
-                    display: flex;"
-        >
-            <vcd-datagrid
-                [gridData]="gridData"
-                (gridRefresh)="refresh($event)"
-                [columns]="columns"
-                [height]="150"
-                [pagination]="pagination"
-            >
-            </vcd-datagrid>
-            <h3>Ends Here!</h3>
-        </div>
-    `,
+    styleUrls: ['./datagrid-height.example.component.scss'],
+    templateUrl: './datagrid-height.example.component.html',
 })
 export class DatagridHeightExampleComponent {
     pagination: PaginationConfiguration = {

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -20,7 +20,8 @@ interface Data {
 }
 
 /**
- * A component that holds an example of the show/hide columns capability.
+ * Shows linked buttons on the top of the datagrid.
+ * Has examples of both buttons that are global and contextual.
  */
 @Component({
     selector: 'vcd-datagrid-link-example',

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -24,6 +24,8 @@ import { DatagridLinkExampleModule } from './datagrid-link.example.module';
 import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
 import { DatagridHeightExampleModule } from './datagrid-height.example.module';
 import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
+import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
+import { DatagridHeaderExampleModule } from './datagrid-header.example.module';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -75,6 +77,11 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Setting height on the datagrid.',
         },
+        {
+            component: DatagridHeaderExampleComponent,
+            forComponent: null,
+            title: 'Setting the header on the datagrid.',
+        },
     ],
 });
 /**
@@ -91,6 +98,7 @@ Documentation.registerDocumentationEntry({
         DatagridPagionationExampleModule,
         DatagridLinkExampleModule,
         DatagridHeightExampleModule,
+        DatagridHeaderExampleModule,
     ],
 })
 export class DatagridExamplesModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -33,46 +33,6 @@ Documentation.registerDocumentationEntry({
     urlSegment: 'datagrid',
     examples: [
         {
-            component: DatagridThreeRenderersExampleComponent,
-            forComponent: null,
-            title: 'Example with 3 types of grid renderers',
-        },
-        {
-            component: DatagridCssClassesExampleComponent,
-            forComponent: null,
-            title: 'Component that holds an example of the css classes per row capability',
-        },
-        {
-            component: DatagridShowHideExampleComponent,
-            forComponent: null,
-            title: 'Show/Hide datagrid columns example',
-        },
-        {
-            component: DatagridDetailRowExampleComponent,
-            forComponent: null,
-            title: 'Detail row datagrid example',
-        },
-        {
-            component: DatagridSortExampleComponent,
-            forComponent: null,
-            title: 'Shows the sorting capability of the datagrid',
-        },
-        {
-            component: DatagridRowSelectExampleComponent,
-            forComponent: null,
-            title: 'Select datagrid row example',
-        },
-        {
-            component: DatagridPaginationExampleComponent,
-            forComponent: null,
-            title: 'Pagination functionality and text customization example',
-        },
-        {
-            component: DatagridLinkExampleComponent,
-            forComponent: null,
-            title: 'Links from Datagrid Example',
-        },
-        {
             component: DatagridHeightExampleComponent,
             forComponent: null,
             title: 'Setting height on the datagrid.',

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -33,6 +33,41 @@ Documentation.registerDocumentationEntry({
     urlSegment: 'datagrid',
     examples: [
         {
+            component: DatagridThreeRenderersExampleComponent,
+            forComponent: null,
+            title: 'Example with 3 types of grid renderers',
+        },
+        {
+            component: DatagridCssClassesExampleComponent,
+            forComponent: null,
+            title: 'Component that holds an example of the css classes per row capability',
+        },
+        {
+            component: DatagridShowHideExampleComponent,
+            forComponent: null,
+            title: 'Show/Hide datagrid columns example',
+        },
+        {
+            component: DatagridDetailRowExampleComponent,
+            forComponent: null,
+            title: 'Detail row datagrid example',
+        },
+        {
+            component: DatagridSortExampleComponent,
+            forComponent: null,
+            title: 'Shows the sorting capability of the datagrid',
+        },
+        {
+            component: DatagridRowSelectExampleComponent,
+            forComponent: null,
+            title: 'Select datagrid row example',
+        },
+        {
+            component: DatagridPaginationExampleComponent,
+            forComponent: null,
+            title: 'Pagination functionality and text customization example',
+        },
+        {
             component: DatagridHeightExampleComponent,
             forComponent: null,
             title: 'Setting height on the datagrid.',
@@ -41,6 +76,11 @@ Documentation.registerDocumentationEntry({
             component: DatagridHeaderExampleComponent,
             forComponent: null,
             title: 'Setting the header on the datagrid.',
+        },
+        {
+            component: DatagridLinkExampleComponent,
+            forComponent: null,
+            title: 'Links from Datagrid Example',
         },
     ],
 });


### PR DESCRIPTION
# Description:

Allows the user to set a header property on the datagrid which will automatically put a `h3` on the top of the grid with the header text.  Does not put it within the clr-datagrid, so this will not affect the magic pagination or grid height change.

# Other Fixes

Found a few copy-paste errors in the examples folder, so I changed those to reflect the actual purpose of the examples. 

# Testing

Added unit tests to test both the header property existing, not-existing, and changing. Also, added an example to show the header.

<img width="1295" alt="Screen Shot 2020-03-03 at 3 51 55 PM" src="https://user-images.githubusercontent.com/7528512/75818468-ed72ea00-5d66-11ea-82f6-ff86b839b53f.png">

