### PR TITLE
Fix play button by passing the correct template ID to SB

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@clr/icons": "2.2.1",
     "@clr/ui": "2.2.1",
     "@webcomponents/custom-elements": "1.0.0",
-    "angular-cli-ghpages": "^0.6.2",
+    "angular-cli-ghpages": "0.6.2",
     "messageformat": "2.3.0",
     "codecov.io": "0.1.6",
     "karma-coverage": "2.0.1",

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.3",
+    "version": "0.0.5",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"

--- a/projects/doc-lib/src/stack-blitz-writer.service.ts
+++ b/projects/doc-lib/src/stack-blitz-writer.service.ts
@@ -95,7 +95,7 @@ export class StackBlitzWriterService {
         const [mergedFiles, openFile] = this.createPatch(templateFiles, exampleComponent, exampleModule);
 
         const project: Project = {
-            title: this.stackBlitzInfo.projectName,
+            title: this.stackBlitzInfo.templateId,
             description: entry.title,
             template: 'angular-cli',
             dependencies,
@@ -170,7 +170,7 @@ export class StackBlitzWriterService {
         iframeContainerParent.style.visibility = 'hidden';
         iframeContainerParent.style.position = 'absolute';
         document.body.appendChild(iframeContainerParent);
-        const vm = await sdk.embedProjectId(iframeContainer, this.stackBlitzInfo.projectName, { view: 'editor' });
+        const vm = await sdk.embedProjectId(iframeContainer, this.stackBlitzInfo.templateId, { view: 'editor' });
         this.template = [await vm.getFsSnapshot(), await vm.getDependencies()];
         document.body.removeChild(iframeContainerParent);
         return Promise.resolve(this.template);

--- a/projects/i18n/ng-package.json
+++ b/projects/i18n/ng-package.json
@@ -3,5 +3,8 @@
   "dest": "../../dist/i18n",
   "lib": {
     "entryFile": "src/public-api.ts"
-  }
+  },
+  "whitelistedNonPeerDependencies": [
+    "messageformat"
+  ]
 }

--- a/projects/i18n/package.json
+++ b/projects/i18n/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@vcd/i18n",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "peerDependencies": {
     "@angular/common": ">6.0.0",
     "@angular/core": ">6.0.0"
+  },
+  "dependencies": {
+    "messageformat": "2.3.0"
   }
 }


### PR DESCRIPTION
## Description
Manually published new version of @vcd-ui/components and the first
version of @vcd/i18n since the examples require it.

Duplicated messageformat dependency so it can be included when
publishing @vcd/i18n

Updated stackblitz template to load i18n translations. See https://stackblitz.com/edit/vcd-ui-cc-starter-clarity-v8-yhe4yg

## Testing Done
Clicked play on the first example from our three components

![live-examples](https://user-images.githubusercontent.com/549331/75988401-83218d00-5ebf-11ea-85e2-341518c7f078.gif)

Signed-off-by: Juan Mendes <jmendes@vmware.com>