### PR TITLE
Add not sortable flag to grid column

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -49,7 +49,7 @@
     </clr-dg-column>
     <clr-dg-column
         *ngFor="let column of columnsConfig"
-        [clrDgSortBy]="!column.notSortable && column.queryFieldName"
+        [clrDgSortBy]="column.sortable !== false && column.queryFieldName"
         (clrDgSortOrderChange)="resetToPageOne()"
     >
         <ng-container *ngIf="isColumnHideable(column); else notHideable">

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -49,7 +49,7 @@
     </clr-dg-column>
     <clr-dg-column
         *ngFor="let column of columnsConfig"
-        [clrDgSortBy]="column.sortBy || column.queryFieldName"
+        [clrDgSortBy]="!column.notSortable && column.queryFieldName"
         (clrDgSortOrderChange)="resetToPageOne()"
     >
         <ng-container *ngIf="isColumnHideable(column); else notHideable">
@@ -58,15 +58,8 @@
             }}</ng-container>
         </ng-container>
         <ng-template #notHideable>{{ column.displayName }}</ng-template>
-        <clr-dg-filter *ngIf="column.queryFieldName">
-            <ng-template
-                *ngIf="column.filterRendererSpec; else defaultFilter"
-                [vcdComponentRendererOutlet]="{ rendererSpec: column.filterRendererSpec }"
-            >
-            </ng-template>
-            <ng-template #defaultFilter>
-                <vcd-dg-string-filter [config]="{ queryField: column.queryFieldName }"></vcd-dg-string-filter>
-            </ng-template>
+        <clr-dg-filter *ngIf="column.queryFieldName && column.filter">
+            <ng-template [vcdComponentRendererOutlet]="{ rendererSpec: column.filter }"> </ng-template>
         </clr-dg-filter>
     </clr-dg-column>
 

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -715,8 +715,8 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
             }
 
             // Add query filed required for the column filtering. This is then used in DatagridFilter.queryField
-            if (column.queryFieldName && column.filterRendererSpec) {
-                column.filterRendererSpec.config.queryField = column.queryFieldName;
+            if (column.queryFieldName && column.filter) {
+                column.filter.config.queryField = column.queryFieldName;
             }
 
             return columnConfig;

--- a/projects/components/src/datagrid/filters/datagrid-filter.ts
+++ b/projects/components/src/datagrid/filters/datagrid-filter.ts
@@ -50,12 +50,12 @@ export interface FilterRendererSpec<C> extends ComponentRendererSpec<C> {
 /**
  * Extended by filter components used in {@link DatagridComponent}. Those components can only be used inside a
  * clr-dg-filter component and are dynamically rendered by {@link ComponentRendererOutletDirective} using
- * {@link GridColumn.filterRendererSpec}
+ * {@link GridColumn.filter}
  * V is the type of filter input value that is passed into setValue method
  * C extends FilterConfig<V> is configuration of a filter that contains queryField and a value of type V
  */
 export abstract class DatagridFilter<V, C extends FilterConfig<V>> extends SubscriptionTrackerMixin(class {})
-    implements ClrDatagridFilterInterface<unknown>, ComponentRenderer<C> {
+    implements ClrDatagridFilterInterface<V>, ComponentRenderer<C> {
     formGroup: FormGroup;
 
     protected constructor(filterContainer: ClrDatagridFilter) {

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -224,13 +224,7 @@ export interface GridColumn<R> {
      * TODO: Should this be made to work with top level search on grids across all columns?
      *  The above to-do is going to be worked on as part of https://jira.eng.vmware.com/browse/VDUCC-27 and
      */
-    filterRendererSpec?: FilterRendererSpec<FilterConfig<unknown>>;
-
-    /**
-     * To enable only sorting without filtering on the column. This is because, passing in clrDgField turns both filtering
-     * and sorting feature on. And we want filtering to be off on some columns while still having sorting enabled.
-     */
-    sortBy?: string;
+    filter?: FilterRendererSpec<FilterConfig<unknown>>;
 
     /**
      * The configuration for the cliptext in the datagrid.
@@ -238,6 +232,12 @@ export interface GridColumn<R> {
      * If null, will disable cliptext
      */
     cliptextConfig?: CliptextConfig;
+
+    /**
+     * Boolean to turn off sorting on the column. Adding a {@link GridColumn.queryFieldName} by default turns both
+     * filtering and sorting on and this switch allows for turning on just the filtering
+     */
+    notSortable?: boolean;
 }
 
 /**

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -234,10 +234,9 @@ export interface GridColumn<R> {
     cliptextConfig?: CliptextConfig;
 
     /**
-     * Boolean to turn off sorting on the column. Adding a {@link GridColumn.queryFieldName} by default turns both
-     * filtering and sorting on and this switch allows for turning on just the filtering
+     * Whether to show the column as sortable. Defaults to true
      */
-    notSortable?: boolean;
+    sortable?: boolean;
 }
 
 /**

--- a/projects/components/src/utils/test/datagrid/filter-utils.ts
+++ b/projects/components/src/utils/test/datagrid/filter-utils.ts
@@ -97,7 +97,7 @@ export class FilterTestHostComponent {
         finder: WidgetFinder<FilterTestHostComponent>,
         config: C
     ): void {
-        this.column.filterRendererSpec = FilterComponentRendererSpec({ type: filterType, config });
+        this.column.filter = FilterComponentRendererSpec({ type: filterType, config });
         finder.detectChanges();
     }
 }

--- a/projects/examples/src/components/datagrid/datagrid-filter.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-filter.example.component.ts
@@ -72,43 +72,46 @@ export class DatagridFilterExampleComponent {
 
     columns: GridColumn<MockRecord>[] = [
         {
-            displayName: 'Default String filter',
+            displayName: 'Only sortable',
             renderer: 'state',
             queryFieldName: 'state',
+        },
+        {
+            displayName: 'Only filterable',
+            renderer: 'state',
+            queryFieldName: 'state',
+            filter: DatagridStringFilter(WildCardPosition.END, ''),
+            notSortable: true,
         },
         {
             displayName: 'String filter with wild-card',
             renderer: 'state',
             queryFieldName: 'state',
-            filterRendererSpec: DatagridStringFilter(WildCardPosition.END, ''),
+            filter: DatagridStringFilter(WildCardPosition.END, ''),
         },
         {
             displayName: 'Numeric filter',
             renderer: 'age',
             queryFieldName: 'age',
-            filterRendererSpec: DatagridNumericFilter([1, 2]),
+            filter: DatagridNumericFilter([1, 2]),
         },
         {
             displayName: 'Select filter with dynamic options',
             renderer: 'age',
             queryFieldName: 'age',
-            filterRendererSpec: DatagridSelectFilter(this.selectFilterOptions, 60),
+            filter: DatagridSelectFilter(this.selectFilterOptions, 60),
         },
         {
             displayName: 'Select filter with custom FIQL',
             renderer: 'age',
             queryFieldName: 'age',
-            filterRendererSpec: DatagridSelectFilter(
-                this.selectFilterWithCustomFiqlOptions,
-                '(field1=ge=1;field2=le=10)',
-                true
-            ),
+            filter: DatagridSelectFilter(this.selectFilterWithCustomFiqlOptions, '(field1=ge=1;field2=le=10)', true),
         },
         {
             displayName: 'Multi-select filter',
             renderer: 'state',
             queryFieldName: 'state',
-            filterRendererSpec: DatagridMultiSelectFilter(this.multiSelectFilterOptions, ['MA', 'NC']),
+            filter: DatagridMultiSelectFilter(this.multiSelectFilterOptions, ['MA', 'NC']),
         },
     ];
 

--- a/projects/examples/src/components/datagrid/datagrid-filter.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-filter.example.component.ts
@@ -81,7 +81,7 @@ export class DatagridFilterExampleComponent {
             renderer: 'state',
             queryFieldName: 'state',
             filter: DatagridStringFilter(WildCardPosition.END, ''),
-            notSortable: true,
+            sortable: false,
         },
         {
             displayName: 'String filter with wild-card',


### PR DESCRIPTION
As part of this PR, also the following changes are added:

Remove default filter

Make the subscription tracker mixin extent 'class {}' instead of Object

**Demo:**
![notSortableFlag](https://user-images.githubusercontent.com/10735165/77678950-4c8fdd00-6f68-11ea-8971-646ec53b1543.gif)
