### PR TITLE
Added in a subscription tracker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11665,6 +11665,11 @@
         "tslib": "^1.9.0"
       }
     },
+    "rxjs-compat": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.5.4.tgz",
+      "integrity": "sha512-rkn+lbOHUQOurdd74J/hjmDsG9nFx0z66fvnbs8M95nrtKvNqCKdk7iZqdY51CGmDemTQk+kUPy4s8HVOHtkfA=="
+    },
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@clr/angular": "2.2.1",
     "@clr/icons": "2.2.1",
     "@clr/ui": "2.2.1",
+    "@compodoc/compodoc": "1.1.11",
+    "@stackblitz/sdk": "1.3.0",
     "@webcomponents/custom-elements": "1.0.0",
     "angular-cli-ghpages": "0.6.2",
     "messageformat": "2.3.0",
@@ -48,10 +50,9 @@
     "prismjs": "1.17.1",
     "properties": "1.2.1",
     "rxjs": "6.4.0",
+    "rxjs-compat": "6.5.4",
     "tslib": "1.10.0",
-    "zone.js": "0.9.1",
-    "@compodoc/compodoc": "1.1.11",
-    "@stackblitz/sdk": "1.3.0"
+    "zone.js": "0.9.1"
   },
   "husky": {
     "hooks": {

--- a/projects/components/src/common/subscription/index.ts
+++ b/projects/components/src/common/subscription/index.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+export * from './subscription-tracker';
+export * from './subscription-tracker.mixin';

--- a/projects/components/src/common/subscription/subscription-tracker.mixin.spec.ts
+++ b/projects/components/src/common/subscription/subscription-tracker.mixin.spec.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import createSpy = jasmine.createSpy;
+import { Subject } from 'rxjs';
+import { SubscriptionTrackerMixin } from './subscription-tracker.mixin';
+
+describe('SubscriptionTrackerMixin', () => {
+    class SubscribeObject extends SubscriptionTrackerMixin(Object) {}
+
+    describe('subscribing', () => {
+        it('adds a subscription', () => {
+            const destroyable = new SubscribeObject();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            destroyable.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+        it('adds multiple subscriptions', () => {
+            const destroyable = new SubscribeObject();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            destroyable.subscribe(subject, spy);
+            destroyable.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(2);
+        });
+        it('removes subscriptions when ngOnInit is called', () => {
+            const destroyable = new SubscribeObject();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            destroyable.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(1);
+            destroyable.ngOnDestroy();
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('unsubscribing', () => {
+        it('returns a subscription so you can unsubscribe', () => {
+            const destroyable = new SubscribeObject();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            const subscription = destroyable.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(1);
+            destroyable.unsubscribe(subscription);
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        it('errors if you unsubscribe to a subscription that was not created by the subscription tracker', () => {
+            const destroyable = new SubscribeObject();
+            const subject = new Subject<void>();
+            const subscription = subject.subscribe();
+            expect(() => destroyable.unsubscribe(subscription)).toThrow();
+        });
+
+        it('unsubscribe from all subscriptions when unsubscribeAll() is called', () => {
+            const destroyable = new SubscribeObject();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            const subscription1 = destroyable.subscribe(subject, spy);
+            const subscription2 = destroyable.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(2);
+            destroyable.unsubscribeAll();
+            expect(subscription1.closed).toBe(true);
+            expect(subscription2.closed).toBe(true);
+        });
+
+        it('unsubscribe from all subscriptions when ngOnDestroy() is called', () => {
+            const destroyable = new SubscribeObject();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            const subscription1 = destroyable.subscribe(subject, spy);
+            const subscription2 = destroyable.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(2);
+            destroyable.ngOnDestroy();
+            expect(subscription1.closed).toBe(true);
+            expect(subscription2.closed).toBe(true);
+        });
+
+        it('unsubscribe() from subscriptions are not called again if unsubscribeAll() is called multiple times', () => {
+            const destroyable = new SubscribeObject();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            const subscription1 = destroyable.subscribe(subject, spy);
+            const subscription2 = destroyable.subscribe(subject, spy);
+            spyOn(subscription1, 'unsubscribe');
+            spyOn(subscription2, 'unsubscribe');
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(2);
+            destroyable.unsubscribeAll();
+            expect(subscription1.unsubscribe).toHaveBeenCalledTimes(1);
+            expect(subscription2.unsubscribe).toHaveBeenCalledTimes(1);
+            destroyable.unsubscribeAll();
+            expect(subscription1.unsubscribe).toHaveBeenCalledTimes(1);
+            expect(subscription2.unsubscribe).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/projects/components/src/common/subscription/subscription-tracker.mixin.ts
+++ b/projects/components/src/common/subscription/subscription-tracker.mixin.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { OnDestroy } from '@angular/core';
+
+import { Subscription, Observable, PartialObserver } from 'rxjs';
+import { SubscriptionTracker, ISubscriptionTracker } from './subscription-tracker';
+
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+/**
+ * Creates a constructor for a class that can automatically subscribe and unsubscribe from observables.
+ *
+ * All subscriptions are automatically removed when the component is destroyed
+ */
+// tslint:disable-next-line: typedef
+export function SubscriptionTrackerMixin<TBase extends Constructor>(Base: TBase) {
+    return class extends Base implements ISubscriptionTracker, OnDestroy {
+        constructor(...params: any[]) {
+            super(params);
+            this.tracker = new SubscriptionTracker(this);
+        }
+
+        tracker: SubscriptionTracker;
+
+        public subscribe<T>(
+            observable: Observable<T>,
+            observerOrNext?: PartialObserver<T> | ((value: T) => void),
+            error?: (error: any) => void,
+            complete?: () => void
+        ): Subscription {
+            return this.tracker.subscribe(observable, observerOrNext, error, complete);
+        }
+
+        public unsubscribe(subscription: Subscription): Subscription {
+            return this.tracker.unsubscribe(subscription);
+        }
+
+        unsubscribeAll(): void {
+            this.tracker.unsubscribeAll();
+        }
+
+        ngOnDestroy(): void {
+            this.unsubscribeAll();
+        }
+    };
+}

--- a/projects/components/src/common/subscription/subscription-tracker.spec.ts
+++ b/projects/components/src/common/subscription/subscription-tracker.spec.ts
@@ -1,0 +1,119 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import createSpy = jasmine.createSpy;
+import { OnDestroy } from '@angular/core';
+import { Subject } from 'rxjs';
+import { SubscriptionTracker } from './subscription-tracker';
+
+describe('SubscriptionTracker', () => {
+    /**
+     * The Subscription tracker is typically created within Angular components. However, these specs use an
+     * object that implements the OnDestroy interface for simplicity
+     */
+    class Destroyable implements OnDestroy {
+        public tracker = new SubscriptionTracker(this);
+
+        public ngOnDestroyCallCount = 0;
+
+        ngOnDestroy(): void {
+            this.ngOnDestroyCallCount++;
+        }
+    }
+
+    describe('subscribing', () => {
+        it('adds a subscription', () => {
+            const destroyable = new Destroyable();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            destroyable.tracker.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+        it('adds multiple subscriptions', () => {
+            const destroyable = new Destroyable();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            destroyable.tracker.subscribe(subject, spy);
+            destroyable.tracker.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(2);
+        });
+        it('removes subscriptions when ngOnInit is called', () => {
+            const destroyable = new Destroyable();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            destroyable.tracker.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(1);
+            destroyable.ngOnDestroy();
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('unsubscribing', () => {
+        it('returns a subscription so you can unsubscribe', () => {
+            const destroyable = new Destroyable();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            const subscription = destroyable.tracker.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(1);
+            destroyable.tracker.unsubscribe(subscription);
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        it('errors if you unsubscribe to a subscription that was not created by the subscription tracker', () => {
+            const destroyable = new Destroyable();
+            const subject = new Subject<void>();
+            const subscription = subject.subscribe();
+            expect(() => destroyable.tracker.unsubscribe(subscription)).toThrow();
+        });
+
+        it('unsubscribe from all subscriptions when unsubscribeAll() is called', () => {
+            const destroyable = new Destroyable();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            const subscription1 = destroyable.tracker.subscribe(subject, spy);
+            const subscription2 = destroyable.tracker.subscribe(subject, spy);
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(2);
+            destroyable.tracker.unsubscribeAll();
+            expect(subscription1.closed).toBe(true);
+            expect(subscription2.closed).toBe(true);
+        });
+
+        it('unsubscribe() from subscriptions are not called again if unsubscribeAll() is called multiple times', () => {
+            const destroyable = new Destroyable();
+            const spy = createSpy('observableSubscription');
+            const subject = new Subject<void>();
+            const subscription1 = destroyable.tracker.subscribe(subject, spy);
+            const subscription2 = destroyable.tracker.subscribe(subject, spy);
+            spyOn(subscription1, 'unsubscribe');
+            spyOn(subscription2, 'unsubscribe');
+            subject.next();
+            expect(spy).toHaveBeenCalledTimes(2);
+            destroyable.tracker.unsubscribeAll();
+            expect(subscription1.unsubscribe).toHaveBeenCalledTimes(1);
+            expect(subscription2.unsubscribe).toHaveBeenCalledTimes(1);
+            destroyable.tracker.unsubscribeAll();
+            expect(subscription1.unsubscribe).toHaveBeenCalledTimes(1);
+            expect(subscription2.unsubscribe).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('augmenting ngOnDestroy', () => {
+        it('overrides ngOnDestroy', () => {
+            const destroyable = new Destroyable();
+            expect(destroyable.ngOnDestroy).not.toBe(Destroyable.prototype.ngOnDestroy);
+        });
+        it('still calls the original ngOnDestroy with the correct `this`', () => {
+            const destroyable = new Destroyable();
+            destroyable.ngOnDestroy();
+            expect(destroyable.ngOnDestroyCallCount).toBe(1, 'Property ngOnDestroyCallCount was not updated');
+        });
+    });
+});

--- a/projects/components/src/common/subscription/subscription-tracker.ts
+++ b/projects/components/src/common/subscription/subscription-tracker.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { OnDestroy } from '@angular/core';
+import { Observable, PartialObserver, Subscription } from 'rxjs';
+import { toSubscriber } from 'rxjs/util/toSubscriber';
+
+/**
+ * An interface that knows how to subscribe and ubsubscribe from observables.
+ */
+export interface ISubscriptionTracker {
+    /**
+     * Subscribes to the given {@param observable}. Passes along the given {@param observerOrNext}.
+     * Will call the {@param complete} when complete, and {@param error} when errors happen.
+     */
+    subscribe<T>(
+        observable: Observable<T>,
+        observerOrNext?: PartialObserver<T> | ((value: T) => void),
+        error?: (error: any) => void,
+        complete?: () => void
+    ): Subscription;
+
+    /**
+     * Unsubscribes from the given {@param subscription}.
+     */
+    unsubscribe(subscription: Subscription): Subscription;
+
+    /**
+     * Unsubscribes from all subscriptions on this {@link Subscribable}.
+     */
+    unsubscribeAll(): void;
+}
+
+/**
+ * Components can use this to have subscriptions automatically removed when the component is destroyed
+ */
+export class SubscriptionTracker implements ISubscriptionTracker {
+    private subscriptions: Subscription[] = [];
+
+    /**
+     * Constructs this tracker to call {@link unsubscribeAll} when {@link destroyable.ngOnDestroy} is called.
+     */
+    constructor(destroyable: OnDestroy) {
+        const originalOnDestroy = destroyable.ngOnDestroy;
+        destroyable.ngOnDestroy = () => {
+            this.unsubscribeAll();
+            originalOnDestroy.call(destroyable);
+        };
+    }
+
+    subscribe<T>(
+        observable: Observable<T>,
+        observerOrNext?: PartialObserver<T> | ((value: T) => void),
+        error?: (error: any) => void,
+        complete?: () => void
+    ): Subscription {
+        const subscription = observable.subscribe(toSubscriber(observerOrNext, error, complete));
+        this.subscriptions.push(subscription);
+        return subscription;
+    }
+
+    unsubscribe(subscription: Subscription): Subscription {
+        subscription.unsubscribe();
+        const indexOfSubscription = this.subscriptions.indexOf(subscription);
+        if (indexOfSubscription === -1) {
+            throw new Error('Unsubscribing to untracked subscription');
+        }
+        this.subscriptions.splice(indexOfSubscription, 1);
+        return subscription;
+    }
+
+    unsubscribeAll(): void {
+        this.subscriptions.forEach(subscription => subscription.unsubscribe());
+        this.subscriptions = [];
+    }
+}

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -10,3 +10,4 @@ export * from './data-exporter/index';
 export * from './lib/directives/show-clipped-text.directive'; //
 export * from './datagrid/index';
 export * from './components.module';
+export * from './common/subscription';

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -25,6 +25,7 @@ import examplesDocumentationJson from '../../gen/examples-doc.json';
 import { DatagridExamplesModule } from '../components/datagrid/datagrid.examples.module';
 import { ShowClippedTextExamplesModule } from './components/show-clipped-text/show-clipped-text-examples.module';
 import { DataExporterExamplesModule } from '../components/data-exporter/data-exporter.examples.module';
+import { SubscriptionTrackerExamplesModule } from '../components/subscription/subscription-tracker.examples.module';
 
 registerLocaleData(localeFr, 'fr');
 registerLocaleData(localeEs, 'es');
@@ -62,6 +63,7 @@ export const sbInfo: StackBlitzInfo = {
         DatagridExamplesModule,
         DataExporterExamplesModule,
         ShowClippedTextExamplesModule,
+        SubscriptionTrackerExamplesModule,
     ],
     providers: [
         {

--- a/projects/examples/src/components/subscription/subscription-tracker-mixin.example.component.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker-mixin.example.component.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, Input, OnInit } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { SubscriptionTrackerMixin } from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+}
+
+/**
+ * Automatically destroy subscriptions when components are destroyed by using the {@link SubscriptionTrackerMixin}.
+ */
+@Component({
+    selector: 'vcd-subscription-tracker-mixin-example-sub',
+    template: `
+        <h1>This is a Sub Component</h1>
+    `,
+})
+export class SubscriptionTrackerMixinExampleSubComponent extends SubscriptionTrackerMixin(Object) implements OnInit {
+    @Input()
+    observable: Observable<number>;
+
+    ngOnInit(): void {
+        this.subscribe(this.observable, value => console.log(value));
+    }
+}
+
+/**
+ * Console log's when the subscription publishes until you destroy the component.
+ */
+@Component({
+    selector: 'vcd-subscription-tracker-mixin-example',
+    template: `
+        <button (click)="this.pushToObservable()">Push to Observable</button>
+        <button (click)="shouldOpen = !shouldOpen">{{ shouldOpen ? 'Close' : 'Open' }} Sub Component</button>
+        <vcd-subscription-tracker-mixin-example-sub *ngIf="shouldOpen" [observable]="observable">
+        </vcd-subscription-tracker-mixin-example-sub>
+    `,
+})
+export class SubscriptionTrackerMixinExampleComponent {
+    shouldOpen = false;
+    observable = new BehaviorSubject(Math.random());
+
+    pushToObservable(): void {
+        this.observable.next(Math.random());
+    }
+}

--- a/projects/examples/src/components/subscription/subscription-tracker-mixin.example.module.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker-mixin.example.module.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DatagridModule } from '@vcd/ui-components';
+import {
+    SubscriptionTrackerMixinExampleComponent,
+    SubscriptionTrackerMixinExampleSubComponent,
+} from './subscription-tracker-mixin.example.component';
+
+@NgModule({
+    declarations: [SubscriptionTrackerMixinExampleComponent, SubscriptionTrackerMixinExampleSubComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    exports: [SubscriptionTrackerMixinExampleComponent],
+    entryComponents: [SubscriptionTrackerMixinExampleComponent],
+})
+export class SubscriptionTrackerMixinExampleModule {}

--- a/projects/examples/src/components/subscription/subscription-tracker.examples.module.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker.examples.module.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { Documentation } from '@vcd/ui-doc-lib';
+import { SubscriptionTrackerMixinExampleModule } from './subscription-tracker-mixin.example.module';
+import { SubscriptionTrackerMixinExampleComponent } from './subscription-tracker-mixin.example.component';
+import { SubscriptionTracker } from '@vcd/ui-components';
+
+Documentation.registerDocumentationEntry({
+    component: SubscriptionTracker,
+    displayName: 'Subscription Tracker',
+    urlSegment: 'subscriptionTracker',
+    examples: [
+        {
+            component: SubscriptionTrackerMixinExampleComponent,
+            forComponent: null,
+            title: 'Automatically destroy subscriptions when components are destroyed',
+        },
+    ],
+});
+
+/**
+ * A module that imports all subscription tracker examples.
+ */
+@NgModule({
+    imports: [SubscriptionTrackerMixinExampleModule],
+})
+export class SubscriptionTrackerExamplesModule {}

--- a/projects/i18n/src/lib/service/message-format-translation-service.ts
+++ b/projects/i18n/src/lib/service/message-format-translation-service.ts
@@ -38,7 +38,6 @@ export class MessageFormatTranslationService extends TranslationService {
                     Object.assign(toSet[locale], set[locale]);
                 }
             }
-            console.log(toSet);
             this.translationSet.next(toSet);
         } else if (this.translationLoader) {
             let subscribable: Observable<object>;


### PR DESCRIPTION
# Description

Adds in a subscription tracker that can manage multiple subscriptions at once. It also adds in a subscription tracker mixin that allows a class to automatically gain the methods in the subscription tracker and will unsubscribe from these subscriptions when it's destroyed.

# Testing

Added unit tests for both the mixin and the tracker class. Also, added an example that shows how to apply this mixin to a class:

![subscription-tracker](https://user-images.githubusercontent.com/7528512/75919127-fb8a3e80-5e2a-11ea-9ae8-1a25bc0d151a.gif)
