### PR TITLE
Adds activity reporters Into core components

### DIFF
--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -6,3 +6,4 @@ select.all=Select All
 cancel=Cancel
 export=Export
 data-exporter.title=Data Exporter
+loading=Loading

--- a/projects/components/src/common/activity-reporter/activity-reporter.module.ts
+++ b/projects/components/src/common/activity-reporter/activity-reporter.module.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { SpinnerActivityReporterComponent } from './spinner-activity-reporter.component';
+import { I18nModule } from '@vcd/i18n';
+import { BannerActivityReporterComponent } from './banner-activity-reporter.component';
+import { ErrorBannerModule } from '../error/error-banner.module';
+import { LoadingIndicatorModule } from '../loading/loading-indicator.module';
+
+@NgModule({
+    declarations: [BannerActivityReporterComponent, SpinnerActivityReporterComponent],
+    imports: [CommonModule, ClarityModule, I18nModule, ErrorBannerModule, LoadingIndicatorModule],
+    exports: [BannerActivityReporterComponent, SpinnerActivityReporterComponent],
+    entryComponents: [BannerActivityReporterComponent, SpinnerActivityReporterComponent],
+})
+export class ActivityReporterModule {}

--- a/projects/components/src/common/activity-reporter/activity-reporter.spec.ts
+++ b/projects/components/src/common/activity-reporter/activity-reporter.spec.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { ActivityReporter } from './activity-reporter';
+
+interface HasPromiseAndReporter {
+    // The data about the promise for {@link ActivityReporter.monitorEdit}.
+    promise: Promise<string>;
+    // The function that will reject the promise.
+    reject: (error: string) => void;
+    // The function that will resolve the promise.
+    resolve: (resolved: string) => void;
+    // Spys on {@link ActivityReporter.start}
+    startSpy: jasmine.Spy;
+    // Spys on {@link ActivityReporter.reporterError}
+    reportErrorSpy: jasmine.Spy;
+    // Spys on {@link ActivityReporter.reporterSuccess}
+    reportSuccessSpy: jasmine.Spy;
+    // The activity reporter used for testing.
+    reporter: ActivityReporter;
+}
+
+describe('ActivityReporter', () => {
+    beforeEach(function(this: HasPromiseAndReporter): void {
+        this.promise = new Promise<string>((promiseResolve, promiseReject) => {
+            this.resolve = stuff => promiseResolve(stuff);
+            this.reject = stuff => promiseReject(stuff);
+        });
+
+        this.reporter = new SimpleReporter();
+        this.startSpy = spyOn(this.reporter, 'startActivity');
+        this.reportErrorSpy = spyOn(this.reporter, 'reportError');
+        this.reportSuccessSpy = spyOn(this.reporter, 'reportSuccess');
+    });
+
+    class SimpleReporter extends ActivityReporter {
+        reportError(errorText: string): void {}
+
+        reportSuccess(successMessage?: string): void {}
+
+        startActivity(): void {}
+    }
+
+    describe('monitorActivity', () => {
+        it('reports success when the promise is resolved', function(this: HasPromiseAndReporter): Promise<void> {
+            const getPromise = this.reporter.monitorActivity(this.promise);
+            expect(this.startSpy).toHaveBeenCalledTimes(1);
+
+            const toReturn = getPromise.then(result => {
+                expect(this.reportSuccessSpy).toHaveBeenCalledTimes(1);
+            });
+
+            this.resolve('wow!');
+
+            return toReturn;
+        });
+
+        it('reports error when the promise is rejected', function(this: HasPromiseAndReporter): Promise<void> {
+            const getPromise = this.reporter.monitorActivity(this.promise);
+            expect(this.startSpy).toHaveBeenCalledTimes(1);
+            const toReturn = getPromise.then(result => {
+                expect(this.reportErrorSpy).toHaveBeenCalledWith('bad!');
+            });
+            this.reject('bad!');
+            return toReturn;
+        });
+    });
+});

--- a/projects/components/src/common/activity-reporter/activity-reporter.ts
+++ b/projects/components/src/common/activity-reporter/activity-reporter.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+type Response = string | undefined;
+
+/**
+ * Expresses the contract between a activity status and the UI displaying a loading message, reporting
+ * success or errors
+ * Currently, only one concurrent activity is supported.
+ */
+export abstract class ActivityReporter {
+    /**
+     * Indicates the operation completed with an error
+     *
+     *  @param errorText The text to display in the error alert.
+     */
+    abstract reportError(errorText: string): void;
+
+    /**
+     * Indicates the operation completed successfully
+     *
+     * @param successMessage A message to display to the user.
+     */
+    abstract reportSuccess(successMessage?: string): void;
+
+    /*
+     * Indicates an operation has started and the UI should show an activity indicator
+     */
+    abstract startActivity(): void;
+
+    /**
+     * Monitors an activity passed as a Promise
+     * @param activityResolutionPromise Observable of the task representation
+     * don't need a special finish indicator because other parts of the UI get updated
+     */
+    monitorActivity(activityResolutionPromise: Promise<Response>): Promise<Response> {
+        this.startActivity();
+        return activityResolutionPromise
+            .then(activityResolution => {
+                this.reportSuccess(activityResolution);
+                return activityResolution;
+            })
+            .catch(error => {
+                this.reportError(error);
+                return error;
+            });
+    }
+}

--- a/projects/components/src/common/activity-reporter/banner-activity-reporter.component.html
+++ b/projects/components/src/common/activity-reporter/banner-activity-reporter.component.html
@@ -1,0 +1,19 @@
+<clr-alert *ngIf="running" clrAlertType="alert-info" [clrAlertClosable]="false">
+    <div>{{ loadingMessage ? loadingMessage : ('loading' | translate) }}</div>
+</clr-alert>
+
+<clr-alert *ngIf="errorText" clrAlertType="danger" (clrAlertClosed)="onErrorClosed()">
+    <div clr-alert-item class="alert-item">
+        <span class="alert-text">
+            {{ errorText }}
+        </span>
+    </div>
+</clr-alert>
+
+<clr-alert *ngIf="successMessage" clrAlertType="success" (clrAlertClosed)="onSuccessClosed()">
+    <div clr-alert-item class="alert-item">
+        <span class="alert-text">
+            {{ successMessage }}
+        </span>
+    </div>
+</clr-alert>

--- a/projects/components/src/common/activity-reporter/banner-activity-reporter.component.ts
+++ b/projects/components/src/common/activity-reporter/banner-activity-reporter.component.ts
@@ -1,0 +1,82 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, Input } from '@angular/core';
+import { ActivityReporter } from './activity-reporter';
+
+/**
+ * Shows a banner to the user to represent the state of an activity.
+ */
+@Component({
+    selector: 'vcd-banner-activity-reporter',
+    templateUrl: './banner-activity-reporter.component.html',
+})
+export class BannerActivityReporterComponent extends ActivityReporter {
+    running = false;
+    errorText: string;
+    successMessage: string;
+
+    /**
+     * The translated message that is displayed to the user while loading.
+     */
+    @Input()
+    loadingMessage: string;
+
+    constructor() {
+        super();
+    }
+
+    /**
+     * Begins to show the banner with a loading indicator.
+     */
+    startActivity(): void {
+        this.running = true;
+        this.successMessage = null;
+        this.errorText = null;
+    }
+
+    /**
+     * Shows the given {@param errorText} to the user.
+     */
+    reportError(errorText: string): void {
+        this.errorText = errorText;
+        this.running = false;
+    }
+
+    /**
+     * Shows the given {@param successMessage} to the user.
+     */
+    reportSuccess(successMessage: string): void {
+        if (successMessage) {
+            this.successMessage = successMessage;
+        }
+        this.running = false;
+    }
+
+    /**
+     * Closes the error message if displayed.
+     */
+    onErrorClosed(): void {
+        this.errorText = null;
+    }
+
+    /**
+     * Closes the success message if displayed.
+     */
+    onSuccessClosed(): void {
+        this.successMessage = null;
+    }
+
+    /*
+     * Reset the banner activity state manually.
+     *
+     * Call it when banner should be reset to its default state.
+     */
+    reset(): void {
+        this.running = false;
+        this.errorText = null;
+        this.successMessage = null;
+    }
+}

--- a/projects/components/src/common/activity-reporter/banner-activity-reporter.spec.ts
+++ b/projects/components/src/common/activity-reporter/banner-activity-reporter.spec.ts
@@ -1,0 +1,119 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivityReporterModule } from './activity-reporter.module';
+import { WidgetFinder } from '../../utils/test/widget-object';
+import { BannerActivityReporterComponent } from './banner-activity-reporter.component';
+import { BannerActivityReporterWidgetObject } from '../../utils/test/activity-reporter/banner-activity-reporter.wo';
+import { TranslationService, MockTranslationService } from '@vcd/i18n';
+
+@Component({
+    template: `
+        <vcd-banner-activity-reporter [loadingMessage]="loadingMessage"></vcd-banner-activity-reporter>
+    `,
+})
+class TestBannerComponent {
+    @ViewChild(BannerActivityReporterComponent, { static: true }) activityReporter: BannerActivityReporterComponent;
+    loadingMessage: string;
+}
+
+interface HasFinderAndBanner {
+    finder: WidgetFinder<TestBannerComponent>;
+    // The Widget Object for the underlying Clarity grid
+    banner: BannerActivityReporterWidgetObject;
+    // The promise that's passed to the activity reporter.
+    promise: Promise<string>;
+    // The function that will reject the promise.
+    reject: (error: string) => void;
+    // The function that will resolve the promise.
+    resolve: (response: string) => void;
+}
+
+describe('BannerActivityReporterComponent', () => {
+    beforeEach(async function(this: HasFinderAndBanner): Promise<void> {
+        await TestBed.configureTestingModule({
+            imports: [ActivityReporterModule],
+            declarations: [TestBannerComponent],
+            providers: [
+                {
+                    provide: TranslationService,
+                    useValue: new MockTranslationService(),
+                },
+            ],
+        }).compileComponents();
+
+        this.finder = new WidgetFinder(TestBannerComponent);
+        this.banner = this.finder.find(BannerActivityReporterWidgetObject);
+        this.promise = new Promise((promiseResolve, promiseReject) => {
+            this.resolve = stuff => promiseResolve(stuff);
+            this.reject = stuff => promiseReject(stuff);
+        });
+        this.finder.detectChanges();
+    });
+
+    it('displays a default message while the promise is pending', function(this: HasFinderAndBanner): Promise<string> {
+        const promise = this.banner.component.monitorActivity(this.promise);
+        this.finder.detectChanges();
+        expect(this.banner.running).toBeTruthy();
+        expect(this.banner.loadingText).toEqual('{"key":"loading","params":[]}'); // Because of mock translation service
+        this.resolve('winning!');
+        return promise;
+    });
+
+    it('displays a custom message while the promise is pending', function(this: HasFinderAndBanner): Promise<string> {
+        this.finder.hostComponent.loadingMessage = 'loader';
+        const promise = this.banner.component.monitorActivity(this.promise);
+        this.finder.detectChanges();
+        expect(this.banner.running).toBeTruthy();
+        expect(this.banner.loadingText).toEqual('loader'); // Because of mock translation service
+        this.resolve('winning!');
+        return promise;
+    });
+
+    it('removes the activity reporter from the screen after the promise resolves', function(this: HasFinderAndBanner): Promise<
+        void
+    > {
+        const promise = this.banner.component.monitorActivity(this.promise).then(() => {
+            expect(this.banner.running).toBeFalsy();
+            expect(this.banner.sucessText).toEqual('winning!');
+            this.banner.component.onSuccessClosed();
+            expect(this.banner.sucessText).toEqual(null);
+        });
+
+        this.finder.detectChanges();
+        expect(this.banner.running).toBeTruthy();
+        this.resolve('winning!');
+        return promise;
+    });
+
+    it('displays an error on the screen if the promise is rejected', function(this: HasFinderAndBanner): Promise<void> {
+        const promise = this.banner.component.monitorActivity(this.promise).then(() => {
+            expect(this.banner.running).toBeFalsy();
+            expect(this.banner.errorText).toEqual('Bad!');
+            this.banner.component.onErrorClosed();
+            expect(this.banner.errorText).toEqual(null);
+        });
+
+        // On call pending
+        this.finder.detectChanges();
+        expect(this.banner.running).toBeTruthy();
+
+        this.reject('Bad!');
+        return promise;
+    });
+
+    it('clears all content when reset', function(this: HasFinderAndBanner): Promise<string> {
+        const promise = this.banner.component.monitorActivity(this.promise);
+        this.finder.detectChanges();
+        expect(this.banner.running).toBeTruthy();
+        expect(this.banner.loadingText).toEqual('{"key":"loading","params":[]}'); // Because of mock translation service
+        this.banner.component.reset();
+        expect(this.banner.running).toBeFalsy();
+        this.resolve('winning!');
+        return promise;
+    });
+});

--- a/projects/components/src/common/activity-reporter/index.ts
+++ b/projects/components/src/common/activity-reporter/index.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+export * from './activity-reporter';
+export * from './banner-activity-reporter.component';
+export * from './spinner-activity-reporter.component';
+export * from './activity-reporter.module';

--- a/projects/components/src/common/activity-reporter/spinner-activity-reporter.component.html
+++ b/projects/components/src/common/activity-reporter/spinner-activity-reporter.component.html
@@ -1,0 +1,2 @@
+<vcd-error-banner *ngIf="errorText" [(errorMessage)]="errorText"></vcd-error-banner>
+<vcd-loading-indicator [isLoading]="running"></vcd-loading-indicator>

--- a/projects/components/src/common/activity-reporter/spinner-activity-reporter.component.ts
+++ b/projects/components/src/common/activity-reporter/spinner-activity-reporter.component.ts
@@ -1,0 +1,54 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { ActivityReporter } from './activity-reporter';
+
+/**
+ * Spinner activity reporter shows the spinner until an error or success message is returned.
+ * An error message is displayed through the error banner.
+ */
+@Component({
+    selector: 'vcd-spinner-activity-reporter',
+    templateUrl: './spinner-activity-reporter.component.html',
+})
+export class SpinnerActivityReporterComponent extends ActivityReporter {
+    /**
+     * When true show the spinner
+     */
+    public running = false;
+
+    /**
+     * When set show the error text
+     */
+    public errorText: string = null;
+
+    constructor() {
+        super();
+    }
+
+    /**
+     * Begins to show the loading indicator to the user.
+     */
+    startActivity(): void {
+        this.running = true;
+        this.errorText = null;
+    }
+
+    /**
+     * Hides the loading indicator and shows an error message.
+     */
+    reportError(errorText: string): void {
+        this.errorText = errorText;
+        this.running = false;
+    }
+
+    /**
+     * Hides the loading indicator.
+     */
+    reportSuccess(): void {
+        this.running = false;
+    }
+}

--- a/projects/components/src/common/activity-reporter/spinner-activity-reporter.spec.ts
+++ b/projects/components/src/common/activity-reporter/spinner-activity-reporter.spec.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { SpinnerActivityReporterComponent } from './spinner-activity-reporter.component';
+import { SpinnerActivityReporterWidgetObject } from '../../utils/test/activity-reporter/spinner-activity-reporter.wo';
+import { ActivityReporterModule } from './activity-reporter.module';
+import { WidgetFinder } from '../../utils/test/widget-object';
+
+@Component({
+    template: `
+        <vcd-spinner-activity-reporter #activityReporter></vcd-spinner-activity-reporter>
+    `,
+})
+class TestSpinnerComponent {
+    @ViewChild('activityReporter', { static: true }) activityReporter: SpinnerActivityReporterComponent;
+}
+
+interface HasFinderAndSpinner {
+    finder: WidgetFinder<TestSpinnerComponent>;
+    // The Widget Object for the underlying Clarity grid
+    spinner: SpinnerActivityReporterWidgetObject;
+    // The promise that's passed to the activity reporter.
+    promise: Promise<string>;
+    // The function that will reject the promise.
+    reject: (error: string) => void;
+    // The function that will resolve the promise.
+    resolve: (response: string) => void;
+}
+
+describe('SpinnerActivityReporterComponent', () => {
+    beforeEach(async function(this: HasFinderAndSpinner): Promise<void> {
+        await TestBed.configureTestingModule({
+            imports: [ActivityReporterModule],
+            declarations: [TestSpinnerComponent],
+        }).compileComponents();
+
+        this.finder = new WidgetFinder(TestSpinnerComponent);
+        this.spinner = this.finder.find(SpinnerActivityReporterWidgetObject);
+        this.promise = new Promise((promiseResolve, promiseReject) => {
+            this.resolve = stuff => promiseResolve(stuff);
+            this.reject = stuff => promiseReject(stuff);
+        });
+        this.finder.detectChanges();
+    });
+
+    it('displays the spinner while the promise is pending', function(this: HasFinderAndSpinner): Promise<string> {
+        const promise = this.spinner.component.monitorActivity(this.promise);
+        this.finder.detectChanges();
+        expect(this.spinner.isSpinnerSpinning()).toBeTruthy();
+        this.resolve('wow!');
+        return promise;
+    });
+
+    it('removes the activity reporter from the screen after the promise resolves', function(this: HasFinderAndSpinner): Promise<
+        void
+    > {
+        const promise = this.spinner.component.monitorActivity(this.promise).then(() => {
+            this.finder.detectChanges();
+            expect(this.spinner.running).toBeFalsy();
+            expect(this.spinner.isSpinnerSpinning()).toBeFalsy();
+        });
+
+        this.finder.detectChanges();
+        this.resolve('wow!');
+        return promise;
+    });
+
+    it('displays an error on the screen if the promise is rejected', function(this: HasFinderAndSpinner): Promise<
+        void
+    > {
+        const promise = this.spinner.component.monitorActivity(this.promise).then(() => {
+            expect(this.spinner.running).toBeFalsy();
+            expect(this.spinner.errorText).toEqual('Woah there!');
+        });
+        this.finder.detectChanges();
+        this.reject('Woah there!');
+        return promise;
+    });
+});

--- a/projects/components/src/common/error/error-banner.component.html
+++ b/projects/components/src/common/error/error-banner.component.html
@@ -1,0 +1,10 @@
+<clr-alert
+    [(clrAlertClosed)]="closed"
+    [clrAlertType]="alertType"
+    [clrAlertClosable]="alertClosable"
+    (clrAlertClosedChange)="onAlertClosedChange($event)"
+>
+    <div class="alert-item">
+        <span class="alert-text">{{ errorMessage }}</span>
+    </div>
+</clr-alert>

--- a/projects/components/src/common/error/error-banner.component.scss
+++ b/projects/components/src/common/error/error-banner.component.scss
@@ -1,0 +1,9 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+clr-alert ::ng-deep .alert {
+    margin-left: 24px;
+    margin-right: 24px;
+}

--- a/projects/components/src/common/error/error-banner.component.spec.ts
+++ b/projects/components/src/common/error/error-banner.component.spec.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { WidgetFinder } from '../../utils/test/widget-object';
+import { ErrorBannerComponent } from './error-banner.component';
+import { ErrorBannerModule } from './error-banner.module';
+
+@Component({
+    template: `
+        <vcd-error-banner #banner [errorMessage]="message"></vcd-error-banner>
+    `,
+})
+class TestErrorComponent {
+    message: string;
+    @ViewChild('banner', { static: false }) errorBanner: ErrorBannerComponent;
+}
+
+interface HasFinderAndError {
+    finder: WidgetFinder<TestErrorComponent>;
+}
+
+describe('ErrorBannerComponent', () => {
+    beforeEach(async function(this: HasFinderAndError): Promise<void> {
+        await TestBed.configureTestingModule({
+            imports: [ErrorBannerModule],
+            declarations: [TestErrorComponent],
+        }).compileComponents();
+
+        this.finder = new WidgetFinder(TestErrorComponent);
+        this.finder.detectChanges();
+    });
+
+    it('can display an error when shown', function(this: HasFinderAndError): void {
+        this.finder.hostComponent.message = 'Error!!';
+        this.finder.detectChanges();
+        expect(this.finder.hostComponent.errorBanner.closed).toBeFalsy();
+        expect(this.finder.hostComponent.errorBanner.errorMessage).toEqual('Error!!');
+        this.finder.hostComponent.errorBanner.onAlertClosedChange(true);
+        expect(this.finder.hostComponent.errorBanner.errorMessage).toBeFalsy();
+    });
+});

--- a/projects/components/src/common/error/error-banner.component.ts
+++ b/projects/components/src/common/error/error-banner.component.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+/**
+ * Component that displays the error message only if a non empty errorMessage is passed in
+ */
+@Component({
+    selector: 'vcd-error-banner',
+    templateUrl: './error-banner.component.html',
+    styleUrls: ['./error-banner.component.scss'],
+})
+export class ErrorBannerComponent {
+    private _errorMessage = '';
+
+    closed = true;
+
+    /**
+     * Emits events when the error banner is dismissed.
+     */
+    @Output() dismissed = new EventEmitter<void>();
+
+    /**
+     * Two way bound errorMessage, will be cleared when the user dismisses the alert
+     */
+    @Input() get errorMessage(): string {
+        return this._errorMessage;
+    }
+
+    /**
+     * Sets clr-alert type
+     */
+    @Input() alertType: 'danger' | 'warning' | 'info' | 'success' = 'danger';
+
+    /**
+     * Marks clr-alert as closable or not
+     */
+    @Input() alertClosable = true;
+
+    /**
+     * Sets the error message displayed by this error banner.
+     */
+    set errorMessage(val: string) {
+        this._errorMessage = val;
+        this.closed = !val;
+    }
+
+    /**
+     * Emits an event when the error message is changed.
+     */
+    @Output() errorMessageChange = new EventEmitter<string>();
+
+    /**
+     * Clears the error message when the alert is closed.
+     */
+    onAlertClosedChange(closed: boolean): void {
+        this._errorMessage = '';
+        this.errorMessageChange.emit('');
+        this.dismissed.next();
+    }
+}

--- a/projects/components/src/common/error/error-banner.module.ts
+++ b/projects/components/src/common/error/error-banner.module.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { I18nModule } from '@vcd/i18n';
+import { ErrorBannerComponent } from './error-banner.component';
+
+@NgModule({
+    declarations: [ErrorBannerComponent],
+    imports: [CommonModule, ClarityModule, I18nModule],
+    exports: [ErrorBannerComponent],
+    entryComponents: [ErrorBannerComponent],
+})
+export class ErrorBannerModule {}

--- a/projects/components/src/common/error/index.ts
+++ b/projects/components/src/common/error/index.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+export * from './error-banner.component';
+export * from './error-banner.module';

--- a/projects/components/src/common/loading/index.ts
+++ b/projects/components/src/common/loading/index.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+export * from './loading-indicator.component';
+export * from './loading-indicator.module';

--- a/projects/components/src/common/loading/loading-indicator.component.html
+++ b/projects/components/src/common/loading/loading-indicator.component.html
@@ -1,0 +1,10 @@
+<ng-container *ngIf="isLoading">
+    <div class="overlay"></div>
+    <div *ngIf="showSpinner" class="indicator-container">
+        <div>
+            <span [ngClass]="['spinner', loadingTextKey ? 'spinner-inline' : 'spinner-' + size]"> </span>
+            <span class="qa-loading-text" *ngIf="loadingTextKey">{{ loadingTextKey | translate }}</span>
+        </div>
+    </div>
+</ng-container>
+<ng-content></ng-content>

--- a/projects/components/src/common/loading/loading-indicator.component.scss
+++ b/projects/components/src/common/loading/loading-indicator.component.scss
@@ -1,0 +1,34 @@
+$overlay-background-color-default: rgba(250, 250, 250, 0.5);
+$overlay-background-color-modal: rgba(255, 255, 255, 0.5);
+
+@mixin full-height {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+:host {
+    display: block;
+    position: relative;
+}
+
+:host-context(.modal-body) .overlay {
+    background-color: $overlay-background-color-modal;
+}
+
+.overlay {
+    background-color: $overlay-background-color-default;
+    @include full-height();
+    z-index: 10;
+}
+
+.indicator-container {
+    z-index: 600;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    @include full-height();
+}

--- a/projects/components/src/common/loading/loading-indicator.component.spec.ts
+++ b/projects/components/src/common/loading/loading-indicator.component.spec.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { WidgetFinder } from '../../utils/test/widget-object';
+import { LoadingIndicatorComponent } from './loading-indicator.component';
+import { LoadingIndicatorModule } from './loading-indicator.module';
+
+@Component({
+    template: `
+        <vcd-loading-indicator #loading [isLoading]="loadingVal" [size]="size"></vcd-loading-indicator>
+    `,
+})
+class TestErrorComponent {
+    loadingVal = false;
+    size = 'md';
+    @ViewChild('loading', { static: false }) loadingIndicator: LoadingIndicatorComponent;
+}
+
+interface HasFinderAndLoading {
+    finder: WidgetFinder<TestErrorComponent>;
+}
+
+describe('LoadingIndicatorReporterComponent', () => {
+    beforeEach(async function(this: HasFinderAndLoading): Promise<void> {
+        await TestBed.configureTestingModule({
+            imports: [LoadingIndicatorModule],
+            declarations: [TestErrorComponent],
+        }).compileComponents();
+
+        this.finder = new WidgetFinder(TestErrorComponent);
+        this.finder.detectChanges();
+    });
+
+    it('can display an error when shown', function(this: HasFinderAndLoading): void {
+        expect(this.finder.hostComponent.loadingIndicator.isLoading).toBeFalsy();
+        this.finder.hostComponent.loadingVal = true;
+        this.finder.detectChanges();
+        expect(this.finder.hostComponent.loadingIndicator.isLoading).toBeTruthy();
+        expect(this.finder.hostComponent.loadingIndicator.size).toEqual('md');
+        this.finder.hostComponent.size = 'lg';
+        this.finder.detectChanges();
+        expect(this.finder.hostComponent.loadingIndicator.size).toEqual('lg');
+        this.finder.hostComponent.size = 'not a size';
+        this.finder.detectChanges();
+        expect(this.finder.hostComponent.loadingIndicator.size).toEqual('md');
+    });
+});

--- a/projects/components/src/common/loading/loading-indicator.component.ts
+++ b/projects/components/src/common/loading/loading-indicator.component.ts
@@ -1,0 +1,76 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, Input } from '@angular/core';
+
+export enum SIZES {
+    sm = 'sm',
+    md = 'md',
+    lg = 'lg',
+}
+export type SpinnerSize = keyof typeof SIZES;
+
+/**
+ * Loading indicator for blocking modal dialogs while loading.
+ */
+@Component({
+    selector: 'vcd-loading-indicator',
+    templateUrl: 'loading-indicator.component.html',
+    styleUrls: ['loading-indicator.component.scss'],
+})
+export class LoadingIndicatorComponent {
+    /**
+     * Default spinner size set to "md" - medium used within the modal dialogs
+     */
+    private readonly defaultSpinnerSize: SpinnerSize = SIZES.md;
+    /**
+     * Spinner size.
+     *
+     * Spinners can be displayed in three sizes:
+     *
+     *  - sm(Small): This is the required sizing for inline spinners (see above). It measures 18x18 pixels.
+     *  - md(Medium): Medium spinners measure 36x36 pixels. Default.
+     *  - lg(Large): This is the default size for page spinners (see above).
+     *
+     */
+    private _size: SpinnerSize = this.defaultSpinnerSize;
+    /**
+     * Show/hide the loading indicator.
+     */
+    @Input()
+    public isLoading: boolean;
+
+    /**
+     * Show/hide the spinner if only an overlay is required.
+     */
+    @Input()
+    public showSpinner = true;
+
+    /**
+     * Text to show next to the spinner.
+     */
+    @Input()
+    public loadingTextKey: string = null;
+
+    /**
+     * Spinner size setter.
+     * Sets default size if provided value is not from specified sized.
+     */
+    @Input()
+    set size(size: SpinnerSize) {
+        if (!size || Object.keys(SIZES).indexOf(size) === -1) {
+            this._size = this.defaultSpinnerSize;
+        } else {
+            this._size = size;
+        }
+    }
+
+    /**
+     * Gives the size of this loading indicator.
+     */
+    get size(): SpinnerSize {
+        return this._size;
+    }
+}

--- a/projects/components/src/common/loading/loading-indicator.module.ts
+++ b/projects/components/src/common/loading/loading-indicator.module.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { I18nModule } from '@vcd/i18n';
+import { LoadingIndicatorComponent } from './loading-indicator.component';
+
+@NgModule({
+    declarations: [LoadingIndicatorComponent],
+    imports: [CommonModule, ClarityModule, I18nModule],
+    exports: [LoadingIndicatorComponent],
+    entryComponents: [LoadingIndicatorComponent],
+})
+export class LoadingIndicatorModule {}

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -6,8 +6,11 @@
 /*
  * Public API Surface of components
  */
+export * from './common/subscription/index';
+export * from './common/error/index';
+export * from './common/activity-reporter/index';
+export * from './common/loading/index';
 export * from './data-exporter/index';
 export * from './lib/directives/show-clipped-text.directive'; //
 export * from './datagrid/index';
 export * from './components.module';
-export * from './common/subscription';

--- a/projects/components/src/utils/test/activity-reporter/banner-activity-reporter.wo.ts
+++ b/projects/components/src/utils/test/activity-reporter/banner-activity-reporter.wo.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { WidgetObject } from '../widget-object';
+import { BannerActivityReporterComponent } from '../../../common/activity-reporter';
+
+export class BannerActivityReporterWidgetObject extends WidgetObject<BannerActivityReporterComponent> {
+    static tagName = 'vcd-banner-activity-reporter';
+
+    get running(): boolean {
+        return this.component.running;
+    }
+
+    get errorText(): string {
+        return this.component.errorText;
+    }
+
+    get sucessText(): string {
+        return this.component.successMessage;
+    }
+
+    get loadingText(): string {
+        return this.findElement('clr-alert').nativeElement.textContent;
+    }
+}

--- a/projects/components/src/utils/test/activity-reporter/spinner-activity-reporter.wo.ts
+++ b/projects/components/src/utils/test/activity-reporter/spinner-activity-reporter.wo.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { DebugElement } from '@angular/core';
+import { WidgetObject } from '../widget-object';
+import { SpinnerActivityReporterComponent } from '../../../common/activity-reporter';
+
+export class SpinnerActivityReporterWidgetObject extends WidgetObject<SpinnerActivityReporterComponent> {
+    static tagName = 'vcd-spinner-activity-reporter';
+
+    get running(): boolean {
+        return this.component.running;
+    }
+
+    get errorText(): string {
+        return this.component.errorText;
+    }
+
+    /**
+     * Gives the spinner for this element
+     */
+    private getSpinner(): DebugElement {
+        const element = this.findElement('.spinner');
+
+        if (!element) {
+            throw new Error('Could not find the spinner element.');
+        }
+        return element;
+    }
+
+    public isSpinnerSpinning(): boolean {
+        try {
+            return !!this.getSpinner();
+        } catch (error) {
+            return false;
+        }
+    }
+}

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -26,6 +26,9 @@ import { DatagridExamplesModule } from '../components/datagrid/datagrid.examples
 import { ShowClippedTextExamplesModule } from './components/show-clipped-text/show-clipped-text-examples.module';
 import { DataExporterExamplesModule } from '../components/data-exporter/data-exporter.examples.module';
 import { SubscriptionTrackerExamplesModule } from '../components/subscription/subscription-tracker.examples.module';
+import { LoadingIndicatorExamplesModule } from '../components/loading/loading-indicator.examples.module';
+import { ErrorBannerExamplesModule } from '../components/error/error-banner.examples.module';
+import { ActivityReporterExamplesModule } from '../components/activity-reporter/activity-reporter.examples.module';
 
 registerLocaleData(localeFr, 'fr');
 registerLocaleData(localeEs, 'es');
@@ -64,6 +67,9 @@ export const sbInfo: StackBlitzInfo = {
         DataExporterExamplesModule,
         ShowClippedTextExamplesModule,
         SubscriptionTrackerExamplesModule,
+        LoadingIndicatorExamplesModule,
+        ErrorBannerExamplesModule,
+        ActivityReporterExamplesModule,
     ],
     providers: [
         {

--- a/projects/examples/src/components/activity-reporter/activity-reporter.examples.module.ts
+++ b/projects/examples/src/components/activity-reporter/activity-reporter.examples.module.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { Documentation } from '@vcd/ui-doc-lib';
+import { BannerActivityReporterComponent } from '@vcd/ui-components';
+import { SpinnerActivityReporterExampleComponent } from './spinner-activity-reporter.example.component';
+import { SpinnerActivityReporterExampleModule } from './spinner-activity-reporter.example.module';
+import { BannerActivityReporterExampleModule } from './banner-activity-reporter.example.module';
+import { BannerActivityReporterExampleComponent } from './banner-activity-reporter.example.component';
+
+Documentation.registerDocumentationEntry({
+    component: BannerActivityReporterComponent, // TODO: allow doc-lib to supoort documentation for non-components
+    displayName: 'Activity Reporter',
+    urlSegment: 'activityReporter',
+    examples: [
+        {
+            component: SpinnerActivityReporterExampleComponent,
+            forComponent: null,
+            title: 'Show/Hide the spinner activity reporter',
+        },
+        {
+            component: BannerActivityReporterExampleComponent,
+            forComponent: null,
+            title: 'Show/Hide the banner activity reporter',
+        },
+    ],
+});
+
+/**
+ * A module that imports all activity reporter examples.
+ */
+@NgModule({
+    imports: [SpinnerActivityReporterExampleModule, BannerActivityReporterExampleModule],
+})
+export class ActivityReporterExamplesModule {}

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.html
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.html
@@ -1,0 +1,4 @@
+<button *ngIf="!showBanner" (click)="startActivity()">Start Activity Reporter</button>
+<button *ngIf="showBanner" (click)="throwError()">Throw Error</button>
+<button *ngIf="showBanner" (click)="reportSuccess()">Report Success</button>
+<vcd-banner-activity-reporter></vcd-banner-activity-reporter>

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { BannerActivityReporterComponent, ActivityReporter } from '@vcd/ui-components';
+
+/**
+ * Press the button to show/hide the banner activity reporter
+ */
+@Component({
+    selector: 'vcd-banner-activity-reporter-example',
+    templateUrl: './banner-activity-reporter.example.component.html',
+})
+export class BannerActivityReporterExampleComponent {
+    showBanner = false;
+    resolve;
+    reject;
+
+    @ViewChild(BannerActivityReporterComponent, { static: true }) reporter: ActivityReporter;
+
+    startActivity(): void {
+        this.showBanner = true;
+        this.reporter
+            .monitorActivity(
+                new Promise((resolve, reject) => {
+                    this.reject = reject;
+                    this.resolve = resolve;
+                })
+            )
+            .then(result => {
+                this.showBanner = false;
+                return result;
+            });
+    }
+
+    throwError(): void {
+        this.reject('Error!!');
+    }
+
+    reportSuccess(): void {
+        this.resolve('done!');
+    }
+}

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ActivityReporterModule } from '@vcd/ui-components';
+import { BannerActivityReporterExampleComponent } from './banner-activity-reporter.example.component';
+
+@NgModule({
+    declarations: [BannerActivityReporterExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ActivityReporterModule],
+    exports: [BannerActivityReporterExampleComponent],
+    entryComponents: [BannerActivityReporterExampleComponent],
+})
+export class BannerActivityReporterExampleModule {}

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.html
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.html
@@ -1,0 +1,4 @@
+<button *ngIf="!showSpinner" (click)="startActivity()">Start Activity Reporter</button>
+<button *ngIf="showSpinner" (click)="throwError()">Throw Error</button>
+<button *ngIf="showSpinner" (click)="reportSuccess()">Report Success</button>
+<vcd-spinner-activity-reporter></vcd-spinner-activity-reporter>

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { SpinnerActivityReporterComponent, ActivityReporter } from '@vcd/ui-components';
+
+/**
+ * Press the button to show/hide the spinner activity reporter
+ */
+@Component({
+    selector: 'vcd-spinner-activity-reporter-example',
+    templateUrl: './spinner-activity-reporter.example.component.html',
+})
+export class SpinnerActivityReporterExampleComponent {
+    showSpinner = false;
+    resolve;
+    reject;
+
+    @ViewChild(SpinnerActivityReporterComponent, { static: true }) reporter: ActivityReporter;
+
+    startActivity(): void {
+        this.showSpinner = true;
+        this.reporter
+            .monitorActivity(
+                new Promise((resolve, reject) => {
+                    this.reject = reject;
+                    this.resolve = resolve;
+                })
+            )
+            .then(result => {
+                this.showSpinner = false;
+                return result;
+            });
+    }
+
+    throwError(): void {
+        this.reject('Error!!');
+    }
+
+    reportSuccess(): void {
+        this.resolve('done!');
+    }
+}

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ActivityReporterModule } from '@vcd/ui-components';
+import { SpinnerActivityReporterExampleComponent } from './spinner-activity-reporter.example.component';
+
+@NgModule({
+    declarations: [SpinnerActivityReporterExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ActivityReporterModule],
+    exports: [SpinnerActivityReporterExampleComponent],
+    entryComponents: [SpinnerActivityReporterExampleComponent],
+})
+export class SpinnerActivityReporterExampleModule {}

--- a/projects/examples/src/components/error/error-banner.example.component.html
+++ b/projects/examples/src/components/error/error-banner.example.component.html
@@ -1,0 +1,2 @@
+<button (click)="showError = !showError">Show/Hide Error</button>
+<vcd-error-banner [errorMessage]="showError ? 'Error!' : undefined"></vcd-error-banner>

--- a/projects/examples/src/components/error/error-banner.example.component.ts
+++ b/projects/examples/src/components/error/error-banner.example.component.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+
+/**
+ * Press the button to show/hide the error banner.
+ */
+@Component({
+    selector: 'vcd-error-banner-example',
+    templateUrl: './error-banner.example.component.html',
+})
+export class ErrorBannerExampleComponent {
+    showError = false;
+}

--- a/projects/examples/src/components/error/error-banner.example.module.ts
+++ b/projects/examples/src/components/error/error-banner.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ErrorBannerModule } from '@vcd/ui-components';
+import { ErrorBannerExampleComponent } from './error-banner.example.component';
+
+@NgModule({
+    declarations: [ErrorBannerExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ErrorBannerModule],
+    exports: [ErrorBannerExampleComponent],
+    entryComponents: [ErrorBannerExampleComponent],
+})
+export class ErrorBannerExampleModule {}

--- a/projects/examples/src/components/error/error-banner.examples.module.ts
+++ b/projects/examples/src/components/error/error-banner.examples.module.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { Documentation } from '@vcd/ui-doc-lib';
+import { ErrorBannerComponent } from '@vcd/ui-components';
+import { ErrorBannerExampleComponent } from './error-banner.example.component';
+import { ErrorBannerExampleModule } from './error-banner.example.module';
+
+Documentation.registerDocumentationEntry({
+    component: ErrorBannerComponent,
+    displayName: 'Error Banner',
+    urlSegment: 'errorBanner',
+    examples: [
+        {
+            component: ErrorBannerExampleComponent,
+            forComponent: null,
+            title: 'Error banner when the button is pressed',
+        },
+    ],
+});
+
+/**
+ * A module that imports all error banner examples.
+ */
+@NgModule({
+    imports: [ErrorBannerExampleModule],
+})
+export class ErrorBannerExamplesModule {}

--- a/projects/examples/src/components/loading/loading-indicator.example.component.html
+++ b/projects/examples/src/components/loading/loading-indicator.example.component.html
@@ -1,0 +1,2 @@
+<button (click)="isLoading = !isLoading">Start/Stop Loading</button>
+<vcd-loading-indicator [isLoading]="isLoading"></vcd-loading-indicator>

--- a/projects/examples/src/components/loading/loading-indicator.example.component.ts
+++ b/projects/examples/src/components/loading/loading-indicator.example.component.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+
+/**
+ * Press the button to start/stop the loading indicator.
+ */
+@Component({
+    selector: 'vcd-loading-indicator-example',
+    templateUrl: './loading-indicator.example.component.html',
+})
+export class LoadingIndicatorExampleComponent {
+    isLoading = false;
+}

--- a/projects/examples/src/components/loading/loading-indicator.example.module.ts
+++ b/projects/examples/src/components/loading/loading-indicator.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { LoadingIndicatorExampleComponent } from './loading-indicator.example.component';
+import { LoadingIndicatorModule } from '@vcd/ui-components';
+
+@NgModule({
+    declarations: [LoadingIndicatorExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, LoadingIndicatorModule],
+    exports: [LoadingIndicatorExampleComponent],
+    entryComponents: [LoadingIndicatorExampleComponent],
+})
+export class LoadingIndicatorExampleModule {}

--- a/projects/examples/src/components/loading/loading-indicator.examples.module.ts
+++ b/projects/examples/src/components/loading/loading-indicator.examples.module.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { Documentation } from '@vcd/ui-doc-lib';
+import { LoadingIndicatorComponent } from '@vcd/ui-components';
+import { LoadingIndicatorExampleComponent } from './loading-indicator.example.component';
+import { LoadingIndicatorExampleModule } from './loading-indicator.example.module';
+
+Documentation.registerDocumentationEntry({
+    component: LoadingIndicatorComponent,
+    displayName: 'Loading Indicator',
+    urlSegment: 'loadingIndicator',
+    examples: [
+        {
+            component: LoadingIndicatorExampleComponent,
+            forComponent: null,
+            title: 'Shows a loading indicator when set to loading',
+        },
+    ],
+});
+
+/**
+ * A module that imports all loading indicator examples.
+ */
+@NgModule({
+    imports: [LoadingIndicatorExampleModule],
+})
+export class LoadingIndicatorExamplesModule {}

--- a/projects/examples/src/components/subscription/subscription-tracker-mixin.example.component.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker-mixin.example.component.ts
@@ -7,10 +7,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { SubscriptionTrackerMixin } from '@vcd/ui-components';
 
-interface Data {
-    value: string;
-}
-
 /**
  * Automatically destroy subscriptions when components are destroyed by using the {@link SubscriptionTrackerMixin}.
  */

--- a/tslint.json
+++ b/tslint.json
@@ -31,7 +31,7 @@
       true,
       {
         "match":  "Copyright \\d{4}(-\\d{4})? VMware, Inc.\n[ *]*SPDX-License-Identifier: BSD-2-Clause",
-        "default": "Copyright 2019 VMware, Inc.\nSPDX-License-Identifier: BSD-2-Clause"
+        "default": "Copyright 2020 VMware, Inc.\nSPDX-License-Identifier: BSD-2-Clause"
       }
     ],
     "import-blacklist": [


### PR DESCRIPTION
# Description

Adds the activity reporter from VCD-UI into the core components library. This abstract class allows for components to monitor observables and post errors when appropriate. This change also required moving over the Error Banner and the Loading Indicator. 

I removed the dependency to ResovledCursor by extracting an interface (`ActivityResponse`) that is the simplest set of information we need (just error? and status). After that, everything was mostly copy-paste.

# Testing

Added unit tests to achieve ~100% coverage of the diff. In addition, added examples of the loading indicator, the error banner, and both types of activity reporters (banner + spinner)

![activity-monitor](https://user-images.githubusercontent.com/7528512/76229807-27c20880-61f9-11ea-9b79-21795b59630b.gif)

# Notes to Reviewer

Some items that I would like a second opinion on:
1. In the tests for banner and spinner activity reporter, I had to disable the line length checker for the it statements. I couldn't find another way to rework it so that the line was not too long, but open to suggestions.
2. In the activity-reporter.examples.module.ts file, I had to use `BannerActivityReporterComponent` as the component for the documentation registration. This is because `ActivityReporter` is an abstract class that doesn't satisfy the requirements for `component`. I put a TODO requesting a change to doc-lib to support documentation for non-component files, but I don't know if there is a better way. 