### PR TITLE
TSLint ordered imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:i18n": "ng test i18n",
     "test:ci:i18n": "ng test i18n --watch=false --browsers ChromeHeadlessNoSandbox --code-coverage",
     "lint": "ng lint",
-    "lint-fix": "tslint --fix 'projectmkdir -p s/**/*.ts' -e 'projects/doc-lib/node_modules/**/*.ts'",
+    "lint-fix": "tslint --fix -p tsconfig.json",
     "e2e": "ng e2e",
     "build-components-doc": "mkdir -p projects/examples/gen; node $NODE_DEBUG_OPTION dist/doc-lib/index.js projects/components/tsconfig.lib.json projects/components/src/public-api.ts projects/examples/gen/components-doc.json",
     "build-examples-doc": "mkdir -p projects/examples/gen; node $NODE_DEBUG_OPTION dist/doc-lib/index.js projects/examples/tsconfig.app.json projects/examples/src/main.ts projects/examples/gen/examples-doc.json",

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"

--- a/projects/components/src/common/activity-reporter/activity-reporter.module.ts
+++ b/projects/components/src/common/activity-reporter/activity-reporter.module.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { SpinnerActivityReporterComponent } from './spinner-activity-reporter.component';
 import { I18nModule } from '@vcd/i18n';
-import { BannerActivityReporterComponent } from './banner-activity-reporter.component';
 import { ErrorBannerModule } from '../error/error-banner.module';
 import { LoadingIndicatorModule } from '../loading/loading-indicator.module';
+import { BannerActivityReporterComponent } from './banner-activity-reporter.component';
+import { SpinnerActivityReporterComponent } from './spinner-activity-reporter.component';
 
 @NgModule({
     declarations: [BannerActivityReporterComponent, SpinnerActivityReporterComponent],

--- a/projects/components/src/common/activity-reporter/banner-activity-reporter.spec.ts
+++ b/projects/components/src/common/activity-reporter/banner-activity-reporter.spec.ts
@@ -5,11 +5,11 @@
 
 import { Component, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActivityReporterModule } from './activity-reporter.module';
-import { WidgetFinder } from '../../utils/test/widget-object';
-import { BannerActivityReporterComponent } from './banner-activity-reporter.component';
+import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import { BannerActivityReporterWidgetObject } from '../../utils/test/activity-reporter/banner-activity-reporter.wo';
-import { TranslationService, MockTranslationService } from '@vcd/i18n';
+import { WidgetFinder } from '../../utils/test/widget-object';
+import { ActivityReporterModule } from './activity-reporter.module';
+import { BannerActivityReporterComponent } from './banner-activity-reporter.component';
 
 @Component({
     template: `

--- a/projects/components/src/common/activity-reporter/spinner-activity-reporter.spec.ts
+++ b/projects/components/src/common/activity-reporter/spinner-activity-reporter.spec.ts
@@ -5,10 +5,10 @@
 
 import { Component, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { SpinnerActivityReporterComponent } from './spinner-activity-reporter.component';
 import { SpinnerActivityReporterWidgetObject } from '../../utils/test/activity-reporter/spinner-activity-reporter.wo';
-import { ActivityReporterModule } from './activity-reporter.module';
 import { WidgetFinder } from '../../utils/test/widget-object';
+import { ActivityReporterModule } from './activity-reporter.module';
+import { SpinnerActivityReporterComponent } from './spinner-activity-reporter.component';
 
 @Component({
     template: `

--- a/projects/components/src/common/error/error-banner.module.ts
+++ b/projects/components/src/common/error/error-banner.module.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
 import { ErrorBannerComponent } from './error-banner.component';

--- a/projects/components/src/common/loading/loading-indicator.module.ts
+++ b/projects/components/src/common/loading/loading-indicator.module.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
 import { LoadingIndicatorComponent } from './loading-indicator.component';

--- a/projects/components/src/common/pipes/nested-property.pipe.spec.ts
+++ b/projects/components/src/common/pipes/nested-property.pipe.spec.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NestedPropertyPipe } from './nested-property.pipe';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, LOCALE_ID } from '@angular/core';
-import { PipesModule } from './pipes.module';
-import localeFrData from '@angular/common/locales/fr';
 import { DatePipe, DecimalPipe, registerLocaleData } from '@angular/common';
+import localeFrData from '@angular/common/locales/fr';
+import { Component, LOCALE_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { WidgetObject } from '../../utils/test/widget-object';
+import { NestedPropertyPipe } from './nested-property.pipe';
+import { PipesModule } from './pipes.module';
 
 const localeEnUs = 'en_US';
 const localeFr = 'fr';

--- a/projects/components/src/common/pipes/nested-property.pipe.ts
+++ b/projects/components/src/common/pipes/nested-property.pipe.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Inject, LOCALE_ID, Pipe, PipeTransform } from '@angular/core';
 import { DatePipe, DecimalPipe } from '@angular/common';
+import { Inject, LOCALE_ID, Pipe, PipeTransform } from '@angular/core';
 
 const OBJECT_PROPERTY_SEPARATOR = '.';
 const DATE_OBJECT_CLASS = '[object Date]';

--- a/projects/components/src/common/subscription/subscription-tracker.mixin.ts
+++ b/projects/components/src/common/subscription/subscription-tracker.mixin.ts
@@ -5,8 +5,8 @@
 
 import { OnDestroy } from '@angular/core';
 
-import { Subscription, Observable, PartialObserver } from 'rxjs';
-import { SubscriptionTracker, ISubscriptionTracker } from './subscription-tracker';
+import { Observable, PartialObserver, Subscription } from 'rxjs';
+import { ISubscriptionTracker, SubscriptionTracker } from './subscription-tracker';
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 

--- a/projects/components/src/data-exporter/data-exporter.component.spec.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.spec.ts
@@ -5,14 +5,14 @@
 
 import { TestBed } from '@angular/core/testing';
 
-import { DataExportRequestEvent, ExportColumn } from './data-exporter.component';
-import { DataExporterModule } from './data-exporter.module';
 import { Component } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { DataExporterWidgetObject } from './data-exporter.wo';
+import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import { HasFinder, WidgetFinder } from '../utils/test/widget-object';
 import { CsvExporterService } from './csv-exporter.service';
-import { TranslationService, MockTranslationService } from '@vcd/i18n';
+import { DataExportRequestEvent, ExportColumn } from './data-exporter.component';
+import { DataExporterModule } from './data-exporter.module';
+import { DataExporterWidgetObject } from './data-exporter.wo';
 
 type TestHostFinder = HasFinder<TestHostComponent>;
 

--- a/projects/components/src/data-exporter/data-exporter.module.ts
+++ b/projects/components/src/data-exporter/data-exporter.module.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { I18nModule } from '@vcd/i18n';
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DataExporterComponent } from './data-exporter.component';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { I18nModule } from '@vcd/i18n';
+import { DataExporterComponent } from './data-exporter.component';
 
 @NgModule({
     declarations: [DataExporterComponent],

--- a/projects/components/src/data-exporter/data-exporter.wo.ts
+++ b/projects/components/src/data-exporter/data-exporter.wo.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { DataExporterComponent } from './data-exporter.component';
-import { WidgetObject } from '../utils/test/widget-object';
 import { DebugElement } from '@angular/core';
+import { WidgetObject } from '../utils/test/widget-object';
+import { DataExporterComponent } from './data-exporter.component';
 
 const Css = {
     SelectAll: '.select-all',

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -8,10 +8,12 @@ import { TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { ClrDatagridWidgetObject } from '../utils/test/datagrid/datagrid.wo';
+import { VcdDatagridWidgetObject } from '../utils/test/datagrid/vcd-datagrid.wo';
 import { WidgetFinder } from '../utils/test/widget-object';
-import { GridSelectionType, PaginationConfiguration, ActivityIndicatorType } from './datagrid.component';
+import { ActivityIndicatorType, GridSelectionType, PaginationConfiguration } from './datagrid.component';
 import { DatagridComponent, GridDataFetchResult, GridState } from './datagrid.component';
 import { DatagridModule } from './datagrid.module';
+import { DatagridStringFilter, WildCardPosition } from './filters/datagrid-string-filter.component';
 import {
     ButtonConfig,
     ColumnComponentRendererSpec,
@@ -23,8 +25,6 @@ import {
 import { mockData, MockRecord } from './mock-data';
 import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
 import { WithGridBoldRenderer } from './renderers/bold-text-renderer.wo';
-import { VcdDatagridWidgetObject } from '../utils/test/datagrid/vcd-datagrid.wo';
-import { DatagridStringFilter, WildCardPosition } from './filters/datagrid-string-filter.component';
 
 type MockRecordDatagridComponent = DatagridComponent<MockRecord>;
 

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -18,6 +18,7 @@ import {
     ViewChild,
 } from '@angular/core';
 import { ClrDatagrid, ClrDatagridFilter, ClrDatagridPagination, ClrDatagridStateInterface } from '@clr/angular';
+import { ActivityReporter } from '../common/activity-reporter/activity-reporter';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { DatagridFilter } from './filters/datagrid-filter';
 import {
@@ -31,7 +32,6 @@ import {
     InactiveButtonDisplayMode,
 } from './interfaces/datagrid-column.interface';
 import { ContextualButton } from './interfaces/datagrid-column.interface';
-import { ActivityReporter } from '../common/activity-reporter/activity-reporter';
 
 /**
  * The default number of items on a single page.

--- a/projects/components/src/datagrid/datagrid.module.ts
+++ b/projects/components/src/datagrid/datagrid.module.ts
@@ -3,24 +3,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { ClarityModule } from '@clr/angular';
-import { RouterModule } from '@angular/router';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterModule } from '@angular/router';
+import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
+import { ActivityReporterModule } from '../common/activity-reporter/activity-reporter.module';
+import { PipesModule } from '../common/pipes/pipes.module';
+import { ShowClippedTextDirectiveModule } from '../lib/directives/show-clipped-text.directive.module';
 import { DatagridComponent } from './datagrid.component';
 import { ComponentRendererOutletDirective } from './directives/component-renderer-outlet.directive';
-import { PipesModule } from '../common/pipes/pipes.module';
-import { FunctionRendererPipe } from './pipes/function-renderer.pipe';
-import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
-import { ShowClippedTextDirectiveModule } from '../lib/directives/show-clipped-text.directive.module';
-import { DatagridStringFilterComponent } from './filters/datagrid-string-filter.component';
+import { DatagridMultiSelectFilterComponent } from './filters/datagrid-multiselect-filter.component';
 import { DatagridNumericFilterComponent } from './filters/datagrid-numeric-filter.component';
 import { DatagridSelectFilterComponent } from './filters/datagrid-select-filter.component';
-import { DatagridMultiSelectFilterComponent } from './filters/datagrid-multiselect-filter.component';
-import { ActivityReporterModule } from '../common/activity-reporter/activity-reporter.module';
+import { DatagridStringFilterComponent } from './filters/datagrid-string-filter.component';
+import { FunctionRendererPipe } from './pipes/function-renderer.pipe';
+import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
 
 const directives = [ComponentRendererOutletDirective];
 const pipes = [FunctionRendererPipe];

--- a/projects/components/src/datagrid/filters/datagrid-filter.ts
+++ b/projects/components/src/datagrid/filters/datagrid-filter.ts
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { ClrDatagridFilterInterface } from '@clr/angular/data/datagrid/interfaces/filter.interface';
+import { Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
 import { ClrDatagridFilter } from '@clr/angular';
+import { ClrDatagridFilterInterface } from '@clr/angular/data/datagrid/interfaces/filter.interface';
 import { Observable, Subject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
+import { SubscriptionTrackerMixin } from '../../common/subscription';
 import {
     ComponentRenderer,
     ComponentRendererConstructor,
     ComponentRendererSpec,
 } from '../interfaces/component-renderer.interface';
-import { Input } from '@angular/core';
-import { FormGroup } from '@angular/forms';
-import { debounceTime } from 'rxjs/operators';
-import { SubscriptionTrackerMixin } from '../../common/subscription';
 
 /**
  * Number of milliseconds delayed before emitting the filter has changed observable

--- a/projects/components/src/datagrid/filters/datagrid-multiselect-filter.component.spec.ts
+++ b/projects/components/src/datagrid/filters/datagrid-multiselect-filter.component.spec.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { DatagridFilter, DEBOUNCE_TIME_FOR_GRID_FILTER_CHANGES } from './datagrid-filter';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { createDatagridFilterTestHelper, FilterTestHostComponent } from '../../utils/test/datagrid/filter-utils';
+import { DatagridFilter, DEBOUNCE_TIME_FOR_GRID_FILTER_CHANGES } from './datagrid-filter';
 import {
     DatagridMultiSelectFilterComponent,
     DatagridMultiSelectFilterConfig,
 } from './datagrid-multiselect-filter.component';
-import { createDatagridFilterTestHelper, FilterTestHostComponent } from '../../utils/test/datagrid/filter-utils';
 
 interface HasDgMultiSelectFilter {
     filter: DatagridFilter<string[], DatagridMultiSelectFilterConfig>;

--- a/projects/components/src/datagrid/filters/datagrid-multiselect-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-multiselect-filter.component.ts
@@ -4,12 +4,12 @@
  */
 
 import { Component, Host, Input, OnInit } from '@angular/core';
-import { DatagridFilter, FilterComponentRendererSpec, FilterConfig, FilterRendererSpec } from './datagrid-filter';
-import { SelectOption } from './datagrid-select-filter.component';
-import { ClrDatagridFilter } from '@clr/angular';
 import { FormControl, FormGroup } from '@angular/forms';
+import { ClrDatagridFilter } from '@clr/angular';
 import { FilterBuilder } from '../../utils/filter-builder';
 import { IdGenerator } from '../../utils/id-generator/id-generator';
+import { DatagridFilter, FilterComponentRendererSpec, FilterConfig, FilterRendererSpec } from './datagrid-filter';
+import { SelectOption } from './datagrid-select-filter.component';
 
 /**
  * Same as the {@link SelectOption} but value is always a string

--- a/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.spec.ts
+++ b/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.spec.ts
@@ -2,13 +2,13 @@
  * Copyright 2019 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
-import { createDatagridFilterTestHelper, FilterTestHostComponent } from '../../utils/test/datagrid/filter-utils';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { createDatagridFilterTestHelper, FilterTestHostComponent } from '../../utils/test/datagrid/filter-utils';
 import { DatagridFilter, DEBOUNCE_TIME_FOR_GRID_FILTER_CHANGES } from './datagrid-filter';
 import {
-    DatagridNumericFilterConfig,
-    DatagridNumericFilterComponent,
     DatagridNumericFilter,
+    DatagridNumericFilterComponent,
+    DatagridNumericFilterConfig,
 } from './datagrid-numeric-filter.component';
 
 interface HasDgNumericFilter {

--- a/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.ts
@@ -4,10 +4,10 @@
  */
 
 import { Component, Host, OnInit } from '@angular/core';
-import { DatagridFilter, FilterConfig, FilterComponentRendererSpec, FilterRendererSpec } from './datagrid-filter';
-import { ClrDatagridFilter } from '@clr/angular';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { ClrDatagridFilter } from '@clr/angular';
 import { FilterBuilder } from '../../utils/filter-builder';
+import { DatagridFilter, FilterComponentRendererSpec, FilterConfig, FilterRendererSpec } from './datagrid-filter';
 
 enum FormFields {
     from = 'from',

--- a/projects/components/src/datagrid/filters/datagrid-select-filter.component.spec.ts
+++ b/projects/components/src/datagrid/filters/datagrid-select-filter.component.spec.ts
@@ -2,9 +2,9 @@
  * Copyright 2019 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
+import { fakeAsync, tick } from '@angular/core/testing';
 import { createDatagridFilterTestHelper, FilterTestHostComponent } from '../../utils/test/datagrid/filter-utils';
 import { DatagridFilter, DEBOUNCE_TIME_FOR_GRID_FILTER_CHANGES } from './datagrid-filter';
-import { fakeAsync, tick } from '@angular/core/testing';
 import { DatagridSelectFilterComponent, DatagridSelectFilterConfig } from './datagrid-select-filter.component';
 
 interface HasDgSelectFilter {

--- a/projects/components/src/datagrid/filters/datagrid-select-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-select-filter.component.ts
@@ -2,11 +2,11 @@
  * Copyright 2019 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
-import { DatagridFilter, FilterComponentRendererSpec, FilterConfig, FilterRendererSpec } from './datagrid-filter';
 import { Component, Host, OnInit } from '@angular/core';
-import { ClrDatagridFilter } from '@clr/angular';
 import { FormBuilder } from '@angular/forms';
+import { ClrDatagridFilter } from '@clr/angular';
 import { FilterBuilder } from '../../utils/filter-builder';
+import { DatagridFilter, FilterComponentRendererSpec, FilterConfig, FilterRendererSpec } from './datagrid-filter';
 
 /**
  * Options displayed in a select input option list

--- a/projects/components/src/datagrid/filters/datagrid-string-filter.component.spec.ts
+++ b/projects/components/src/datagrid/filters/datagrid-string-filter.component.spec.ts
@@ -2,15 +2,15 @@
  * Copyright 2019 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
+import { fakeAsync, tick } from '@angular/core/testing';
+import { createDatagridFilterTestHelper, FilterTestHostComponent } from '../../utils/test/datagrid/filter-utils';
+import { DatagridFilter, DEBOUNCE_TIME_FOR_GRID_FILTER_CHANGES } from './datagrid-filter';
 import {
+    DatagridStringFilter,
     DatagridStringFilterComponent,
     DatagridStringFilterConfig,
     WildCardPosition,
-    DatagridStringFilter,
 } from './datagrid-string-filter.component';
-import { createDatagridFilterTestHelper, FilterTestHostComponent } from '../../utils/test/datagrid/filter-utils';
-import { DatagridFilter, DEBOUNCE_TIME_FOR_GRID_FILTER_CHANGES } from './datagrid-filter';
-import { fakeAsync, tick } from '@angular/core/testing';
 
 interface HasDgStringFilter {
     filter: DatagridFilter<string, DatagridStringFilterConfig>;

--- a/projects/components/src/datagrid/filters/datagrid-string-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-string-filter.component.ts
@@ -4,11 +4,11 @@
  */
 
 import { Component, Host, OnInit } from '@angular/core';
-import { DatagridFilter, FilterConfig, FilterComponentRendererSpec, FilterRendererSpec } from './datagrid-filter';
-import { ClrDatagridFilter } from '@clr/angular';
-import { FilterBuilder } from '../../utils/filter-builder';
 import { FormBuilder } from '@angular/forms';
+import { ClrDatagridFilter } from '@clr/angular';
 import { debounce, debounceTime } from 'rxjs/operators';
+import { FilterBuilder } from '../../utils/filter-builder';
+import { DatagridFilter, FilterComponentRendererSpec, FilterConfig, FilterRendererSpec } from './datagrid-filter';
 
 export enum WildCardPosition {
     START = 'START',

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -6,7 +6,7 @@
 /**
  * Whether something shows up in the column toggler
  */
-import { TooltipSize, CliptextConfig } from '../../lib/directives/show-clipped-text.directive';
+import { CliptextConfig, TooltipSize } from '../../lib/directives/show-clipped-text.directive';
 import { FilterConfig, FilterRendererSpec } from '../filters/datagrid-filter';
 import { ComponentRendererConstructor, ComponentRendererSpec } from './component-renderer.interface';
 

--- a/projects/components/src/datagrid/renderers/bold-text-renderer.component.spec.ts
+++ b/projects/components/src/datagrid/renderers/bold-text-renderer.component.spec.ts
@@ -6,8 +6,8 @@
 import { Component, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { WidgetFinder } from '../../utils/test/widget-object';
+import { BoldTextRenderer, BoldTextRendererComponent } from './bold-text-renderer.component';
 import { BoldTextRendererWidgetObject } from './bold-text-renderer.wo';
-import { BoldTextRendererComponent, BoldTextRenderer } from './bold-text-renderer.component';
 
 @Component({
     template: `

--- a/projects/components/src/datagrid/renderers/bold-text-renderer.component.ts
+++ b/projects/components/src/datagrid/renderers/bold-text-renderer.component.ts
@@ -5,7 +5,7 @@
 
 import { Component, Input } from '@angular/core';
 import { ComponentRenderer } from '../interfaces/component-renderer.interface';
-import { ColumnRendererSpec, ColumnComponentRendererSpec } from '../interfaces/datagrid-column.interface';
+import { ColumnComponentRendererSpec, ColumnRendererSpec } from '../interfaces/datagrid-column.interface';
 /**
  * {@link ComponentRenderer.config} type that the {@link BoldTextRendererComponent} can understand
  */

--- a/projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts
+++ b/projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts
@@ -4,9 +4,9 @@
  */
 
 import { Type } from '@angular/core';
-import { BoldTextRendererComponent } from './bold-text-renderer.component';
-import { WidgetObject } from '../../utils/test/widget-object';
 import { VcdDatagridWidgetObject } from '../../utils/test/datagrid/vcd-datagrid.wo';
+import { WidgetObject } from '../../utils/test/widget-object';
+import { BoldTextRendererComponent } from './bold-text-renderer.component';
 
 /**
  * Mixin that allows {@link ClrDatagridWidgetObject} to read information from {@link BoldTextRendererComponent}

--- a/projects/components/src/test.ts
+++ b/projects/components/src/test.ts
@@ -4,9 +4,9 @@
  */
 
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
-
 import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
+// tslint:disable-next-line: ordered-imports
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 

--- a/projects/components/src/utils/test/activity-reporter/banner-activity-reporter.wo.ts
+++ b/projects/components/src/utils/test/activity-reporter/banner-activity-reporter.wo.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { WidgetObject } from '../widget-object';
 import { BannerActivityReporterComponent } from '../../../common/activity-reporter';
+import { WidgetObject } from '../widget-object';
 
 export class BannerActivityReporterWidgetObject extends WidgetObject<BannerActivityReporterComponent> {
     static tagName = 'vcd-banner-activity-reporter';

--- a/projects/components/src/utils/test/activity-reporter/spinner-activity-reporter.wo.ts
+++ b/projects/components/src/utils/test/activity-reporter/spinner-activity-reporter.wo.ts
@@ -4,8 +4,8 @@
  */
 
 import { DebugElement } from '@angular/core';
-import { WidgetObject } from '../widget-object';
 import { SpinnerActivityReporterComponent } from '../../../common/activity-reporter';
+import { WidgetObject } from '../widget-object';
 
 export class SpinnerActivityReporterWidgetObject extends WidgetObject<SpinnerActivityReporterComponent> {
     static tagName = 'vcd-spinner-activity-reporter';

--- a/projects/components/src/utils/test/datagrid/filter-utils.ts
+++ b/projects/components/src/utils/test/datagrid/filter-utils.ts
@@ -6,8 +6,6 @@
 import { Component, Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
-import { WidgetFinder } from '../widget-object';
-import { ClrDatagridWidgetObject } from './datagrid.wo';
 import {
     DatagridFilter,
     DatagridModule,
@@ -17,6 +15,8 @@ import {
 } from '../../../datagrid';
 import { MockRecord } from '../../../datagrid/mock-data';
 import { IdGenerator } from '../../id-generator/id-generator';
+import { WidgetFinder } from '../widget-object';
+import { ClrDatagridWidgetObject } from './datagrid.wo';
 
 /**
  * Used inside beforeEach functions of filter tests and it does the following:

--- a/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { DatagridComponent } from './../../../datagrid/datagrid.component';
 import { WidgetObject } from '../widget-object';
+import { DatagridComponent } from './../../../datagrid/datagrid.component';
 import { ClrDatagridWidgetObject } from './datagrid.wo';
 
 /**

--- a/projects/components/src/utils/test/widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, Input, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HasFinder, WidgetFinder, WidgetObject } from './widget-object';
 
 /**

--- a/projects/doc-lib/src/api-viewer/api-viewer.module.ts
+++ b/projects/doc-lib/src/api-viewer/api-viewer.module.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { CommonModule } from '@angular/common';
 import { ApiViewerComponent } from './api-viewer.component';
 
 const declarations = [ApiViewerComponent];

--- a/projects/doc-lib/src/doc-lib.module.ts
+++ b/projects/doc-lib/src/doc-lib.module.ts
@@ -4,12 +4,12 @@
  */
 
 import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
-import { CompodocSchema } from './compodoc/compodoc-schema';
-import { DocumentationRetrieverService } from './documentation-retriever.service';
 import { CompoDocRetrieverService } from './compodoc/compodoc-retriever.service';
-import { PrismHighlightService } from './highlight/prism/prism-highlight.service';
-import { HighlightService } from './highlight/highlight.service';
+import { CompodocSchema } from './compodoc/compodoc-schema';
 import { DocumentationContainerModule } from './documentation-container/documentation-container.module';
+import { DocumentationRetrieverService } from './documentation-retriever.service';
+import { HighlightService } from './highlight/highlight.service';
+import { PrismHighlightService } from './highlight/prism/prism-highlight.service';
 import { STACKBLITZ_INFO, StackBlitzInfo, StackBlitzWriterService } from './stack-blitz-writer.service';
 
 const declarations = [];

--- a/projects/doc-lib/src/documentation-container/documentation-container.module.ts
+++ b/projects/doc-lib/src/documentation-container/documentation-container.module.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { CommonModule } from '@angular/common';
-import { DocumentationContainerComponent } from './documentation-container.component';
-import { OverviewViewerModule } from '../overview-viewer/overview-viewer.module';
-import { ExampleViewerModule } from '../example-viewer/example-viewer.module';
 import { ApiViewerModule } from '../api-viewer/api-viewer.module';
+import { ExampleViewerModule } from '../example-viewer/example-viewer.module';
+import { OverviewViewerModule } from '../overview-viewer/overview-viewer.module';
+import { DocumentationContainerComponent } from './documentation-container.component';
 
 const declarations = [DocumentationContainerComponent];
 

--- a/projects/doc-lib/src/documentation.ts
+++ b/projects/doc-lib/src/documentation.ts
@@ -4,8 +4,8 @@
  */
 
 import { Type } from '@angular/core';
-import { DocumentationContainerComponent } from './documentation-container/documentation-container.component';
 import { Routes } from '@angular/router';
+import { DocumentationContainerComponent } from './documentation-container/documentation-container.component';
 
 /**
  * Represents each entry in {@link DocumentationEntry.examples}, that is an examples that shows a particular usage of a components

--- a/projects/doc-lib/src/example-viewer/example-viewer.module.ts
+++ b/projects/doc-lib/src/example-viewer/example-viewer.module.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { CommonModule } from '@angular/common';
-import { ExampleViewerComponent } from './example-viewer.component';
-import { SourceCodeViewerModule } from '../source-code-viewer/source-code-viewer.module';
 import { OverviewViewerModule } from '../overview-viewer/overview-viewer.module';
+import { SourceCodeViewerModule } from '../source-code-viewer/source-code-viewer.module';
+import { ExampleViewerComponent } from './example-viewer.component';
 
 const declarations = [ExampleViewerComponent];
 

--- a/projects/doc-lib/src/highlight/prism/prism-highlight.service.ts
+++ b/projects/doc-lib/src/highlight/prism/prism-highlight.service.ts
@@ -5,8 +5,8 @@
 
 import { Injectable } from '@angular/core';
 import Prism from 'prismjs';
-import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-scss';
+import 'prismjs/components/prism-typescript';
 import { HighlightService } from '../highlight.service';
 
 @Injectable()

--- a/projects/doc-lib/src/overview-viewer/overview-viewer.module.ts
+++ b/projects/doc-lib/src/overview-viewer/overview-viewer.module.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { CommonModule } from '@angular/common';
 import { OverviewViewerComponent } from './overview-viewer.component';
 
 const declarations = [OverviewViewerComponent];

--- a/projects/doc-lib/src/source-code-viewer/source-code-viewer.module.ts
+++ b/projects/doc-lib/src/source-code-viewer/source-code-viewer.module.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { CommonModule } from '@angular/common';
 import { SourceCodeViewerComponent } from './source-code-viewer.component';
 
 const declarations = [SourceCodeViewerComponent];

--- a/projects/doc-lib/src/stack-blitz-writer.service.ts
+++ b/projects/doc-lib/src/stack-blitz-writer.service.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { Inject, InjectionToken } from '@angular/core';
 import sdk from '@stackblitz/sdk';
+import { OpenOptions, Project } from '@stackblitz/sdk/typings/interfaces';
+import { CompodocComponent, CompodocModule } from './compodoc/compodoc-schema';
 import { ExampleEntry } from './documentation';
 import { DocumentationRetrieverService } from './documentation-retriever.service';
-import { CompodocComponent, CompodocModule } from './compodoc/compodoc-schema';
-import { OpenOptions, Project } from '@stackblitz/sdk/typings/interfaces';
-import { Inject, InjectionToken } from '@angular/core';
 
 export interface StackBlitzInfo {
     /** Something like 'vcd-ui-cc-starter-clarity-v8-yhe4yg', then ID of a StackBlitz URL */

--- a/projects/doc-lib/src/test.ts
+++ b/projects/doc-lib/src/test.ts
@@ -7,6 +7,7 @@
 
 import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
+// tslint:disable-next-line: ordered-imports
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 

--- a/projects/examples/e2e/src/app.e2e-spec.ts
+++ b/projects/examples/e2e/src/app.e2e-spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { AppPage } from './app.po';
 import { browser, logging } from 'protractor';
+import { AppPage } from './app.po';
 
 describe('workspace-project App', () => {
     let page: AppPage;

--- a/projects/examples/src/app/app-routing.module.ts
+++ b/projects/examples/src/app/app-routing.module.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { RouterModule } from '@angular/router';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
     imports: [RouterModule.forRoot([])],

--- a/projects/examples/src/app/app.component.ts
+++ b/projects/examples/src/app/app.component.ts
@@ -4,8 +4,8 @@
  */
 
 import { Component } from '@angular/core';
-import { Documentation, DocumentationEntry } from '@vcd/ui-doc-lib';
 import { Router } from '@angular/router';
+import { Documentation, DocumentationEntry } from '@vcd/ui-doc-lib';
 
 interface SideNavEntries {
     title: string;

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -3,32 +3,32 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { registerLocaleData } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
 import { InjectionToken, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { HttpClientModule } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { registerLocaleData } from '@angular/common';
 
-import localeFr from '@angular/common/locales/fr';
 import localeEs from '@angular/common/locales/es';
+import localeFr from '@angular/common/locales/fr';
 import { FormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
+import { I18nModule, TranslationService } from '@vcd/i18n';
 import { ComponentsModule } from '@vcd/ui-components';
 import { CompodocSchema, DocLibModule, StackBlitzInfo } from '@vcd/ui-doc-lib';
-import { I18nModule, TranslationService } from '@vcd/i18n';
 import { AppRoutingModule } from './app-routing.module';
 
 import { AppComponent } from './app.component';
 
 import componentsDocumentationJson from '../../gen/components-doc.json';
 import examplesDocumentationJson from '../../gen/examples-doc.json';
-import { DatagridExamplesModule } from '../components/datagrid/datagrid.examples.module';
-import { ShowClippedTextExamplesModule } from './components/show-clipped-text/show-clipped-text-examples.module';
-import { DataExporterExamplesModule } from '../components/data-exporter/data-exporter.examples.module';
-import { SubscriptionTrackerExamplesModule } from '../components/subscription/subscription-tracker.examples.module';
-import { LoadingIndicatorExamplesModule } from '../components/loading/loading-indicator.examples.module';
-import { ErrorBannerExamplesModule } from '../components/error/error-banner.examples.module';
 import { ActivityReporterExamplesModule } from '../components/activity-reporter/activity-reporter.examples.module';
+import { DataExporterExamplesModule } from '../components/data-exporter/data-exporter.examples.module';
+import { DatagridExamplesModule } from '../components/datagrid/datagrid.examples.module';
+import { ErrorBannerExamplesModule } from '../components/error/error-banner.examples.module';
+import { LoadingIndicatorExamplesModule } from '../components/loading/loading-indicator.examples.module';
+import { SubscriptionTrackerExamplesModule } from '../components/subscription/subscription-tracker.examples.module';
+import { ShowClippedTextExamplesModule } from './components/show-clipped-text/show-clipped-text-examples.module';
 
 registerLocaleData(localeFr, 'fr');
 registerLocaleData(localeEs, 'es');

--- a/projects/examples/src/app/components/show-clipped-text/positioning/show-clipped-text-positioning-example.module.ts
+++ b/projects/examples/src/app/components/show-clipped-text/positioning/show-clipped-text-positioning-example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ShowClippedTextPositioningExampleComponent } from './show-clipped-text-positioning-example.component';
+import { NgModule } from '@angular/core';
 import { ComponentsModule } from '@vcd/ui-components';
+import { ShowClippedTextPositioningExampleComponent } from './show-clipped-text-positioning-example.component';
 
 @NgModule({
     declarations: [ShowClippedTextPositioningExampleComponent],

--- a/projects/examples/src/app/components/show-clipped-text/show-clipped-text-examples.module.ts
+++ b/projects/examples/src/app/components/show-clipped-text/show-clipped-text-examples.module.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Documentation } from '@vcd/ui-doc-lib';
+import { NgModule } from '@angular/core';
 import { ShowClippedTextDirective } from '@vcd/ui-components';
+import { Documentation } from '@vcd/ui-doc-lib';
 import { ShowClippedTextPositioningExampleComponent } from './positioning/show-clipped-text-positioning-example.component';
 import { ShowClippedTextPositioningExampleModule } from './positioning/show-clipped-text-positioning-example.module';
-import { ShowClippedTextSizingExampleModule } from './sizing/show-clipped-text-sizing-example.module';
 import { ShowClippedTextSizingExampleComponent } from './sizing/show-clipped-text-sizing-example.component';
+import { ShowClippedTextSizingExampleModule } from './sizing/show-clipped-text-sizing-example.module';
 
 Documentation.registerDocumentationEntry({
     component: ShowClippedTextDirective,

--- a/projects/examples/src/app/components/show-clipped-text/sizing/show-clipped-text-sizing-example.module.ts
+++ b/projects/examples/src/app/components/show-clipped-text/sizing/show-clipped-text-sizing-example.module.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ShowClippedTextSizingExampleComponent } from './show-clipped-text-sizing-example.component';
 import { ComponentsModule } from '@vcd/ui-components';
+import { ShowClippedTextSizingExampleComponent } from './show-clipped-text-sizing-example.component';
 
 @NgModule({
     declarations: [ShowClippedTextSizingExampleComponent],

--- a/projects/examples/src/components/activity-reporter/activity-reporter.examples.module.ts
+++ b/projects/examples/src/components/activity-reporter/activity-reporter.examples.module.ts
@@ -4,12 +4,12 @@
  */
 
 import { NgModule } from '@angular/core';
-import { Documentation } from '@vcd/ui-doc-lib';
 import { BannerActivityReporterComponent } from '@vcd/ui-components';
+import { Documentation } from '@vcd/ui-doc-lib';
+import { BannerActivityReporterExampleComponent } from './banner-activity-reporter.example.component';
+import { BannerActivityReporterExampleModule } from './banner-activity-reporter.example.module';
 import { SpinnerActivityReporterExampleComponent } from './spinner-activity-reporter.example.component';
 import { SpinnerActivityReporterExampleModule } from './spinner-activity-reporter.example.module';
-import { BannerActivityReporterExampleModule } from './banner-activity-reporter.example.module';
-import { BannerActivityReporterExampleComponent } from './banner-activity-reporter.example.component';
 
 Documentation.registerDocumentationEntry({
     component: BannerActivityReporterComponent, // TODO: allow doc-lib to supoort documentation for non-components

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component, ViewChild } from '@angular/core';
-import { BannerActivityReporterComponent, ActivityReporter } from '@vcd/ui-components';
+import { ActivityReporter, BannerActivityReporterComponent } from '@vcd/ui-components';
 
 /**
  * Press the button to show/hide the banner activity reporter

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { ActivityReporterModule } from '@vcd/ui-components';
 import { BannerActivityReporterExampleComponent } from './banner-activity-reporter.example.component';
 

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component, ViewChild } from '@angular/core';
-import { SpinnerActivityReporterComponent, ActivityReporter } from '@vcd/ui-components';
+import { ActivityReporter, SpinnerActivityReporterComponent } from '@vcd/ui-components';
 
 /**
  * Press the button to show/hide the spinner activity reporter

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { ActivityReporterModule } from '@vcd/ui-components';
 import { SpinnerActivityReporterExampleComponent } from './spinner-activity-reporter.example.component';
 

--- a/projects/examples/src/components/data-exporter/data-exporter.example.module.ts
+++ b/projects/examples/src/components/data-exporter/data-exporter.example.module.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
-import { DataExporterExampleComponent } from './data-exporter.example.component';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DataExporterModule } from '@vcd/ui-components';
+import { DataExporterExampleComponent } from './data-exporter.example.component';
 
 @NgModule({
     declarations: [DataExporterExampleComponent],

--- a/projects/examples/src/components/data-exporter/data-exporter.examples.module.ts
+++ b/projects/examples/src/components/data-exporter/data-exporter.examples.module.ts
@@ -6,8 +6,8 @@
 import { NgModule } from '@angular/core';
 import { DataExporterExampleComponent } from './data-exporter.example.component';
 
-import { Documentation } from '@vcd/ui-doc-lib';
 import { DataExporterComponent } from '@vcd/ui-components';
+import { Documentation } from '@vcd/ui-doc-lib';
 import { DataExporterExampleModule } from './data-exporter.example.module';
 
 Documentation.registerDocumentationEntry({

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
@@ -5,12 +5,12 @@
 
 import { Component } from '@angular/core';
 import {
+    ActivityIndicatorType,
+    ButtonConfig,
+    ContextualButtonPosition,
     GridColumn,
     GridDataFetchResult,
     GridState,
-    ButtonConfig,
-    ContextualButtonPosition,
-    ActivityIndicatorType,
 } from '@vcd/ui-components';
 
 interface Data {

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.module.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';

--- a/projects/examples/src/components/datagrid/datagrid-css-classes.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-css-classes.example.module.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridCssClassesExampleComponent } from './datagrid-css-classes.example.component';

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { GridDataFetchResult, GridColumn, GridState } from '@vcd/ui-components';
+import { GridColumn, GridDataFetchResult, GridState } from '@vcd/ui-components';
 
 interface Data {
     value: string;

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 

--- a/projects/examples/src/components/datagrid/datagrid-filter.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-filter.example.component.ts
@@ -5,16 +5,16 @@
 
 import { Component } from '@angular/core';
 import {
-    GridColumn,
-    GridDataFetchResult,
-    GridState,
-    SelectOption,
-    WildCardPosition,
+    DatagridMultiSelectFilter,
     DatagridNumericFilter,
     DatagridSelectFilter,
     DatagridStringFilter,
-    DatagridMultiSelectFilter,
+    GridColumn,
+    GridDataFetchResult,
+    GridState,
     MultiSelectOption,
+    SelectOption,
+    WildCardPosition,
 } from '@vcd/ui-components';
 import { mockData, MockRecord } from './mock-data';
 

--- a/projects/examples/src/components/datagrid/datagrid-filter.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-filter.example.module.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';

--- a/projects/examples/src/components/datagrid/datagrid-header.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-header.example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { GridDataFetchResult, GridColumn, GridState } from '@vcd/ui-components';
+import { GridColumn, GridDataFetchResult, GridState } from '@vcd/ui-components';
 
 interface Data {
     value: string;

--- a/projects/examples/src/components/datagrid/datagrid-header.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-header.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
 

--- a/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { GridDataFetchResult, GridColumn, GridState, PaginationConfiguration } from '@vcd/ui-components';
+import { GridColumn, GridDataFetchResult, GridState, PaginationConfiguration } from '@vcd/ui-components';
 
 interface Data {
     value: string;

--- a/projects/examples/src/components/datagrid/datagrid-height.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
 

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -5,12 +5,12 @@
 
 import { Component } from '@angular/core';
 import {
-    GridDataFetchResult,
-    GridColumn,
-    GridState,
     ButtonConfig,
-    GridSelectionType,
     ContextualButtonPosition,
+    GridColumn,
+    GridDataFetchResult,
+    GridSelectionType,
+    GridState,
     InactiveButtonDisplayMode,
 } from '@vcd/ui-components';
 

--- a/projects/examples/src/components/datagrid/datagrid-link.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
 

--- a/projects/examples/src/components/datagrid/datagrid-pagination-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-pagination-example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { GridDataFetchResult, GridColumn, GridState, PaginationConfiguration } from '@vcd/ui-components';
+import { GridColumn, GridDataFetchResult, GridState, PaginationConfiguration } from '@vcd/ui-components';
 
 interface Data {
     value: string;

--- a/projects/examples/src/components/datagrid/datagrid-pagination-example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-pagination-example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
 

--- a/projects/examples/src/components/datagrid/datagrid-row-icon.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-icon.example.component.ts
@@ -5,12 +5,12 @@
 
 import { Component, Input } from '@angular/core';
 import {
+    ColumnComponentRendererSpec,
+    ColumnRendererSpec,
+    ComponentRenderer,
     GridColumn,
     GridDataFetchResult,
     GridState,
-    ComponentRenderer,
-    ColumnComponentRendererSpec,
-    ColumnRendererSpec,
 } from '@vcd/ui-components';
 
 interface Data {

--- a/projects/examples/src/components/datagrid/datagrid-row-icon.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-icon.example.module.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridRowIconExampleComponent, RowIconRendererComponent } from './datagrid-row-icon.example.component';

--- a/projects/examples/src/components/datagrid/datagrid-row-select.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-select.example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { GridDataFetchResult, GridState, GridColumn, GridSelectionType } from '@vcd/ui-components';
+import { GridColumn, GridDataFetchResult, GridSelectionType, GridState } from '@vcd/ui-components';
 
 interface Data {
     href: string;

--- a/projects/examples/src/components/datagrid/datagrid-row-select.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-select.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
 

--- a/projects/examples/src/components/datagrid/datagrid-show-hide.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-show-hide.example.module.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { DatagridShowHideExampleComponent } from './datagrid-show-hide.example.component';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
+import { DatagridShowHideExampleComponent } from './datagrid-show-hide.example.component';
 
 @NgModule({
     declarations: [DatagridShowHideExampleComponent],

--- a/projects/examples/src/components/datagrid/datagrid-sort.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-sort.example.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { GridDataFetchResult, GridColumn, GridState } from '@vcd/ui-components';
+import { GridColumn, GridDataFetchResult, GridState } from '@vcd/ui-components';
 
 interface Data {
     value: string;

--- a/projects/examples/src/components/datagrid/datagrid-sort.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-sort.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
 

--- a/projects/examples/src/components/datagrid/datagrid-three-renderers.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-three-renderers.example.component.ts
@@ -5,12 +5,12 @@
 
 import { Component } from '@angular/core';
 import {
+    BoldTextRenderer,
     BoldTextRendererComponent,
+    ColumnComponentRendererSpec,
     GridColumn,
     GridDataFetchResult,
     GridState,
-    ColumnComponentRendererSpec,
-    BoldTextRenderer,
 } from '@vcd/ui-components';
 import { mockData, MockRecord } from './mock-data';
 

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -6,12 +6,16 @@
 import { NgModule } from '@angular/core';
 import { DatagridComponent } from '@vcd/ui-components';
 import { Documentation } from '@vcd/ui-doc-lib';
+import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';
+import { DatagridActivityReporterExampleModule } from './datagrid-activity-reporter.example.module';
 import { DatagridCliptextExampleComponent } from './datagrid-cliptext.example.component';
 import { DatagridCliptextExampleModule } from './datagrid-cliptext.example.module';
 import { DatagridCssClassesExampleComponent } from './datagrid-css-classes.example.component';
 import { DatagridCssClassesExampleModule } from './datagrid-css-classes.example.module';
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 import { DatagridDetailRowExampleModule } from './datagrid-detail-row.example.module';
+import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
+import { DatagridFilterExampleModule } from './datagrid-filter.example.module';
 import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
 import { DatagridHeaderExampleModule } from './datagrid-header.example.module';
 import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
@@ -20,6 +24,8 @@ import { DatagridLinkExampleComponent } from './datagrid-link.example.component'
 import { DatagridLinkExampleModule } from './datagrid-link.example.module';
 import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
 import { DatagridPagionationExampleModule } from './datagrid-pagination-example.module';
+import { DatagridRowIconExampleComponent } from './datagrid-row-icon.example.component';
+import { DatagridRowIconExampleModule } from './datagrid-row-icon.example.module';
 import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
 import { DatagridRowSelectExampleModule } from './datagrid-row-select.example.module';
 import { DatagridShowHideExampleComponent } from './datagrid-show-hide.example.component';
@@ -28,12 +34,6 @@ import { DatagridSortExampleComponent } from './datagrid-sort.example.component'
 import { DatagridSortExampleModule } from './datagrid-sort.example.module';
 import { DatagridThreeRenderersExampleComponent } from './datagrid-three-renderers.example.component';
 import { DatagridThreeRenderersExampleModule } from './datagrid-three-renderers.example.module';
-import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';
-import { DatagridActivityReporterExampleModule } from './datagrid-activity-reporter.example.module';
-import { DatagridFilterExampleModule } from './datagrid-filter.example.module';
-import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
-import { DatagridRowIconExampleModule } from './datagrid-row-icon.example.module';
-import { DatagridRowIconExampleComponent } from './datagrid-row-icon.example.component';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,

--- a/projects/examples/src/components/error/error-banner.example.module.ts
+++ b/projects/examples/src/components/error/error-banner.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { ErrorBannerModule } from '@vcd/ui-components';
 import { ErrorBannerExampleComponent } from './error-banner.example.component';
 

--- a/projects/examples/src/components/error/error-banner.examples.module.ts
+++ b/projects/examples/src/components/error/error-banner.examples.module.ts
@@ -4,8 +4,8 @@
  */
 
 import { NgModule } from '@angular/core';
-import { Documentation } from '@vcd/ui-doc-lib';
 import { ErrorBannerComponent } from '@vcd/ui-components';
+import { Documentation } from '@vcd/ui-doc-lib';
 import { ErrorBannerExampleComponent } from './error-banner.example.component';
 import { ErrorBannerExampleModule } from './error-banner.example.module';
 

--- a/projects/examples/src/components/loading/loading-indicator.example.module.ts
+++ b/projects/examples/src/components/loading/loading-indicator.example.module.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { LoadingIndicatorExampleComponent } from './loading-indicator.example.component';
+import { ClarityModule } from '@clr/angular';
 import { LoadingIndicatorModule } from '@vcd/ui-components';
+import { LoadingIndicatorExampleComponent } from './loading-indicator.example.component';
 
 @NgModule({
     declarations: [LoadingIndicatorExampleComponent],

--- a/projects/examples/src/components/loading/loading-indicator.examples.module.ts
+++ b/projects/examples/src/components/loading/loading-indicator.examples.module.ts
@@ -4,8 +4,8 @@
  */
 
 import { NgModule } from '@angular/core';
-import { Documentation } from '@vcd/ui-doc-lib';
 import { LoadingIndicatorComponent } from '@vcd/ui-components';
+import { Documentation } from '@vcd/ui-doc-lib';
 import { LoadingIndicatorExampleComponent } from './loading-indicator.example.component';
 import { LoadingIndicatorExampleModule } from './loading-indicator.example.module';
 

--- a/projects/examples/src/components/subscription/subscription-tracker-mixin.example.component.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker-mixin.example.component.ts
@@ -4,8 +4,8 @@
  */
 
 import { Component, Input, OnInit } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
 import { SubscriptionTrackerMixin } from '@vcd/ui-components';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 /**
  * Automatically destroy subscriptions when components are destroyed by using the {@link SubscriptionTrackerMixin}.

--- a/projects/examples/src/components/subscription/subscription-tracker-mixin.example.module.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker-mixin.example.module.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ClarityModule } from '@clr/angular';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
 import { DatagridModule } from '@vcd/ui-components';
 import {
     SubscriptionTrackerMixinExampleComponent,

--- a/projects/examples/src/components/subscription/subscription-tracker.examples.module.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker.examples.module.ts
@@ -4,10 +4,10 @@
  */
 
 import { NgModule } from '@angular/core';
-import { Documentation } from '@vcd/ui-doc-lib';
-import { SubscriptionTrackerMixinExampleModule } from './subscription-tracker-mixin.example.module';
-import { SubscriptionTrackerMixinExampleComponent } from './subscription-tracker-mixin.example.component';
 import { SubscriptionTracker } from '@vcd/ui-components';
+import { Documentation } from '@vcd/ui-doc-lib';
+import { SubscriptionTrackerMixinExampleComponent } from './subscription-tracker-mixin.example.component';
+import { SubscriptionTrackerMixinExampleModule } from './subscription-tracker-mixin.example.module';
 
 Documentation.registerDocumentationEntry({
     component: SubscriptionTracker,

--- a/projects/examples/src/main.ts
+++ b/projects/examples/src/main.ts
@@ -6,9 +6,9 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
+import { BOOTSTRAP_DETAILS } from '@vcd/i18n';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
-import { BOOTSTRAP_DETAILS } from '@vcd/i18n';
 
 if (environment.production) {
     enableProdMode();

--- a/projects/examples/src/test.ts
+++ b/projects/examples/src/test.ts
@@ -6,6 +6,7 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import 'zone.js/dist/zone-testing';
+// tslint:disable-next-line: ordered-imports
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 // Required so typescript to access karma's context

--- a/projects/i18n/src/lib/i18n.module.ts
+++ b/projects/i18n/src/lib/i18n.module.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { TranslationLoader } from './loader/translation-loader';
+import { HttpClient } from '@angular/common/http';
 import { ModuleWithProviders, Optional, Provider } from '@angular/core';
-import { NgModule, InjectionToken, Inject } from '@angular/core';
+import { Inject, InjectionToken, NgModule } from '@angular/core';
+import { TranslationLoader } from './loader/translation-loader';
 import { FormatDateTimePipe } from './pipe/format-date-time-pipe';
+import { TranslationPipe } from './pipe/translation-pipe';
 import { MessageFormatTranslationService } from './service/message-format-translation-service';
 import { TranslationService } from './service/translation-service';
 import { BOOTSTRAP_DETAILS } from './utils/tokens';
-import { TranslationPipe } from './pipe/translation-pipe';
-import { HttpClient } from '@angular/common/http';
 
 let singletonService: TranslationService = null;
 

--- a/projects/i18n/src/lib/pipe/format-date-time-pipe.spec.ts
+++ b/projects/i18n/src/lib/pipe/format-date-time-pipe.spec.ts
@@ -7,9 +7,9 @@
  * Copyright 2018-2019 VMware, Inc. All rights reserved. VMware Confidential
  */
 
+import { MockTranslationService } from '../service/mock-translation-service';
 import { PlatformUtil } from '../utils/platform-util';
 import { formatDateStringToValidFormatForIE, FormatDateTimePipe } from './format-date-time-pipe';
-import { MockTranslationService } from '../service/mock-translation-service';
 
 describe('FormatDateTimePipe', () => {
     const dateString = '04/26/2018, 4:54:06 PM';

--- a/projects/i18n/src/lib/pipe/format-date-time-pipe.ts
+++ b/projects/i18n/src/lib/pipe/format-date-time-pipe.ts
@@ -7,8 +7,8 @@
  * Copyright 2018-2019 VMware, Inc. All rights reserved. VMware Confidential
  */
 import { Injectable, Pipe, PipeTransform } from '@angular/core';
-import { PlatformUtil } from '../utils/platform-util';
 import { TranslationService } from '../service/translation-service';
+import { PlatformUtil } from '../utils/platform-util';
 
 /**
  * This function modifies the timezone format in the provided date string in order to work in IE11

--- a/projects/i18n/src/lib/pipe/translation-pipe.spec.ts
+++ b/projects/i18n/src/lib/pipe/translation-pipe.spec.ts
@@ -4,10 +4,10 @@
  */
 
 import { ChangeDetectorRef } from '@angular/core';
-import { MockTranslationService } from '../service/mock-translation-service';
-import { TranslationPipe } from './translation-pipe';
-import { TranslationService } from '../service/translation-service';
 import { BehaviorSubject } from 'rxjs';
+import { MockTranslationService } from '../service/mock-translation-service';
+import { TranslationService } from '../service/translation-service';
+import { TranslationPipe } from './translation-pipe';
 
 class GeneralTranslationPipe extends TranslationPipe {
     constructor(service: TranslationService, myChangeRef: ChangeDetectorRef) {

--- a/projects/i18n/src/lib/pipe/translation-pipe.ts
+++ b/projects/i18n/src/lib/pipe/translation-pipe.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { PipeTransform, ChangeDetectorRef, Injectable, Pipe } from '@angular/core';
+import { ChangeDetectorRef, Injectable, Pipe, PipeTransform } from '@angular/core';
 import { TranslationService } from '../service/translation-service';
 
 /**

--- a/projects/i18n/src/lib/service/basic-translation-service.ts
+++ b/projects/i18n/src/lib/service/basic-translation-service.ts
@@ -4,8 +4,8 @@
  */
 
 import { BehaviorSubject } from 'rxjs';
-import { TranslationService, TranslationSet } from './translation-service';
 import { Observable } from 'rxjs';
+import { TranslationService, TranslationSet } from './translation-service';
 
 /**
  * Interpolate a translation using regex.

--- a/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
+++ b/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
@@ -6,9 +6,9 @@
 /*
  * Copyright 2017 VMware, Inc. All rights reserved. VMware Confidential
  */
-import { MessageFormatTranslationService } from './message-format-translation-service';
-import { TranslationLoader } from '../loader/translation-loader';
 import { BehaviorSubject } from 'rxjs';
+import { TranslationLoader } from '../loader/translation-loader';
+import { MessageFormatTranslationService } from './message-format-translation-service';
 
 describe('MessageFormatTranslationService', () => {
     const translationSet = {

--- a/projects/i18n/src/lib/service/message-format-translation-service.ts
+++ b/projects/i18n/src/lib/service/message-format-translation-service.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import MessageFormat from 'messageformat';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { TranslationLoader } from '../loader/translation-loader';
 import { FormatDateOptions } from './basic-translation-service';
 import { TranslationService, TranslationSet } from './translation-service';
-import MessageFormat from 'messageformat';
-import { Observable, BehaviorSubject } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 /**
  * Translation service to implement ICU MessageFormat.

--- a/projects/i18n/src/test.ts
+++ b/projects/i18n/src/test.ts
@@ -7,6 +7,7 @@
 
 import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
+// tslint:disable-next-line: ordered-imports
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 

--- a/tslint.json
+++ b/tslint.json
@@ -79,7 +79,7 @@
       "as-needed"
     ],
     "object-literal-sort-keys": false,
-    "ordered-imports": false,
+    "ordered-imports": true,
     "quotemark": [
       true,
       "single"
@@ -106,8 +106,6 @@
       "allow-leading-underscore",
       "allow-pascal-case"
     ],
-
-    // Security related
     "function-constructor": true,
     "no-delete-expression": true,
     "no-document-domain": true,


### PR DESCRIPTION
# Description:

Enabled the ordered import rule on the tslint file. Also, in package.json, corrected the way that linting errors are fixed. 

In all the test.ts files, I had to disable auto ordering to push up the zone.js imports to the top. 

# Testing:

Ran all the unit tests and made sure the linting fixer still worked.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>