### PR TITLE
Fix the master branch condition expression for CI jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -163,7 +163,7 @@ jobs:
                   path: ./dist/examples
                   key: examples
             - run: npx ng deploy --no-build
-              if: github.event_name == 'push' && github.ref == 'master'
+              if: github.event_name == 'push' && github.ref == 'refs/heads/master'
               env:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -227,7 +227,7 @@ jobs:
               with:
                   lib-name: 'components'
             - name: Publish components@next
-              if: steps.check-components-tag.outputs.isLibTag != 'true' && steps.check-components-package.outputs.isLibPackageChanged == 'true' && github.event_name == 'push' && github.ref == 'master'
+              if: steps.check-components-tag.outputs.isLibTag != 'true' && steps.check-components-package.outputs.isLibPackageChanged == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
               run: |
                   cd ./dist/components
                   npm publish --tag next
@@ -294,7 +294,7 @@ jobs:
               with:
                   lib-name: 'doc-lib'
             - name: Publish doc-lib@next
-              if: steps.check-doc-lib-tag.outputs.isLibTag != 'true' && steps.check-doc-lib-package.outputs.isLibPackageChanged == 'true' && github.event_name == 'push' && github.ref == 'master'
+              if: steps.check-doc-lib-tag.outputs.isLibTag != 'true' && steps.check-doc-lib-package.outputs.isLibPackageChanged == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
               run: |
                   cd ./dist/doc-lib
                   npm publish --tag next
@@ -361,7 +361,7 @@ jobs:
               with:
                   lib-name: 'i18n'
             - name: Publish i18n@next
-              if: steps.check-i18n-tag.outputs.isLibTag != 'true' && steps.check-i18n-package.outputs.isLibPackageChanged == 'true' && github.event_name == 'push' && github.ref == 'master'
+              if: steps.check-i18n-tag.outputs.isLibTag != 'true' && steps.check-i18n-package.outputs.isLibPackageChanged == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
               run: |
                   cd ./dist/i18n
                   npm publish --tag next

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"


### PR DESCRIPTION
The if condition expressions to perform jobs only on the master branch were wrong and the condition expressions are corrected.
It didn't fail during my testing because of the `on:` condition for the workflow at top of the yaml file. Previously, it was only running on pushes to master branch and I changed it just before finalizing my changes and didn't test the condition.

Test Run: https://github.com/ps37/vmware-cloud-director-ui-components/runs/528355791?check_suite_focus=true