### PR TITLE
Implemented auto cliptext in the grid cells

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -111,7 +111,7 @@
             </div>
         </clr-dg-cell>
 
-        <clr-dg-cell *ngFor="let column of columnsConfig">
+        <clr-dg-cell [vcdShowClippedText]="column.cliptextConfig" *ngFor="let column of columnsConfig">
             <!-- Default renderer -->
             <ng-container *ngIf="column.fieldName">{{ restItem | nestedProperty: column.fieldName }}</ng-container>
 

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -3,25 +3,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, ViewChild, TemplateRef, ContentChild } from '@angular/core';
+import { Component, ContentChild, TemplateRef, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
+import { ClrDatagridWidgetObject } from '../utils/test/datagrid/datagrid.wo';
+import { WidgetFinder } from '../utils/test/widget-object';
 import { GridSelectionType, PaginationConfiguration } from './datagrid.component';
 import { DatagridComponent, GridDataFetchResult, GridState } from './datagrid.component';
+import { DatagridModule } from './datagrid.module';
 import {
+    ButtonConfig,
+    ColumnComponentRendererSpec,
+    ContextualButtonPosition,
     GridColumn,
     GridColumnHideable,
-    ButtonConfig,
-    ContextualButtonPosition,
     InactiveButtonDisplayMode,
-    ColumnComponentRendererSpec,
 } from './interfaces/datagrid-column.interface';
-import { TestBed } from '@angular/core/testing';
-import { DatagridModule } from './datagrid.module';
-import { WidgetFinder } from '../utils/test/widget-object';
-import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
-import { ClrDatagridWidgetObject } from '../utils/test/datagrid/datagrid.wo';
-import { WithGridBoldRenderer } from './renderers/bold-text-renderer.wo';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { mockData, MockRecord } from './mock-data';
+import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
+import { WithGridBoldRenderer } from './renderers/bold-text-renderer.wo';
 
 type MockRecordDatagridComponent = DatagridComponent<MockRecord>;
 
@@ -108,6 +109,38 @@ describe('DatagridComponent', () => {
                     'secondRowB',
                     'Expected a different new class to display for the second row.'
                 );
+            });
+
+            describe('@Input() columns.disableCliptext', () => {
+                beforeEach(function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.gridData = {
+                        items: mockData,
+                        totalItems: 2,
+                    };
+                    this.finder.detectChanges();
+                });
+
+                it('clips text when disableCliptext is unset', function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.columns = [{ displayName: 'Name', renderer: 'name' }];
+                    this.finder.detectChanges();
+                    expect(this.clrGridWidget.columnClippedTextDirective(0).disabled).toBeFalsy();
+                });
+
+                it('clips text when disableCliptext is false', function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.columns = [
+                        { displayName: 'Name', renderer: 'name', cliptextConfig: { size: TooltipSize.md } },
+                    ];
+                    this.finder.detectChanges();
+                    expect(this.clrGridWidget.columnClippedTextDirective(0).disabled).toBeFalsy();
+                });
+
+                it('does not clip text when disableCliptext is true', function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.columns = [
+                        { displayName: 'Name', renderer: 'name', cliptextConfig: { disabled: true } },
+                    ];
+                    this.finder.detectChanges();
+                    expect(this.clrGridWidget.columnClippedTextDirective(0).disabled).toBeTruthy();
+                });
             });
 
             describe('@Input() selectionType', () => {

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -4,32 +4,33 @@
  */
 
 import {
+    AfterViewInit,
     Component,
+    ContentChild,
+    ElementRef,
     EventEmitter,
+    HostBinding,
     Input,
     OnInit,
     Output,
     TemplateRef,
-    ViewChild,
     TrackByFunction,
-    ContentChild,
-    ElementRef,
-    AfterViewInit,
-    HostBinding,
+    ViewChild,
 } from '@angular/core';
-import { ClrDatagridFilter, ClrDatagrid, ClrDatagridStateInterface, ClrDatagridPagination } from '@clr/angular';
+import { ClrDatagrid, ClrDatagridFilter, ClrDatagridPagination, ClrDatagridStateInterface } from '@clr/angular';
+import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
+import { DatagridFilter } from './filters/datagrid-filter';
 import {
+    Button,
+    ButtonConfig,
+    ColumnRendererSpec,
+    ContextualButtonPosition,
     FunctionRenderer,
     GridColumn,
     GridColumnHideable,
-    ButtonConfig,
-    ContextualButtonPosition,
-    Button,
     InactiveButtonDisplayMode,
-    ColumnRendererSpec,
 } from './interfaces/datagrid-column.interface';
 import { ContextualButton } from './interfaces/datagrid-column.interface';
-import { DatagridFilter } from './filters/datagrid-filter';
 
 /**
  * The default number of items on a single page.
@@ -231,6 +232,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
 
     ContextualButtonPosition = ContextualButtonPosition;
     GridColumnHideable = GridColumnHideable;
+    TooltipSize = TooltipSize;
     private _columns: GridColumn<R>[];
 
     @ContentChild(TemplateRef, { static: false }) detailTemplate!: TemplateRef<ElementRef>;

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -6,6 +6,7 @@
 /**
  * Whether something shows up in the column toggler
  */
+import { TooltipSize, CliptextConfig } from '../../lib/directives/show-clipped-text.directive';
 import { FilterConfig, FilterRendererSpec } from '../filters/datagrid-filter';
 import { ComponentRendererConstructor, ComponentRendererSpec } from './component-renderer.interface';
 
@@ -234,6 +235,13 @@ export interface GridColumn<R> {
      * and sorting feature on. And we want filtering to be off on some columns while still having sorting enabled.
      */
     sortBy?: string;
+
+    /**
+     * The configuration for the cliptext in the datagrid.
+     * Defaults to size: 'lg', mouseoutDelay: undefined.
+     * If null, will disable cliptext
+     */
+    cliptextConfig?: CliptextConfig;
 }
 
 /**

--- a/projects/components/src/lib/directives/show-clipped-text.directive.test-helper.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.test-helper.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { ComponentFixture } from '@angular/core/testing';
 import { Component, ElementRef, ViewChild } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
 import { ShowClippedTextDirective, TooltipPosition } from './show-clipped-text.directive';
 
 /**
@@ -41,6 +41,11 @@ export class ShowClippedTextDirectiveTestHelper {
         Object.assign(this.host.style, defaults);
     }
 
+    set disabled(disabled: boolean) {
+        this.componentInstance.disabled = disabled;
+        this.fixture.detectChanges();
+    }
+
     set hostText(text: string) {
         this.componentInstance.text = text;
         this.fixture.detectChanges();
@@ -71,8 +76,7 @@ export class ShowClippedTextDirectiveTestHelper {
     }
 
     get isTooltipVisible(): boolean {
-        const opacity = this.tooltip.style.opacity;
-        return opacity === '1' || opacity === '';
+        return !!this.tooltip && (this.tooltip.style.opacity === '1' || this.tooltip.style.opacity === '');
     }
 
     get tooltipText(): string {
@@ -118,8 +122,8 @@ export class ShowClippedTextDirectiveTestHelper {
 
 @Component({
     template: `
-        <div [vcdShowClippedText] style="width: 20px" #div>{{ text }}</div>
-        <div [vcdShowClippedText] style="width: 20px" #div2>{{ text2 }}</div>
+        <div [vcdShowClippedText]="{ disabled: disabled }" style="width: 20px" #div>{{ text }}</div>
+        <div [vcdShowClippedText]="{ disabled: disabled }" style="width: 20px" #div2>{{ text2 }}</div>
     `,
 })
 export class ShowClippedTextDirectiveTestHostComponent {
@@ -129,4 +133,5 @@ export class ShowClippedTextDirectiveTestHostComponent {
 
     public text = 'texting';
     public text2 = 'texting too';
+    public disabled = false;
 }

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -4,15 +4,13 @@
  */
 
 import { GridSelectionType } from './../../../datagrid/datagrid.component';
-/*!
- * Copyright 2019 VMware, Inc.
- * SPDX-License-Identifier: BSD-2-Clause
- */
 
-import { WidgetObject } from '../widget-object';
 import { DebugElement, Type } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { ClrDatagrid } from '@clr/angular';
 import { DatagridFilter } from '../../../datagrid';
+import { ShowClippedTextDirective } from '../../../lib/directives/show-clipped-text.directive';
+import { WidgetObject } from '../widget-object';
 
 const ROW_TAG = 'clr-dg-row';
 const CELL_TAG = 'clr-dg-cell';
@@ -33,6 +31,15 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
      */
     getCellText(row: number, column: number): string {
         return this.getNodeText(this.getCell(row, column));
+    }
+
+    /**
+     * Retrieves if the cell will clip text
+     * @param column 0-based index of column
+     */
+    columnClippedTextDirective(column: number): ShowClippedTextDirective {
+        const res = this.getCell(0, column);
+        return res.injector.get(ShowClippedTextDirective);
     }
 
     /**

--- a/projects/examples/src/components/datagrid/datagrid-cliptext.example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-cliptext.example.component.html
@@ -1,0 +1,1 @@
+<vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns"></vcd-datagrid>

--- a/projects/examples/src/components/datagrid/datagrid-cliptext.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-cliptext.example.component.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { BoldTextRenderer, GridColumn, GridDataFetchResult, GridState, TooltipSize } from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+}
+
+/**
+ * Shows cliptext on the columns, except for the last one.
+ */
+@Component({
+    selector: 'vcd-datagrid-cliptext-example',
+    templateUrl: './datagrid-cliptext.example.component.html',
+})
+export class DatagridCliptextExampleComponent {
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Column 1',
+            renderer: BoldTextRenderer(rec => rec.value),
+        },
+        {
+            displayName: 'Column 2',
+            renderer: 'value',
+        },
+        {
+            displayName: 'Column 3',
+            renderer: 'value',
+        },
+        {
+            displayName: 'Column 4',
+            renderer: 'value',
+            cliptextConfig: {
+                size: TooltipSize.md,
+            },
+        },
+        {
+            displayName: 'Column 5',
+            renderer: 'value',
+            cliptextConfig: { disabled: true },
+        },
+    ];
+
+    refresh(eventData: GridState<Data>): void {
+        this.gridData = {
+            items: [{ value: 'longggggggggggggggggggggggggggggg' }],
+            totalItems: 1,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-cliptext.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-cliptext.example.module.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ClarityModule } from '@clr/angular';
+import { DatagridModule } from '@vcd/ui-components';
+import { DatagridCliptextExampleComponent } from './datagrid-cliptext.example.component';
+
+@NgModule({
+    declarations: [DatagridCliptextExampleComponent],
+    imports: [CommonModule, ClarityModule, DatagridModule],
+    exports: [DatagridCliptextExampleComponent],
+    entryComponents: [DatagridCliptextExampleComponent],
+})
+export class DatagridCliptextExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid-three-renderers.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-three-renderers.example.module.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridThreeRenderersExampleComponent } from './datagrid-three-renderers.example.component';

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -4,30 +4,32 @@
  */
 
 import { NgModule } from '@angular/core';
-import { DatagridShowHideExampleComponent } from './datagrid-show-hide.example.component';
 import { DatagridComponent } from '@vcd/ui-components';
 import { Documentation } from '@vcd/ui-doc-lib';
+import { DatagridCliptextExampleComponent } from './datagrid-cliptext.example.component';
+import { DatagridCliptextExampleModule } from './datagrid-cliptext.example.module';
 import { DatagridCssClassesExampleComponent } from './datagrid-css-classes.example.component';
-import { DatagridThreeRenderersExampleComponent } from './datagrid-three-renderers.example.component';
-import { DatagridThreeRenderersExampleModule } from './datagrid-three-renderers.example.module';
 import { DatagridCssClassesExampleModule } from './datagrid-css-classes.example.module';
-import { DatagridShowHideExampleModule } from './datagrid-show-hide.example.module';
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 import { DatagridDetailRowExampleModule } from './datagrid-detail-row.example.module';
-import { DatagridSortExampleModule } from './datagrid-sort.example.module';
-import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
-import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
-import { DatagridRowSelectExampleModule } from './datagrid-row-select.example.module';
-import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
-import { DatagridPagionationExampleModule } from './datagrid-pagination-example.module';
-import { DatagridLinkExampleModule } from './datagrid-link.example.module';
-import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
-import { DatagridHeightExampleModule } from './datagrid-height.example.module';
-import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
+import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
+import { DatagridFilterExampleModule } from './datagrid-filter.example.module';
 import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
 import { DatagridHeaderExampleModule } from './datagrid-header.example.module';
-import { DatagridFilterExampleModule } from './datagrid-filter.example.module';
-import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
+import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
+import { DatagridHeightExampleModule } from './datagrid-height.example.module';
+import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
+import { DatagridLinkExampleModule } from './datagrid-link.example.module';
+import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
+import { DatagridPagionationExampleModule } from './datagrid-pagination-example.module';
+import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
+import { DatagridRowSelectExampleModule } from './datagrid-row-select.example.module';
+import { DatagridShowHideExampleComponent } from './datagrid-show-hide.example.component';
+import { DatagridShowHideExampleModule } from './datagrid-show-hide.example.module';
+import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
+import { DatagridSortExampleModule } from './datagrid-sort.example.module';
+import { DatagridThreeRenderersExampleComponent } from './datagrid-three-renderers.example.component';
+import { DatagridThreeRenderersExampleModule } from './datagrid-three-renderers.example.module';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -85,9 +87,9 @@ Documentation.registerDocumentationEntry({
             title: 'Links from Datagrid Example',
         },
         {
-            component: DatagridFilterExampleComponent,
+            component: DatagridCliptextExampleComponent,
             forComponent: null,
-            title: 'Data grid filters',
+            title: 'Cliptext in the datagrid cells',
         },
     ],
 });
@@ -107,6 +109,7 @@ Documentation.registerDocumentationEntry({
         DatagridHeightExampleModule,
         DatagridHeaderExampleModule,
         DatagridFilterExampleModule,
+        DatagridCliptextExampleModule,
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
# Description

Grid cells will automatically enable cliptext using the show-cliptext directive. This is always the case unless the client sets disableCliptext to true within the column configuration.

# Testing

Added an example that shows text being clipped for normal renderers and component renderers. It also shows cliptext being disabled. Also, added tests to test if disabling cliptext actually removes the directive. 

![cliptext](https://user-images.githubusercontent.com/7528512/76647757-c9b45e80-6533-11ea-9608-8e3f175a11bd.gif)

# Reviewer Notes:
1. I chose to make cliptext size be always large. Should this be an input option?

Signed-off-by: Ryan Bradford <rbradford@vmware.com>
