### PR TITLE
Enabled activity reporting on the grid

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,4 +1,8 @@
 <h3 *ngIf="this.header" class="vcd-header">{{ header }}</h3>
+<vcd-spinner-activity-reporter #actionReporter *ngIf="ActivityIndicatorType.SPINNER === indicatorType">
+</vcd-spinner-activity-reporter>
+<vcd-banner-activity-reporter #actionReporter *ngIf="ActivityIndicatorType.BANNER === indicatorType">
+</vcd-banner-activity-reporter>
 <clr-datagrid
     [clrDgLoading]="isLoading"
     [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent-grid']"
@@ -10,7 +14,7 @@
                 class="btn"
                 [ngClass]="button.class"
                 *ngIf="isButtonShown(button)"
-                (click)="button.handler()"
+                (click)="runButtonHandler(button, [])"
                 [disabled]="isButtonDisabled(button, button.isActive())"
             >
                 <ng-container>{{ button.label }}</ng-container>
@@ -23,7 +27,7 @@
                     *ngFor="let button of this.getFeaturedButtons()"
                     type="button"
                     class="btn btn-icon"
-                    (click)="button.handler(datagridSelection)"
+                    (click)="runButtonHandler(button, datagridSelection)"
                     [disabled]="isButtonDisabled(button, button.isActive(datagridSelection))"
                 >
                     <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
@@ -80,7 +84,7 @@
                 <button
                     class="btn btn-icon action-button"
                     *ngFor="let button of this.getFeaturedButtons(restItem)"
-                    (click)="button.handler([restItem])"
+                    (click)="runButtonHandler(button, [restItem])"
                     [disabled]="isButtonDisabled(button, button.isActive([restItem]))"
                 >
                     <a role="tooltip" aria-haspopup="true" class="tooltip tooltip-sm">
@@ -101,7 +105,7 @@
                                 class="btn"
                                 [ngClass]="button.class"
                                 [disabled]="!button.isActive([restItem])"
-                                (click)="button.handler([restItem])"
+                                (click)="runButtonHandler(button, [restItem])"
                             >
                                 {{ button.label }}
                             </button>
@@ -155,7 +159,7 @@
                 class="btn"
                 [ngClass]="button.class"
                 [disabled]="!button.isActive(this.datagridSelection)"
-                (click)="button.handler(this.datagridSelection)"
+                (click)="runButtonHandler(button, this.datagridSelection)"
             >
                 {{ button.label }}
             </button>

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -733,7 +733,7 @@ describe('DatagridComponent', () => {
             it('does not show a header when none is set', function(this: HasFinderAndGrid): void {
                 this.finder.hostComponent.header = undefined;
                 this.finder.detectChanges();
-                expect(this.vcdDatagrid.gridHeader).toEqual(undefined);
+                expect(this.vcdDatagrid.gridHeader).toEqual('');
             });
         });
     });

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -23,15 +23,18 @@ import {
 import { mockData, MockRecord } from './mock-data';
 import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
 import { WithGridBoldRenderer } from './renderers/bold-text-renderer.wo';
+import { VcdDatagridWidgetObject } from '../utils/test/datagrid/vcd-datagrid.wo';
 
 type MockRecordDatagridComponent = DatagridComponent<MockRecord>;
 
-class GridWithBoldRenderer extends WithGridBoldRenderer(ClrDatagridWidgetObject) {}
+class GridWithBoldRenderer extends WithGridBoldRenderer(VcdDatagridWidgetObject)<MockRecord> {}
 
 interface HasFinderAndGrid {
     finder: WidgetFinder<HostWithDatagridComponent>;
     // The Widget Object for the underlying Clarity grid
-    clrGridWidget: GridWithBoldRenderer;
+    clrGridWidget: ClrDatagridWidgetObject;
+    // The Widget Object for the VCD Datagrid
+    vcdDatagrid: GridWithBoldRenderer;
     // The instance of DatagridComponent
     component: MockRecordDatagridComponent;
 }
@@ -44,7 +47,8 @@ describe('DatagridComponent', () => {
         }).compileComponents();
 
         this.finder = new WidgetFinder(HostWithDatagridComponent);
-        this.clrGridWidget = this.finder.find(GridWithBoldRenderer);
+        this.vcdDatagrid = this.finder.find(GridWithBoldRenderer);
+        this.clrGridWidget = this.vcdDatagrid.clrDatagrid;
     });
 
     describe('Grid', () => {
@@ -720,16 +724,16 @@ describe('DatagridComponent', () => {
             it('shows the header if set and allows it to be changed', function(this: HasFinderAndGrid): void {
                 this.finder.hostComponent.header = 'Some Header!';
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.gridHeader).toEqual('Some Header!');
+                expect(this.vcdDatagrid.gridHeader).toEqual('Some Header!');
                 this.finder.hostComponent.header = 'Some Other Header!';
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.gridHeader).toEqual('Some Other Header!');
+                expect(this.vcdDatagrid.gridHeader).toEqual('Some Other Header!');
             });
 
             it('does not show a header when none is set', function(this: HasFinderAndGrid): void {
                 this.finder.hostComponent.header = undefined;
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.gridHeader).toEqual(undefined);
+                expect(this.vcdDatagrid.gridHeader).toEqual(undefined);
             });
         });
     });
@@ -770,7 +774,7 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getBoldText(0, 0)).toBe(mockData[0].name);
+                expect(this.vcdDatagrid.getBoldText(0, 0)).toBe(mockData[0].name);
             });
         });
     });

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -9,7 +9,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { ClrDatagridWidgetObject } from '../utils/test/datagrid/datagrid.wo';
 import { WidgetFinder } from '../utils/test/widget-object';
-import { GridSelectionType, PaginationConfiguration } from './datagrid.component';
+import { GridSelectionType, PaginationConfiguration, ActivityIndicatorType } from './datagrid.component';
 import { DatagridComponent, GridDataFetchResult, GridState } from './datagrid.component';
 import { DatagridModule } from './datagrid.module';
 import {
@@ -679,6 +679,41 @@ describe('DatagridComponent', () => {
                     });
                 });
             });
+
+            describe('@Input() indicatorType', () => {
+                let resolvePromise;
+
+                beforeEach(function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.buttonConfig.globalButtons = [
+                        {
+                            label: 'Add',
+                            isActive: () => true,
+                            handler: () =>
+                                new Promise(resolve => {
+                                    resolvePromise = resolve;
+                                }),
+                            class: 'button',
+                        },
+                    ];
+                    this.finder.detectChanges();
+                });
+
+                it('is able to show the spinner indicator', function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.indicatorType = ActivityIndicatorType.SPINNER;
+                    this.finder.detectChanges();
+                    const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
+                    this.clrGridWidget.pressTopButton(0);
+                    expect(spy).toHaveBeenCalledTimes(1);
+                });
+
+                it('is able to show the banner indicator', function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.indicatorType = ActivityIndicatorType.BANNER;
+                    this.finder.detectChanges();
+                    const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
+                    this.clrGridWidget.pressTopButton(0);
+                    expect(spy).toHaveBeenCalledTimes(1);
+                });
+            });
         });
 
         describe('@Input() header', () => {
@@ -757,6 +792,7 @@ describe('DatagridComponent', () => {
             [buttonConfig]="buttonConfig"
             [height]="height"
             [header]="header"
+            [indicatorType]="indicatorType"
         >
             <ng-template let-record="record"> DETAILS: {{ record.name }} </ng-template>
         </vcd-datagrid>
@@ -780,6 +816,8 @@ export class HostWithDatagridComponent {
     height?: number;
 
     header?: string;
+
+    indicatorType?: ActivityIndicatorType;
 
     buttonConfig: ButtonConfig<MockRecord> = {
         globalButtons: [],

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -31,6 +31,7 @@ import {
     InactiveButtonDisplayMode,
 } from './interfaces/datagrid-column.interface';
 import { ContextualButton } from './interfaces/datagrid-column.interface';
+import { ActivityReporter } from '../common/activity-reporter/activity-reporter';
 
 /**
  * The default number of items on a single page.
@@ -96,6 +97,20 @@ export interface SortedColumn {
      * The name of the column that is sorted.
      */
     name: string;
+}
+
+/**
+ * The types of activity indicators that can be displayed on top of the grid.
+ */
+export enum ActivityIndicatorType {
+    /**
+     * Display a {@link SpinnerActivityReporterComponent} indicator
+     */
+    SPINNER,
+    /**
+     * Display a {@link BannerActivityReporterComponent} indicator
+     */
+    BANNER,
 }
 
 /**
@@ -213,6 +228,12 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
     }
 
     /**
+     * The type of activity indicator that should sit ontop of the grid.
+     */
+    @Input()
+    indicatorType: ActivityIndicatorType;
+
+    /**
      * Set from the caller component using this grid. The input is set upon fetching data by the caller
      */
     @Input() set gridData(result: GridDataFetchResult<R>) {
@@ -233,6 +254,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
     ContextualButtonPosition = ContextualButtonPosition;
     GridColumnHideable = GridColumnHideable;
     TooltipSize = TooltipSize;
+    ActivityIndicatorType = ActivityIndicatorType;
     private _columns: GridColumn<R>[];
 
     @ContentChild(TemplateRef, { static: false }) detailTemplate!: TemplateRef<ElementRef>;
@@ -400,6 +422,11 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
     @ViewChild(ClrDatagridPagination, { static: false }) paginationComponent: ClrDatagridPagination;
 
     /**
+     * The activity reporter that all activites are displayed on
+     */
+    @ViewChild('actionReporter', { static: false }) actionReporter: ActivityReporter;
+
+    /**
      * Returns an identifier for the given record at the given index.
      *
      * If the record has a href, defaults to that. Else, defaults to index.
@@ -495,6 +522,16 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
      */
     hasContextualButtons(): boolean {
         return this._buttonConfig.contextualButtonConfig.buttons.length !== 0;
+    }
+
+    /**
+     * Runs the handler function for the given button with the given selection.
+     */
+    runButtonHandler(button: Button<R>, selection?: R[]): void {
+        const response = button.handler(selection);
+        if (response && this.actionReporter) {
+            this.actionReporter.monitorActivity(response);
+        }
     }
 
     /**

--- a/projects/components/src/datagrid/datagrid.module.ts
+++ b/projects/components/src/datagrid/datagrid.module.ts
@@ -20,6 +20,7 @@ import { DatagridStringFilterComponent } from './filters/datagrid-string-filter.
 import { DatagridNumericFilterComponent } from './filters/datagrid-numeric-filter.component';
 import { DatagridSelectFilterComponent } from './filters/datagrid-select-filter.component';
 import { DatagridMultiSelectFilterComponent } from './filters/datagrid-multiselect-filter.component';
+import { ActivityReporterModule } from '../common/activity-reporter/activity-reporter.module';
 
 const directives = [ComponentRendererOutletDirective];
 const pipes = [FunctionRendererPipe];
@@ -42,6 +43,7 @@ const filters = [
         FormsModule,
         BrowserAnimationsModule,
         I18nModule,
+        ActivityReporterModule,
     ],
     declarations: [DatagridComponent, ...directives, ...renderers, ...pipes, ...filters],
     providers: [],

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -63,7 +63,7 @@ export interface Button<R> {
      *
      * @param entity the currently selected entities.
      */
-    handler: (rec?: R[]) => void;
+    handler: (rec?: R[]) => Promise<string | undefined> | void;
     /**
      * The function that is called to determine if the button should be displayed.
      *
@@ -76,10 +76,6 @@ export interface Button<R> {
  * A type of button whose displayability does not depend on the selected entity.
  */
 export interface GlobalButton<R> extends Button<R> {
-    /**
-     * The function that is called when the button is pressed.
-     */
-    handler: () => void;
     /**
      * The function that is called to determine if the button should be displayed.
      */
@@ -95,7 +91,7 @@ export interface ContextualButton<R> extends Button<R> {
      *
      * @param entity the currently selected entities.
      */
-    handler: (entity: R[]) => void;
+    handler: (entity: R[]) => Promise<string | undefined> | void;
     /**
      * The function that is called to determine if the button should be displayed.
      *

--- a/projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts
+++ b/projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts
@@ -4,18 +4,18 @@
  */
 
 import { Type } from '@angular/core';
-import { ClrDatagridWidgetObject } from '../../utils/test/datagrid/datagrid.wo';
 import { BoldTextRendererComponent } from './bold-text-renderer.component';
 import { WidgetObject } from '../../utils/test/widget-object';
+import { VcdDatagridWidgetObject } from '../../utils/test/datagrid/vcd-datagrid.wo';
 
 /**
  * Mixin that allows {@link ClrDatagridWidgetObject} to read information from {@link BoldTextRendererComponent}
  */
 // tslint:disable-next-line:typedef
-export function WithGridBoldRenderer<TBase extends Type<ClrDatagridWidgetObject>>(Base: TBase) {
+export function WithGridBoldRenderer<TBase extends Type<VcdDatagridWidgetObject<unknown>>>(Base: TBase) {
     return class extends Base {
         getBoldText(row: number, column: number): string {
-            const cellElement = this.getCell(row, column);
+            const cellElement = this.clrDatagrid.getCell(row, column);
             return this.getNodeText(this.findElement('strong', cellElement));
         }
     };

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -200,8 +200,8 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
      * Gives the header above the grid.
      */
     get gridHeader(): string | undefined {
-        const headerElement = this.root.nativeElement.previousSibling;
-        return headerElement.nodeType !== 8 ? headerElement.textContent : undefined;
+        const headerElement = this.findElement('h3', this.root.parent);
+        return headerElement ? headerElement.nativeElement.textContent : undefined;
     }
 
     /**

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -6,7 +6,6 @@
 import { GridSelectionType } from './../../../datagrid/datagrid.component';
 
 import { DebugElement, Type } from '@angular/core';
-import { By } from '@angular/platform-browser';
 import { ClrDatagrid } from '@clr/angular';
 import { DatagridFilter } from '../../../datagrid';
 import { ShowClippedTextDirective } from '../../../lib/directives/show-clipped-text.directive';
@@ -197,21 +196,13 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
-     * Gives the header above the grid.
-     */
-    get gridHeader(): string | undefined {
-        const headerElement = this.findElement('h3', this.root.parent);
-        return headerElement ? headerElement.nativeElement.textContent : undefined;
-    }
-
-    /**
      * Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that
      * subclasses should not return the DebugElement, they should return a string from a section of the HTML.
      *
      * @param row 0-based index of row
      * @param column 0-based index of column
      */
-    protected getCell(row: number, column: number): DebugElement {
+    getCell(row: number, column: number): DebugElement {
         return this.findElement(`${ROW_TAG}:nth-of-type(${row + 1}) ${CELL_TAG}:nth-of-type(${column + 1})`);
     }
 

--- a/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
@@ -16,8 +16,8 @@ export class VcdDatagridWidgetObject<R> extends WidgetObject<DatagridComponent<R
     /**
      * Gives the header above the grid.
      */
-    get gridHeader(): string | undefined {
-        return this.findElement('h3') ? this.getText('h3') : undefined;
+    get gridHeader(): string {
+        return this.getText('h3');
     }
 
     /**

--- a/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { DatagridComponent } from './../../../datagrid/datagrid.component';
+import { WidgetObject } from '../widget-object';
+import { ClrDatagridWidgetObject } from './datagrid.wo';
+
+/**
+ * Widget Object for our VCD DataGrid
+ */
+export class VcdDatagridWidgetObject<R> extends WidgetObject<DatagridComponent<R>> {
+    static tagName = `vcd-datagrid`;
+
+    /**
+     * Gives the header above the grid.
+     */
+    get gridHeader(): string | undefined {
+        return this.findElement('h3') ? this.getText('h3') : undefined;
+    }
+
+    /**
+     * Gives the widget object for this clr datagrid.
+     */
+    get clrDatagrid(): ClrDatagridWidgetObject {
+        const constElement = this.findElement(ClrDatagridWidgetObject.tagName);
+        return new ClrDatagridWidgetObject(this.fixture, constElement, constElement.componentInstance);
+    }
+}

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -79,11 +79,13 @@ export abstract class WidgetObject<T> {
 
     /**
      * Returns text content of this widget
+     * If the element cannot be found, gives empty string.
      * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.
      */
 
     protected getText(cssSelector: string): string {
-        return this.getNodeText(this.findElement(cssSelector));
+        const element = this.findElement(cssSelector);
+        return element ? this.getNodeText(element) : '';
     }
 
     /**

--- a/projects/examples/src/app/components/show-clipped-text/sizing/show-clipped-text-sizing-example.component.html
+++ b/projects/examples/src/app/components/show-clipped-text/sizing/show-clipped-text-sizing-example.component.html
@@ -1,11 +1,11 @@
 <h2>Using fixed width and small tooltip</h2>
 <label>Text for div below: <input [(ngModel)]="text" type="text"/></label>
-<div [vcdShowClippedText]="TooltipSize.sm" class="fixed-width">{{ text }}</div>
+<div [vcdShowClippedText]="{ size: TooltipSize.sm }" class="fixed-width">{{ text }}</div>
 
 <h2>Using Max width using medium tooltip</h2>
 <label>Text for div below: <input [(ngModel)]="text2" type="text"/></label><br />
-<div [vcdShowClippedText]="TooltipSize.md" class="max-width">{{ text2 }}</div>
+<div [vcdShowClippedText]="{ size: TooltipSize.md }" class="max-width">{{ text2 }}</div>
 
 <h2>This div is a standard block using large tooltip</h2>
 <label>Text for div below: <input [(ngModel)]="text3" type="text"/></label>
-<div [vcdShowClippedText]="TooltipSize.lg">{{ text3 }}</div>
+<div [vcdShowClippedText]="{ size: TooltipSize.lg }">{{ text3 }}</div>

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.html
@@ -1,0 +1,9 @@
+<button *ngIf="started" (click)="this.reject('Woah there!')">Throw Error</button>
+<button *ngIf="started" (click)="this.resolve('Good!')">Sucess</button>
+<vcd-datagrid
+    [gridData]="gridData"
+    (gridRefresh)="refresh($event)"
+    [columns]="columns"
+    [buttonConfig]="buttonConfig"
+    [indicatorType]="indicatorType"
+></vcd-datagrid>

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import {
+    GridColumn,
+    GridDataFetchResult,
+    GridState,
+    ButtonConfig,
+    ContextualButtonPosition,
+    ActivityIndicatorType,
+} from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+}
+
+/**
+ * Shows the activity banner and how it interacts with the buttons.
+ *
+ * Press the global button to show the activity reporter, then press either of the buttons
+ * to resolve the promise.
+ */
+@Component({
+    selector: 'vcd-datagrid-activity-reporter-example',
+    templateUrl: './datagrid-activity-reporter.example.component.html',
+})
+export class DatagridActivityReporterExampleComponent {
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Some Column',
+            renderer: 'value',
+        },
+    ];
+
+    resolve: () => void;
+    reject: (error: Error) => void;
+    started = false;
+    indicatorType = ActivityIndicatorType.BANNER;
+
+    buttonConfig: ButtonConfig<Data> = {
+        globalButtons: [
+            {
+                label: 'Start Indicator',
+                isActive: () => true,
+                handler: () => {
+                    return new Promise((resolve, reject) => {
+                        this.started = true;
+                        this.resolve = resolve;
+                        this.reject = reject;
+                    })
+                        .then((): string => {
+                            this.started = false;
+                            return 'good';
+                        })
+                        .catch(error => {
+                            this.started = false;
+                            throw error;
+                        });
+                },
+            },
+        ],
+        contextualButtonConfig: {
+            buttons: [],
+            featured: [],
+            featuredCount: 0,
+            position: ContextualButtonPosition.TOP,
+        },
+    };
+
+    refresh(eventData: GridState<Data>): void {
+        this.gridData = {
+            items: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
+            totalItems: 2,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.module.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClarityModule } from '@clr/angular';
+import { DatagridModule } from '@vcd/ui-components';
+import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';
+
+@NgModule({
+    declarations: [DatagridActivityReporterExampleComponent],
+    imports: [CommonModule, ClarityModule, DatagridModule],
+    exports: [DatagridActivityReporterExampleComponent],
+    entryComponents: [DatagridActivityReporterExampleComponent],
+})
+export class DatagridActivityReporterExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -12,7 +12,6 @@ import { DatagridCssClassesExampleComponent } from './datagrid-css-classes.examp
 import { DatagridCssClassesExampleModule } from './datagrid-css-classes.example.module';
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 import { DatagridDetailRowExampleModule } from './datagrid-detail-row.example.module';
-import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
 import { DatagridFilterExampleModule } from './datagrid-filter.example.module';
 import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
 import { DatagridHeaderExampleModule } from './datagrid-header.example.module';
@@ -30,6 +29,8 @@ import { DatagridSortExampleComponent } from './datagrid-sort.example.component'
 import { DatagridSortExampleModule } from './datagrid-sort.example.module';
 import { DatagridThreeRenderersExampleComponent } from './datagrid-three-renderers.example.component';
 import { DatagridThreeRenderersExampleModule } from './datagrid-three-renderers.example.module';
+import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';
+import { DatagridActivityReporterExampleModule } from './datagrid-activity-reporter.example.module';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -95,6 +96,10 @@ Documentation.registerDocumentationEntry({
             component: DatagridCliptextExampleComponent,
             forComponent: null,
             title: 'Cliptext in the datagrid cells',
+        }, {
+            component: DatagridActivityReporterExampleComponent,
+            forComponent: null,
+            title: 'Activity reporter + buttons example',
         },
     ],
 });
@@ -115,6 +120,7 @@ Documentation.registerDocumentationEntry({
         DatagridHeaderExampleModule,
         DatagridFilterExampleModule,
         DatagridCliptextExampleModule,
+        DatagridActivityReporterExampleModule,
     ],
 })
 export class DatagridExamplesModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -13,6 +13,7 @@ import { DatagridCssClassesExampleModule } from './datagrid-css-classes.example.
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 import { DatagridDetailRowExampleModule } from './datagrid-detail-row.example.module';
 import { DatagridFilterExampleModule } from './datagrid-filter.example.module';
+import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
 import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
 import { DatagridHeaderExampleModule } from './datagrid-header.example.module';
 import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
@@ -96,7 +97,8 @@ Documentation.registerDocumentationEntry({
             component: DatagridCliptextExampleComponent,
             forComponent: null,
             title: 'Cliptext in the datagrid cells',
-        }, {
+        },
+        {
             component: DatagridActivityReporterExampleComponent,
             forComponent: null,
             title: 'Activity reporter + buttons example',


### PR DESCRIPTION
# Description

Added the activity reporter on top of the grid. Exposes it as a field of the datagrid, and also allows button handlers to return a promise that triggers the activity reporting. 

# Testing

Added unit tests to test that it works with the datagrid. In addition, added an example to show how to return a promise from the button handler and trigger reporting.

# Reviewer Notes:
1. Datagrid example is a little abstract.
2. Searching this.root.parent for h3 in the datagrid.wo.ts file to find the header feels strange.
3. Should we provide a better export from the datagrid to monitor activities outside of the grid buttons?

![grid-activity](https://user-images.githubusercontent.com/7528512/77086459-3322ea00-69d8-11ea-9b14-259fed83a526.gif)

Signed-off-by: Ryan Bradford <rbradford@vmware.com>