### PR TITLE
Fixed cliptext tests.

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"

--- a/projects/components/src/common/activity-reporter/index.ts
+++ b/projects/components/src/common/activity-reporter/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+export * from './activity-reporter.module';
 export * from './activity-reporter';
 export * from './banner-activity-reporter.component';
 export * from './spinner-activity-reporter.component';
-export * from './activity-reporter.module';

--- a/projects/components/src/lib/directives/index.ts
+++ b/projects/components/src/lib/directives/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+export * from './show-clipped-text.directive';

--- a/projects/components/src/lib/directives/show-clipped-text.directive.spec.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { ShowClippedTextDirective, tip, TooltipPosition } from './show-clipped-text.directive';
+import { fireTipTransitionEndForTests, ShowClippedTextDirective, TooltipPosition } from './show-clipped-text.directive';
 import {
     ShowClippedTextDirectiveTestHelper,
     ShowClippedTextDirectiveTestHostComponent,
@@ -86,14 +86,13 @@ describe('ShowClippedTextDirective', () => {
         it('hides the tooltip if the mouse moves away from the tooltip', fakeAsync(function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.disabled = false;
-            helper.componentInstance.directive.mouseoutDelay = 2; // TODO: make setter
             helper.width = '10px';
             helper.moveMouseOverHost();
             helper.moveMouseOffHost();
-            tick(1);
+            tick(helper.hideDelay / 2);
             helper.moveMouseOverTooltip();
             helper.moveMouseOffTooltip();
-            tick(10);
+            tick(helper.hideDelay * 2);
             expect(helper.isTooltipVisible).toBe(false);
         }));
 
@@ -113,11 +112,10 @@ describe('ShowClippedTextDirective', () => {
             helper.moveMouseOverHost();
             // To avoid waiting a whole second
             helper.componentInstance.directive.mouseoutDelay = 1;
-            helper.transitionTime = '1ms';
             helper.moveMouseOffHost();
-            tick(50);
+            tick(2);
             // Transition end is not called when the window is not focused, so need to add this.
-            tip.onTransitionEnd(new Event('transitionend'));
+            fireTipTransitionEndForTests(new Event('transitionend'));
             expect(helper.tooltipVisibility).toBe('hidden', 'CSS visibility should have been set to hidden');
         }));
     });

--- a/projects/components/src/lib/directives/show-clipped-text.directive.spec.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ShowClippedTextDirective } from './show-clipped-text.directive';
+import { ShowClippedTextDirective, tip, TooltipPosition } from './show-clipped-text.directive';
 import {
     ShowClippedTextDirectiveTestHelper,
     ShowClippedTextDirectiveTestHostComponent,
@@ -26,8 +26,7 @@ function timeout(ms = 0): Promise<number> {
     return new Promise(resolve => window.setTimeout(resolve, ms));
 }
 
-// TODO: https://jira.eng.vmware.com/browse/VDUCC-116
-xdescribe('ShowClippedTextDirective', () => {
+describe('ShowClippedTextDirective', () => {
     beforeEach(async function(this: Test): Promise<void> {
         await TestBed.configureTestingModule({
             declarations: [ShowClippedTextDirective, ShowClippedTextDirectiveTestHostComponent],
@@ -38,25 +37,23 @@ xdescribe('ShowClippedTextDirective', () => {
         await timeout(this.clippedTextHelper.hideDelay * 2);
     });
 
-    // TODO: https://jira.eng.vmware.com/browse/VDUCC-116
-    // describe('singletonTooltip', () => {
-    // it('creates a single tooltip even when there are multiple directives', function(this: Test): void {
-    //     expect(this.clippedTextHelper.tooltipCount).toBe(1);
-    // });
+    describe('singletonTooltip', () => {
+        it('creates a single tooltip even when there are multiple directives', function(this: Test): void {
+            expect(this.clippedTextHelper.tooltipCount).toBe(1);
+        });
 
-    // it('deletes the singleton tooltip after all instances are removed', function(this: Test): void {
-    //     this.clippedTextHelper.destroy();
-    //     expect(this.clippedTextHelper.tooltipCount).toBe(0);
-    // });
-    // });
+        it('deletes the singleton tooltip after all instances are removed', function(this: Test): void {
+            this.clippedTextHelper.destroy();
+            expect(this.clippedTextHelper.tooltipCount).toBe(0);
+        });
+    });
 
     describe('showing tooltip', () => {
-        // TODO: https://jira.eng.vmware.com/browse/VDUCC-116
-        // it('displays the tooltip if the element is clipped', function(this: Test): void {
-        //     const helper = this.clippedTextHelper;
-        //     helper.moveMouseOverHost();
-        //     expect(helper.isTooltipVisible).toBe(true, 'Tooltip should have been visible since element is clipped');
-        // });
+        it('displays the tooltip if the element is clipped', function(this: Test): void {
+            const helper = this.clippedTextHelper;
+            helper.moveMouseOverHost();
+            expect(helper.isTooltipVisible).toBe(true, 'Tooltip should have been visible since element is clipped');
+        });
         it('does not display the tooltip if the element is not clipped', function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.width = '1000px';
@@ -115,21 +112,19 @@ xdescribe('ShowClippedTextDirective', () => {
             expect(helper.isTooltipVisible).toBe(true);
         });
 
-        // TODO https://jira.eng.vmware.com/browse/VDUCC-116
-        // it('changes visibility to hidden after the tooltip fades out', async function(this: Test): Promise<void> {
-        //     const helper = this.clippedTextHelper;
-        //     helper.width = '10px';
-        //     helper.moveMouseOverHost();
-        //     // To avoid waiting a whole second
-        //     helper.componentInstance.directive.mouseoutDelay = 1;
-        //     helper.transitionTime = '1ms';
-        //     helper.moveMouseOffHost();
-        //     // Required for the transition to end, trying to set it to the 1ms above does not work, 25ms works sometimes
-        //     // 50 seems to work all the time
-        //     // Potential for flakiness here ¯\_(ツ)_/¯
-        //     await timeout(50);
-        //     expect(helper.tooltipVisibility).toBe('hidden', 'CSS visibility should have been set to hidden');
-        // });
+        it('changes visibility to hidden after the tooltip fades out', async function(this: Test): Promise<void> {
+            const helper = this.clippedTextHelper;
+            helper.width = '10px';
+            helper.moveMouseOverHost();
+            // To avoid waiting a whole second
+            helper.componentInstance.directive.mouseoutDelay = 1;
+            helper.transitionTime = '1ms';
+            helper.moveMouseOffHost();
+            await timeout(50);
+            // Transition end is not called when the window is not focused, so need to add this.
+            tip.onTransitionEnd(new Event('transitionend'));
+            expect(helper.tooltipVisibility).toBe('hidden', 'CSS visibility should have been set to hidden');
+        });
     });
 
     describe('disabling the tooltip', () => {
@@ -180,50 +175,48 @@ xdescribe('ShowClippedTextDirective', () => {
         });
     });
 
-    // TODO https://jira.eng.vmware.com/browse/VDUCC-116
-    // describe('@Input vcdShowClippedText (tooltipSize)', () => {
-    //     it('displays tooltip with the given default size of 200px', async function(this: Test): Promise<void> {
-    //         const helper = this.clippedTextHelper;
-    //         helper.hostText = 'Something that is longer than the default width so tooltip reaches its max width';
-    //         helper.width = '10px';
-    //         await timeout(0);
-    //         helper.moveMouseOverHost();
-    //         expect(helper.tooltipSize).toBe(200);
-    //     });
-    // });
+    describe('@Input vcdShowClippedText (tooltipSize)', () => {
+        it('displays tooltip with the given default size of 200px', async function(this: Test): Promise<void> {
+            const helper = this.clippedTextHelper;
+            helper.hostText = 'Something that is longer than the default width so tooltip reaches its max width';
+            helper.width = '10px';
+            await timeout(0);
+            helper.moveMouseOverHost();
+            expect(helper.tooltipSize).toBe(200);
+        });
+    });
 
-    // TODO https://jira.eng.vmware.com/browse/VDUCC-116
-    // describe('Dynamic position', () => {
-    //     it('displays tooltip on bottom-right when host is in top-left quadrant', function(this: Test): void {
-    //         const helper = this.clippedTextHelper;
-    //         helper.width = '10px';
-    //         helper.hostPosition = TooltipPosition.tl;
-    //         helper.moveMouseOverHost();
-    //         expect(helper.tooltipPosition).toBe(TooltipPosition.br);
-    //     });
-    //
-    //     it('displays tooltip on bottom-left when host is in top-right quadrant', function(this: Test): void {
-    //         const helper = this.clippedTextHelper;
-    //         helper.width = '10px';
-    //         helper.hostPosition = TooltipPosition.tr;
-    //         helper.moveMouseOverHost();
-    //         expect(helper.tooltipPosition).toBe(TooltipPosition.bl);
-    //     });
-    //
-    //     it('displays tooltip on top-right when host is in bottom-left quadrant', function(this: Test): void {
-    //         const helper = this.clippedTextHelper;
-    //         helper.width = '10px';
-    //         helper.hostPosition = TooltipPosition.bl;
-    //         helper.moveMouseOverHost();
-    //         expect(helper.tooltipPosition).toBe(TooltipPosition.tr);
-    //     });
-    //
-    //     it('displays tooltip on top-left when host is in bottom-right quadrant', function(this: Test): void {
-    //         const helper = this.clippedTextHelper;
-    //         helper.width = '10px';
-    //         helper.hostPosition = TooltipPosition.br;
-    //         helper.moveMouseOverHost();
-    //         expect(helper.tooltipPosition).toBe(TooltipPosition.tl);
-    //     });
-    // });
+    describe('Dynamic position', () => {
+        it('displays tooltip on bottom-right when host is in top-left quadrant', function(this: Test): void {
+            const helper = this.clippedTextHelper;
+            helper.width = '10px';
+            helper.hostPosition = TooltipPosition.tl;
+            helper.moveMouseOverHost();
+            expect(helper.tooltipPosition).toBe(TooltipPosition.br);
+        });
+
+        it('displays tooltip on bottom-left when host is in top-right quadrant', function(this: Test): void {
+            const helper = this.clippedTextHelper;
+            helper.width = '10px';
+            helper.hostPosition = TooltipPosition.tr;
+            helper.moveMouseOverHost();
+            expect(helper.tooltipPosition).toBe(TooltipPosition.bl);
+        });
+
+        it('displays tooltip on top-right when host is in bottom-left quadrant', function(this: Test): void {
+            const helper = this.clippedTextHelper;
+            helper.width = '10px';
+            helper.hostPosition = TooltipPosition.bl;
+            helper.moveMouseOverHost();
+            expect(helper.tooltipPosition).toBe(TooltipPosition.tr);
+        });
+
+        it('displays tooltip on top-left when host is in bottom-right quadrant', function(this: Test): void {
+            const helper = this.clippedTextHelper;
+            helper.width = '10px';
+            helper.hostPosition = TooltipPosition.br;
+            helper.moveMouseOverHost();
+            expect(helper.tooltipPosition).toBe(TooltipPosition.tl);
+        });
+    });
 });

--- a/projects/components/src/lib/directives/show-clipped-text.directive.spec.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ShowClippedTextDirective, tip, TooltipPosition } from './show-clipped-text.directive';
 import {
     ShowClippedTextDirectiveTestHelper,
@@ -34,7 +34,6 @@ describe('ShowClippedTextDirective', () => {
         this.fixture = TestBed.createComponent(ShowClippedTextDirectiveTestHostComponent);
         this.fixture.detectChanges();
         this.clippedTextHelper = new ShowClippedTextDirectiveTestHelper(this.fixture);
-        await timeout(this.clippedTextHelper.hideDelay * 2);
     });
 
     describe('singletonTooltip', () => {
@@ -66,53 +65,49 @@ describe('ShowClippedTextDirective', () => {
     });
 
     describe('hiding the tooltip', () => {
-        it('hides the tooltip after a timeout', async function(this: Test): Promise<void> {
+        it('hides the tooltip after a timeout', fakeAsync(function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.moveMouseOverHost();
             helper.moveMouseOffHost();
-            await timeout(helper.hideDelay);
+            tick(helper.hideDelay);
             expect(helper.isTooltipVisible).toBe(false);
-        });
+        }));
 
-        it('does not hide the tooltip if the mouse quickly goes to the tooltip', async function(this: Test): Promise<
-            void
-        > {
+        it('does not hide the tooltip if the mouse quickly goes to the tooltip', fakeAsync(function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.width = '10px';
             helper.moveMouseOverHost();
             helper.moveMouseOffHost();
-            await timeout(helper.hideDelay - 1);
+            tick(helper.hideDelay - 1);
             helper.moveMouseOverTooltip();
             expect(helper.isTooltipVisible).toBe(true);
-        });
+        }));
 
-        it('hides the tooltip if the mouse moves away from the tooltip', async function(this: Test): Promise<void> {
+        it('hides the tooltip if the mouse moves away from the tooltip', fakeAsync(function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.disabled = false;
             helper.componentInstance.directive.mouseoutDelay = 2; // TODO: make setter
             helper.width = '10px';
             helper.moveMouseOverHost();
             helper.moveMouseOffHost();
-            await timeout(1);
+            tick(1);
             helper.moveMouseOverTooltip();
             helper.moveMouseOffTooltip();
-            await timeout(10);
+            tick(10);
             expect(helper.isTooltipVisible).toBe(false);
-        });
+        }));
 
-        it('does not hide tooltip if the mouse quickly returns to host element', async function(this: Test): Promise<
-            void
-        > {
+        it('does not hide tooltip if the mouse quickly returns to host element', fakeAsync(function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.width = '10px';
             helper.moveMouseOverHost();
             helper.moveMouseOffHost();
-            await timeout(1);
+            tick(1);
             helper.moveMouseOverHost();
             expect(helper.isTooltipVisible).toBe(true);
-        });
+        }));
 
-        it('changes visibility to hidden after the tooltip fades out', async function(this: Test): Promise<void> {
+        it('changes visibility to hidden after the tooltip fades out', fakeAsync(function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.width = '10px';
             helper.moveMouseOverHost();
@@ -120,11 +115,11 @@ describe('ShowClippedTextDirective', () => {
             helper.componentInstance.directive.mouseoutDelay = 1;
             helper.transitionTime = '1ms';
             helper.moveMouseOffHost();
-            await timeout(50);
+            tick(50);
             // Transition end is not called when the window is not focused, so need to add this.
             tip.onTransitionEnd(new Event('transitionend'));
             expect(helper.tooltipVisibility).toBe('hidden', 'CSS visibility should have been set to hidden');
-        });
+        }));
     });
 
     describe('disabling the tooltip', () => {
@@ -136,7 +131,7 @@ describe('ShowClippedTextDirective', () => {
             helper.disabled = false;
         });
 
-        it('can be modified dynamically', async function(this: Test): Promise<void> {
+        it('can be modified dynamically', fakeAsync(function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.disabled = true;
             helper.moveMouseOverHost();
@@ -145,8 +140,8 @@ describe('ShowClippedTextDirective', () => {
             helper.moveMouseOverHost();
             expect(helper.isTooltipVisible).toBeTruthy();
             helper.moveMouseOffHost();
-            await timeout(helper.hideDelay);
-        });
+            tick(helper.hideDelay);
+        }));
     });
 
     describe('tracking host changes while mouse is hovering', () => {
@@ -176,14 +171,14 @@ describe('ShowClippedTextDirective', () => {
     });
 
     describe('@Input vcdShowClippedText (tooltipSize)', () => {
-        it('displays tooltip with the given default size of 200px', async function(this: Test): Promise<void> {
+        it('displays tooltip with the given default size of 200px', fakeAsync(function(this: Test): void {
             const helper = this.clippedTextHelper;
             helper.hostText = 'Something that is longer than the default width so tooltip reaches its max width';
             helper.width = '10px';
-            await timeout(0);
+            tick(0);
             helper.moveMouseOverHost();
             expect(helper.tooltipSize).toBe(200);
-        });
+        }));
     });
 
     describe('Dynamic position', () => {

--- a/projects/components/src/lib/directives/show-clipped-text.directive.test-helper.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.test-helper.ts
@@ -115,7 +115,7 @@ export class ShowClippedTextDirectiveTestHelper {
         return this.tooltip.querySelector('.tooltip-content');
     }
 
-    private get tooltip(): HTMLElement {
+    public get tooltip(): HTMLElement {
         return document.querySelector('.tooltip.vcd-show-clipped-text');
     }
 }

--- a/projects/components/src/lib/directives/show-clipped-text.directive.test-helper.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.test-helper.ts
@@ -99,10 +99,6 @@ export class ShowClippedTextDirectiveTestHelper {
         return document.querySelectorAll('.tooltip.vcd-show-clipped-text').length;
     }
 
-    public set transitionTime(time: string) {
-        this.tooltipContent.style.transitionDuration = time;
-    }
-
     public get tooltipVisibility(): string {
         return this.tooltipContent.style.visibility;
     }
@@ -115,7 +111,7 @@ export class ShowClippedTextDirectiveTestHelper {
         return this.tooltip.querySelector('.tooltip-content');
     }
 
-    public get tooltip(): HTMLElement {
+    private get tooltip(): HTMLElement {
         return document.querySelector('.tooltip.vcd-show-clipped-text');
     }
 }

--- a/projects/components/src/lib/directives/show-clipped-text.directive.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.ts
@@ -39,7 +39,7 @@ export interface CliptextConfig {
 /**
  * Singleton tooltip created by directive
  */
-export const tip = {
+const tip = {
     /** A single DOM node structure for the popup is created and shared with all instances (the .tooltip)  */
     container: null as HTMLElement,
 
@@ -327,3 +327,14 @@ export class ShowClippedTextDirective implements OnDestroy, OnInit {
         return Math.ceil(this.hostElement.getBoundingClientRect().width) < this.hostElement.scrollWidth;
     }
 }
+
+/**
+ * Used to call {@link tip.onTransitionEnd} from outside this file.
+ * We need to expose {@link tip.onTransitionEnd} because when the window is not focused
+ * (as in a headless chrome environment), the transitionend event is not fired.
+ * As such, from the tests, you need to manually call this method.
+ */
+export const fireTipTransitionEndForTests = (event: Event) => {
+    // Since we're at it, please remove the param from onTransitionEnd since we don't use it
+    tip.onTransitionEnd(event);
+};

--- a/projects/components/src/lib/directives/show-clipped-text.directive.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.ts
@@ -39,7 +39,7 @@ export interface CliptextConfig {
 /**
  * Singleton tooltip created by directive
  */
-const tip = {
+export const tip = {
     /** A single DOM node structure for the popup is created and shared with all instances (the .tooltip)  */
     container: null as HTMLElement,
 
@@ -256,7 +256,7 @@ export class ShowClippedTextDirective implements OnDestroy, OnInit {
     private mutationObserver = new MutationObserver(() => {
         // Make sure isMouseOver is first. It's an optimization to avoid measuring the DOM
         // Also don't update the tooltip if content changes but the mouse is over a different host
-        if (tip.isMouseOver && this.hostElement === tip.currentHost) {
+        if (tip.isMouseOver && tip.currentDirective && this.hostElement === tip.currentHost) {
             if (this.isOverflowing()) {
                 tip.update();
             } else {

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -8,8 +8,8 @@
  */
 export * from './common/subscription';
 export * from './common/error';
-export * from './common/activity-reporter';
 export * from './common/loading';
+export * from './common/activity-reporter/index';
 export * from './data-exporter';
 export * from './lib/directives';
 export * from './datagrid';

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -11,7 +11,12 @@ export * from './common/error/index';
 export * from './common/activity-reporter/index';
 export * from './common/loading/index';
 export * from './data-exporter/index';
-export * from './lib/directives/show-clipped-text.directive'; //
+export {
+    ShowClippedTextDirective,
+    TooltipPosition,
+    TooltipSize,
+    CliptextConfig,
+} from './lib/directives/show-clipped-text.directive'; //
 export * from './datagrid/index';
 export * from './components.module';
 export * from './utils/test/index';

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -6,17 +6,12 @@
 /*
  * Public API Surface of components
  */
-export * from './common/subscription/index';
-export * from './common/error/index';
-export * from './common/activity-reporter/index';
-export * from './common/loading/index';
-export * from './data-exporter/index';
-export {
-    ShowClippedTextDirective,
-    TooltipPosition,
-    TooltipSize,
-    CliptextConfig,
-} from './lib/directives/show-clipped-text.directive'; //
-export * from './datagrid/index';
+export * from './common/subscription';
+export * from './common/error';
+export * from './common/activity-reporter';
+export * from './common/loading';
+export * from './data-exporter';
+export * from './lib/directives';
+export * from './datagrid';
 export * from './components.module';
-export * from './utils/test/index';
+export * from './utils/test';

--- a/projects/components/src/utils/test/index.ts
+++ b/projects/components/src/utils/test/index.ts
@@ -4,6 +4,7 @@
  */
 
 export * from './datagrid/datagrid.wo';
+export * from './datagrid/vcd-datagrid.wo';
 export * from './activity-reporter/banner-activity-reporter.wo';
 export * from './activity-reporter/spinner-activity-reporter.wo';
 export * from './widget-object';

--- a/projects/components/src/utils/test/index.ts
+++ b/projects/components/src/utils/test/index.ts
@@ -4,7 +4,7 @@
  */
 
 export * from './datagrid/datagrid.wo';
-export * from './datagrid/vcd-datagrid.wo';
+// export * from './datagrid/vcd-datagrid.wo';
 export * from './activity-reporter/banner-activity-reporter.wo';
 export * from './activity-reporter/spinner-activity-reporter.wo';
 export * from './widget-object';


### PR DESCRIPTION
# Description

Fixes the cliptext tests so that they always pass, regardless of if the window is focused or it is running in GH Actions.

Necessary Changes made:

1. transitionend doesn't seem to run when the window is unfocused. So I made the tip static object exported (but not exported from the public API) and directly called the transitionEnd method from the test.
2. mutationObserver threw an error that hostElement could not be found because tip.currentDirective is undefined. So, I added a check to make sure tip.currentDirective is defined.

Those were the two issues causing the test failures.

Improvements Made:

1. Removed most of the await timeout(...) to speed up the tests. Only two were required to still be there and are both commented (and we're commented originally before this change). 

# Testing

Ran the tests locally numerous times. Also, ran them on GH Actions a dozen or so times by creating pull requests and pushing empty commits. They appear to always pass now.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>