### PR TITLE
Changes to Datagrid + Widget Object

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -64,7 +64,7 @@
     </clr-dg-column>
 
     <clr-dg-row
-        *ngFor="let restItem of items; let i = index; trackBy: trackBy"
+        *clrDgItems="let restItem of items; let i = index; trackBy: trackBy"
         [ngForTrackBy]="trackBy"
         [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
         [clrDgItem]="restItem"

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -62,9 +62,12 @@ $supported-buttons: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
     width: $BUTTON_WIDTH !important;
 }
 
+.dropdown .dropdown-toggle.btn.dropdown-small {
+    padding-right: 0.5rem;
+}
+
 .dropdown-small {
     min-width: unset;
-    padding-right: 0.5rem !important;
 }
 
 .action-icon {

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -64,6 +64,7 @@ $supported-buttons: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
 
 .dropdown-small {
     min-width: unset;
+    padding-right: 0.5rem !important;
 }
 
 .action-icon {

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -190,6 +190,15 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() gridData', () => {
+                it('shows a placeholder when no data is present', function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.gridData = {
+                        items: [],
+                        totalItems: 0,
+                    };
+                    this.finder.detectChanges();
+                    expect(this.clrGridWidget.hasPlaceholder).toBeTruthy();
+                });
+
                 describe('when data is refreshed unselects a row if the row is removed', () => {
                     it('in single selection', function(this: HasFinderAndGrid): void {
                         this.finder.hostComponent.selectionType = GridSelectionType.Single;

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -69,6 +69,7 @@ describe('DatagridComponent', () => {
                 expect(this.clrGridWidget.columnHeaders).toEqual(
                     this.finder.hostComponent.columns.map(col => col.displayName)
                 );
+                expect(this.clrGridWidget.getColumnHeader(0)).toEqual(this.finder.hostComponent.columns[0].displayName);
             });
 
             it('displays rows based on the grid data received', function(this: HasFinderAndGrid): void {
@@ -344,13 +345,13 @@ describe('DatagridComponent', () => {
 
         it('displays loading indicators while data is loading', function(this: HasFinderAndGrid): void {
             this.finder.detectChanges();
-            expect(this.clrGridWidget.component.loading).toBe(true, 'Initially loading indicator should be true');
+            expect(this.clrGridWidget.loading).toBe(true, 'Initially loading indicator should be true');
             this.finder.hostComponent.gridData = {
                 items: mockData,
                 totalItems: 2,
             };
             this.finder.detectChanges();
-            expect(this.clrGridWidget.component.loading).toBe(
+            expect(this.clrGridWidget.loading).toBe(
                 false,
                 'After setting gridData, loading indicator should not be visible'
             );
@@ -399,6 +400,7 @@ describe('DatagridComponent', () => {
 
             it('hides the columns with hidable value of  "Hidden"', function(this: HasFinderAndGrid): void {
                 expect(this.clrGridWidget.isColumnDisplayed(2)).toBe(false);
+                expect(this.clrGridWidget.hiddenColumnHeaders).toEqual(['Default Renderer']);
             });
 
             it('shows the columns with hidable value of undefined', function(this: HasFinderAndGrid): void {
@@ -576,7 +578,9 @@ describe('DatagridComponent', () => {
 
                 it('the button handler is called when the button is pressed', function(this: HasFinderAndGrid): void {
                     const spy = spyOn(this.finder.hostComponent.buttonConfig.globalButtons[0], 'handler');
-                    this.clrGridWidget.pressTopButton(0);
+                    expect(this.clrGridWidget.getTopButtonText(0, 1)).toEqual('Add');
+                    expect(this.clrGridWidget.getTopButtonDisabled(0, 1)).toBeFalsy();
+                    this.clrGridWidget.pressTopButton(0, 1);
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
             });
@@ -652,10 +656,10 @@ describe('DatagridComponent', () => {
                     });
 
                     it('responds when the user presses a contextual button', function(this: HasFinderAndGrid): void {
-                        const spy = jasmine.createSpy('clickHanlder');
+                        const spy = jasmine.createSpy('clickHandler');
                         this.finder.hostComponent.buttonConfig.contextualButtonConfig.buttons[0].handler = spy;
                         this.clrGridWidget.selectRow(0);
-                        this.clrGridWidget.pressTopButton(0);
+                        this.clrGridWidget.pressTopButton(0, 1);
                         expect(spy).toHaveBeenCalledWith([mockData[0]]);
                     });
                 });
@@ -668,11 +672,13 @@ describe('DatagridComponent', () => {
                     });
 
                     it('responds when the user presses a contextual button', function(this: HasFinderAndGrid): void {
-                        const spy = jasmine.createSpy('clickHanlder');
+                        const spy = jasmine.createSpy('clickHandler');
                         this.finder.hostComponent.buttonConfig.contextualButtonConfig.buttons[0].handler = spy;
                         this.finder.detectChanges();
                         this.clrGridWidget.pressButtonAtRow(0, 0);
                         expect(spy).toHaveBeenCalledWith([mockData[0]]);
+                        expect(this.clrGridWidget.getButtonAtRowText(0, 0)).toEqual('Add');
+                        expect(this.clrGridWidget.getButtonAtRowDisabled(0, 0)).toBeFalsy();
                     });
 
                     it('adds CSS to set the width based on the maximum number of buttons', function(this: HasFinderAndGrid): void {
@@ -703,7 +709,7 @@ describe('DatagridComponent', () => {
                     this.finder.hostComponent.indicatorType = ActivityIndicatorType.SPINNER;
                     this.finder.detectChanges();
                     const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
-                    this.clrGridWidget.pressTopButton(0);
+                    this.clrGridWidget.pressTopButton(0, 1);
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
 
@@ -711,7 +717,7 @@ describe('DatagridComponent', () => {
                     this.finder.hostComponent.indicatorType = ActivityIndicatorType.BANNER;
                     this.finder.detectChanges();
                     const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
-                    this.clrGridWidget.pressTopButton(0);
+                    this.clrGridWidget.pressTopButton(0, 1);
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
             });
@@ -779,6 +785,7 @@ describe('DatagridComponent', () => {
                 this.finder.hostComponent.columns = [{ displayName: '', renderer: 'details.gender' }];
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getCellText(0, 0)).toEqual(mockData[0].details.gender);
+                expect(this.clrGridWidget.getRowValues(0)).toEqual([mockData[0].details.gender]);
             });
         });
 

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -587,9 +587,9 @@ describe('DatagridComponent', () => {
 
                 it('the button handler is called when the button is pressed', function(this: HasFinderAndGrid): void {
                     const spy = spyOn(this.finder.hostComponent.buttonConfig.globalButtons[0], 'handler');
-                    expect(this.clrGridWidget.getButtonText('add')).toEqual('Add');
-                    expect(this.clrGridWidget.getButtonDisabled('add')).toBeFalsy();
-                    this.clrGridWidget.pressButton('add');
+                    expect(this.clrGridWidget.getTopButtonText('add')).toEqual('Add');
+                    expect(this.clrGridWidget.isTopButtonEnabled('add')).toBeTruthy();
+                    this.clrGridWidget.pressTopButton('add');
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
             });
@@ -665,7 +665,7 @@ describe('DatagridComponent', () => {
                         const spy = jasmine.createSpy('clickHandler');
                         this.finder.hostComponent.buttonConfig.contextualButtonConfig.buttons[0].handler = spy;
                         this.clrGridWidget.selectRow(0);
-                        this.clrGridWidget.pressButton('a');
+                        this.clrGridWidget.pressTopButton('a');
                         expect(spy).toHaveBeenCalledWith([mockData[0]]);
                     });
                 });
@@ -681,10 +681,10 @@ describe('DatagridComponent', () => {
                         const spy = jasmine.createSpy('clickHandler');
                         this.finder.hostComponent.buttonConfig.contextualButtonConfig.buttons[0].handler = spy;
                         this.finder.detectChanges();
-                        this.clrGridWidget.pressButton('a');
+                        this.clrGridWidget.pressRowButton('a', 0);
                         expect(spy).toHaveBeenCalledWith([mockData[0]]);
-                        expect(this.clrGridWidget.getButtonText('a')).toEqual('Add');
-                        expect(this.clrGridWidget.getButtonDisabled('a')).toBeFalsy();
+                        expect(this.clrGridWidget.getRowButtonText('a', 0)).toEqual('Add');
+                        expect(this.clrGridWidget.isRowButtonEnabled('a', 0)).toBeTruthy();
                     });
 
                     it('adds CSS to set the width based on the maximum number of buttons', function(this: HasFinderAndGrid): void {
@@ -715,7 +715,7 @@ describe('DatagridComponent', () => {
                     this.finder.hostComponent.indicatorType = ActivityIndicatorType.SPINNER;
                     this.finder.detectChanges();
                     const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
-                    this.clrGridWidget.pressButton('button');
+                    this.clrGridWidget.pressTopButton('button');
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
 
@@ -723,7 +723,7 @@ describe('DatagridComponent', () => {
                     this.finder.hostComponent.indicatorType = ActivityIndicatorType.BANNER;
                     this.finder.detectChanges();
                     const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
-                    this.clrGridWidget.pressButton('button');
+                    this.clrGridWidget.pressTopButton('button');
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
             });

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -554,19 +554,19 @@ describe('DatagridComponent', () => {
                             label: 'Add',
                             isActive: () => true,
                             handler: () => {},
-                            class: 'button',
+                            class: 'add',
                         },
                         {
                             label: 'Remove',
                             isActive: () => false,
                             handler: () => {},
-                            class: 'button',
+                            class: 'remove',
                         },
                         {
                             label: 'Change',
                             isActive: () => false,
                             handler: () => {},
-                            class: 'button',
+                            class: 'change',
                         },
                     ];
                     this.finder.detectChanges();
@@ -578,9 +578,9 @@ describe('DatagridComponent', () => {
 
                 it('the button handler is called when the button is pressed', function(this: HasFinderAndGrid): void {
                     const spy = spyOn(this.finder.hostComponent.buttonConfig.globalButtons[0], 'handler');
-                    expect(this.clrGridWidget.getTopButtonText(0, 1)).toEqual('Add');
-                    expect(this.clrGridWidget.getTopButtonDisabled(0, 1)).toBeFalsy();
-                    this.clrGridWidget.pressTopButton(0, 1);
+                    expect(this.clrGridWidget.getButtonText('add')).toEqual('Add');
+                    expect(this.clrGridWidget.getButtonDisabled('add')).toBeFalsy();
+                    this.clrGridWidget.pressButton('add');
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
             });
@@ -600,24 +600,21 @@ describe('DatagridComponent', () => {
                                 label: 'Add',
                                 isActive: (row: MockRecord[]) => true,
                                 handler: () => {},
-                                class: 'button',
-                                id: 'a',
+                                class: 'a',
                                 icon: 'play',
                             },
                             {
                                 label: 'Remove',
                                 isActive: () => false,
                                 handler: () => {},
-                                class: 'button',
-                                id: 'b',
+                                class: 'b',
                                 icon: 'pause',
                             },
                             {
                                 label: 'Other',
                                 isActive: (row: MockRecord[]) => row.length && row[0].name === 'Person 1',
                                 handler: () => {},
-                                class: 'button',
-                                id: 'c',
+                                class: 'c',
                                 icon: 'pause',
                             },
                         ],
@@ -659,7 +656,7 @@ describe('DatagridComponent', () => {
                         const spy = jasmine.createSpy('clickHandler');
                         this.finder.hostComponent.buttonConfig.contextualButtonConfig.buttons[0].handler = spy;
                         this.clrGridWidget.selectRow(0);
-                        this.clrGridWidget.pressTopButton(0, 1);
+                        this.clrGridWidget.pressButton('a');
                         expect(spy).toHaveBeenCalledWith([mockData[0]]);
                     });
                 });
@@ -675,10 +672,10 @@ describe('DatagridComponent', () => {
                         const spy = jasmine.createSpy('clickHandler');
                         this.finder.hostComponent.buttonConfig.contextualButtonConfig.buttons[0].handler = spy;
                         this.finder.detectChanges();
-                        this.clrGridWidget.pressButtonAtRow(0, 0);
+                        this.clrGridWidget.pressButton('a');
                         expect(spy).toHaveBeenCalledWith([mockData[0]]);
-                        expect(this.clrGridWidget.getButtonAtRowText(0, 0)).toEqual('Add');
-                        expect(this.clrGridWidget.getButtonAtRowDisabled(0, 0)).toBeFalsy();
+                        expect(this.clrGridWidget.getButtonText('a')).toEqual('Add');
+                        expect(this.clrGridWidget.getButtonDisabled('a')).toBeFalsy();
                     });
 
                     it('adds CSS to set the width based on the maximum number of buttons', function(this: HasFinderAndGrid): void {
@@ -709,7 +706,7 @@ describe('DatagridComponent', () => {
                     this.finder.hostComponent.indicatorType = ActivityIndicatorType.SPINNER;
                     this.finder.detectChanges();
                     const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
-                    this.clrGridWidget.pressTopButton(0, 1);
+                    this.clrGridWidget.pressButton('button');
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
 
@@ -717,7 +714,7 @@ describe('DatagridComponent', () => {
                     this.finder.hostComponent.indicatorType = ActivityIndicatorType.BANNER;
                     this.finder.detectChanges();
                     const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
-                    this.clrGridWidget.pressTopButton(0, 1);
+                    this.clrGridWidget.pressButton('button');
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
             });

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -624,7 +624,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
      * Is the given column able to be hidden by the user through the show/hide menu.
      */
     isColumnHideable(column: GridColumn<R>): boolean {
-        return column && column.hideable && column.hideable !== GridColumnHideable.Never;
+        return column && column.hideable !== GridColumnHideable.Never;
     }
 
     /**

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -280,17 +280,28 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
         this._buttonConfig = config;
         this._buttonConfig.inactiveDisplayMode =
             this._buttonConfig.inactiveDisplayMode || InactiveButtonDisplayMode.Disable;
-        this.featuredButtons = new Map(
-            this._buttonConfig.contextualButtonConfig.featured.map(featuredButtonId => [
-                featuredButtonId,
-                this._buttonConfig.contextualButtonConfig.buttons.find(button => button.id === featuredButtonId),
-            ])
-        );
-        this.featuredButtons.forEach(featured => {
-            if (!featured) {
-                throw new Error('Featured button was not found');
-            }
-        });
+        if (this._buttonConfig.contextualButtonConfig.featured) {
+            this.featuredButtons = new Map(
+                this._buttonConfig.contextualButtonConfig.featured.map(featuredButtonClass => [
+                    featuredButtonClass,
+                    this._buttonConfig.contextualButtonConfig.buttons.find(
+                        button => button.class === featuredButtonClass
+                    ),
+                ])
+            );
+            this.featuredButtons.forEach(featured => {
+                if (!featured) {
+                    throw new Error('Featured button was not found');
+                }
+            });
+        } else {
+            this.featuredButtons = new Map(
+                this._buttonConfig.contextualButtonConfig.buttons.map(featuredButton => [
+                    featuredButton.class,
+                    featuredButton,
+                ])
+            );
+        }
     }
 
     /**
@@ -463,8 +474,8 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
      */
     getFeaturedButtons(record?: R): ContextualButton<R>[] {
         return this._buttonConfig.contextualButtonConfig.buttons
-            .filter(button => this.isButtonShown(button, record) && this.featuredButtons.get(button.id))
-            .slice(0, this._buttonConfig.contextualButtonConfig.featuredCount);
+            .filter(button => this.isButtonShown(button, record) && this.featuredButtons.get(button.class))
+            .slice(0, this._buttonConfig.contextualButtonConfig.featuredCount || this.featuredButtons.size);
     }
 
     /**

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -126,12 +126,16 @@ export interface ContextualButtonConfig<R> {
      * An ordered list of {@link ContextualButton.id}s of buttons that should be in a featured position.
      *
      * Only non-hidden buttons will be shown.
+     *
+     * If featured is not set, all buttons will become featured.
      */
     featured?: string[];
     /**
      * How many buttons should display on the featured section.
      *
      * Used when you want to set a limit on the number of featured buttons shown.
+     *
+     * If featuredCount is not set, it will default to the total number of buttons.
      */
     featuredCount?: number;
     /**

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -51,8 +51,10 @@ export interface Button<R> {
     label: string;
     /**
      * The css class the button should have.
+     *
+     * @unique among all added buttons
      */
-    class?: string;
+    class: string;
     /**
      * The way this button should be shown when inactive.
      * Overrides {@link ButtonConfig.inactiveDisplayMode}.
@@ -99,10 +101,6 @@ export interface ContextualButton<R> extends Button<R> {
      */
     isActive: (rec: R[]) => boolean;
     /**
-     * The ID of this button that is unique among buttons passed to the grid.
-     */
-    id: string;
-    /**
      * The Clarity icon of the contextual button that is displayed if the button is featured.
      */
     icon: string;
@@ -129,13 +127,13 @@ export interface ContextualButtonConfig<R> {
      *
      * Only non-hidden buttons will be shown.
      */
-    featured: string[];
+    featured?: string[];
     /**
      * How many buttons should display on the featured section.
      *
      * Used when you want to set a limit on the number of featured buttons shown.
      */
-    featuredCount: number;
+    featuredCount?: number;
     /**
      * Where the buttons should display on the grid.
      */

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -34,13 +34,10 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
 
     /**
      * Gives the text content of all the cells in a row.
+     * @param rowIndex 0-based index of row
      */
     getRowValues(rowIndex: number): string[] {
-        const toReturn = [];
-        for (let columnIndex = 0; columnIndex < this.columnCount; columnIndex++) {
-            toReturn.push(this.getCellText(rowIndex, columnIndex));
-        }
-        return toReturn;
+        return this.getTexts(`${ROW_TAG}:nth-of-type(${rowIndex + 1}) ${CELL_TAG}`);
     }
 
     /**
@@ -209,24 +206,48 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
-     * Gives the text of the button with the given {@param buttonClass}
+     * Gives the text of the button with the given buttonClass on the top of the datagrid.
      */
-    getButtonText(buttonClass: string): string {
+    getTopButtonText(buttonClass: string): string {
         return this.getText(`button.${buttonClass}`);
     }
 
     /**
-     * Says if the button with the given {@param buttonClass} is disabled.
+     * Gives the text of the button with the given buttonClass at a row of the datagrid.
+     * @param row 0-based index of row
      */
-    getButtonDisabled(buttonClass: string): string {
-        return this.findElement(`button.${buttonClass}`).nativeElement.disabled;
+    getRowButtonText(buttonClass: string, row: number): string {
+        return this.getText(`button.${buttonClass}`, this.rows[row]);
     }
 
     /**
-     * Presses the button with the given {@param buttonClass}.
+     * Says if the button on the top of the grid with the given buttonClass is enabled.
      */
-    pressButton(buttonClass: string): void {
+    isTopButtonEnabled(buttonClass: string): boolean {
+        return !this.findElement(`button.${buttonClass}`).nativeElement.disabled;
+    }
+
+    /**
+     * Says if the button at a row in the datagrid with the given buttonClass is enabled.
+     * @param row 0-based index of row
+     */
+    isRowButtonEnabled(buttonClass: string, row: number): boolean {
+        return !this.findElement(`button.${buttonClass}`, this.rows[row]).nativeElement.disabled;
+    }
+
+    /**
+     * Presses the button with the given buttonClass on the top of the datagrid.
+     */
+    pressTopButton(buttonClass: string): void {
         this.click(`button.${buttonClass}`);
+    }
+
+    /**
+     * Presses the button with the given buttonClass on a row of the datagrid.
+     * @param row 0-based index of row
+     */
+    pressRowButton(buttonClass: string, row: number): void {
+        this.click(`button.${buttonClass}`, this.rows[row]);
     }
 
     /**
@@ -249,6 +270,10 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
      *
      * @param row 0-based index of row
      * @param column 0-based index of column
+     *
+     * Because the custom renderer widget object requires getting the {@link DebugElement} of a cell,
+     * but doesn't directly extend {@link ClrDatagridWidgetObject}, this method needs to be public.
+     * This will be fixed in {@link https://jira.eng.vmware.com/browse/VDUCC-127}.
      */
     getCell(row: number, column: number): DebugElement {
         return this.findElement(`${ROW_TAG}:nth-of-type(${row + 1}) ${CELL_TAG}:nth-of-type(${column + 1})`);

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -105,6 +105,13 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Says if the datagrid is showing a placeholder.
+     */
+    get hasPlaceholder(): boolean {
+        return !!this.findElement('clr-dg-placeholder');
+    }
+
+    /**
      * Returns whether or not the column with the given index is displayed by the CSS.
      */
     isColumnDisplayed(index: number): boolean {

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -33,6 +33,26 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Gives the text content of all the cells in a row.
+     */
+    getRowValues(rowIndex: number): string[] {
+        const toReturn = [];
+        for (let columnIndex = 0; columnIndex < this.columnCount; columnIndex++) {
+            toReturn.push(this.getCellText(rowIndex, columnIndex));
+        }
+        return toReturn;
+    }
+
+    /**
+     * Gives the linked text in the given cell represented by the {@param rowIndex} and {@param columnIndex} if present.
+     */
+    getCellLink(rowIndex: number, columnIndex: number): string[] {
+        return this.getCell(rowIndex, columnIndex)
+            .nativeElement.querySelector('a')
+            .getAttribute('href');
+    }
+
+    /**
      * Retrieves if the cell will clip text
      * @param column 0-based index of column
      */
@@ -64,10 +84,24 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Returns an array of the texts for columns that are hidden.
+     */
+    get hiddenColumnHeaders(): string[] {
+        return this.getTexts('clr-dg-column.datagrid-hidden-column');
+    }
+
+    /**
      * Returns the number of rows currently displayed
      */
     get rowCount(): number {
         return this.rows.length;
+    }
+
+    /**
+     * Says if this datagrid is loading.
+     */
+    get loading(): boolean {
+        return this.component.loading;
     }
 
     /**
@@ -168,10 +202,25 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
-     * Presses the button at the given {@param index} on the top of the grid.
+     * Presses the button at the given {@param index} on the top of the grid in the given {@param group}.
      */
-    pressTopButton(index: number): void {
-        this.click(`clr-dg-action-bar button:nth-of-type(${index + 1})`);
+    pressTopButton(index: number, group: number): void {
+        this.click(`clr-dg-action-bar div:nth-of-type(${group}) button:nth-of-type(${index + 1})`);
+    }
+
+    /**
+     * Gives the text of the button at the given {@param index} in the given {@param group} on the top of the grid.
+     */
+    getTopButtonText(index: number, group: number): string {
+        return this.getText(`clr-dg-action-bar div:nth-of-type(${group}) button:nth-of-type(${index + 1})`);
+    }
+
+    /**
+     * Says if the button at the given {@param index} in the given {@param group} on the top of the grid is disabled.
+     */
+    getTopButtonDisabled(index: number, group: number): string {
+        return this.findElement(`clr-dg-action-bar div:nth-of-type(${group}) button:nth-of-type(${index + 1})`)
+            .nativeElement.disabled;
     }
 
     /**
@@ -179,6 +228,23 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
      */
     pressButtonAtRow(buttonIndex: number, rowIndex: number): void {
         this.click(`.action-button-group button:nth-of-type(${buttonIndex + 1})`, this.rows[rowIndex]);
+    }
+
+    /**
+     * Gives the text of the button at the given {@param buttonIndex} at the row at the given {@param rowIndex}.
+     */
+    getButtonAtRowText(buttonIndex: number, rowIndex: number): string {
+        return this.getText(
+            `${ROW_TAG}:nth-of-type(${rowIndex + 1}) .action-button-group button:nth-of-type(${buttonIndex + 1})`
+        );
+    }
+
+    /**
+     * Says if the button at the given {@param buttonIndex} at the row at the given {@param rowIndex} is disabled.
+     */
+    getButtonAtRowDisabled(buttonIndex: number, rowIndex: number): string {
+        return this.findElement(`${ROW_TAG}:nth-of-type(${rowIndex + 1})
+             .action-button-group button:nth-of-type(${buttonIndex + 1})`).nativeElement.disabled;
     }
 
     /**

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -202,49 +202,24 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
-     * Presses the button at the given {@param index} on the top of the grid in the given {@param group}.
+     * Gives the text of the button with the given {@param buttonClass}
      */
-    pressTopButton(index: number, group: number): void {
-        this.click(`clr-dg-action-bar div:nth-of-type(${group}) button:nth-of-type(${index + 1})`);
+    getButtonText(buttonClass: string): string {
+        return this.getText(`button.${buttonClass}`);
     }
 
     /**
-     * Gives the text of the button at the given {@param index} in the given {@param group} on the top of the grid.
+     * Says if the button with the given {@param buttonClass} is disabled.
      */
-    getTopButtonText(index: number, group: number): string {
-        return this.getText(`clr-dg-action-bar div:nth-of-type(${group}) button:nth-of-type(${index + 1})`);
+    getButtonDisabled(buttonClass: string): string {
+        return this.findElement(`button.${buttonClass}`).nativeElement.disabled;
     }
 
     /**
-     * Says if the button at the given {@param index} in the given {@param group} on the top of the grid is disabled.
+     * Presses the button with the given {@param buttonClass}.
      */
-    getTopButtonDisabled(index: number, group: number): string {
-        return this.findElement(`clr-dg-action-bar div:nth-of-type(${group}) button:nth-of-type(${index + 1})`)
-            .nativeElement.disabled;
-    }
-
-    /**
-     * Presses the button at the given {@param buttonIndex} at the row at the given {@param rowIndex}.
-     */
-    pressButtonAtRow(buttonIndex: number, rowIndex: number): void {
-        this.click(`.action-button-group button:nth-of-type(${buttonIndex + 1})`, this.rows[rowIndex]);
-    }
-
-    /**
-     * Gives the text of the button at the given {@param buttonIndex} at the row at the given {@param rowIndex}.
-     */
-    getButtonAtRowText(buttonIndex: number, rowIndex: number): string {
-        return this.getText(
-            `${ROW_TAG}:nth-of-type(${rowIndex + 1}) .action-button-group button:nth-of-type(${buttonIndex + 1})`
-        );
-    }
-
-    /**
-     * Says if the button at the given {@param buttonIndex} at the row at the given {@param rowIndex} is disabled.
-     */
-    getButtonAtRowDisabled(buttonIndex: number, rowIndex: number): string {
-        return this.findElement(`${ROW_TAG}:nth-of-type(${rowIndex + 1})
-             .action-button-group button:nth-of-type(${buttonIndex + 1})`).nativeElement.disabled;
+    pressButton(buttonClass: string): void {
+        this.click(`button.${buttonClass}`);
     }
 
     /**

--- a/projects/components/src/utils/test/index.ts
+++ b/projects/components/src/utils/test/index.ts
@@ -4,7 +4,7 @@
  */
 
 export * from './datagrid/datagrid.wo';
-// export * from './datagrid/vcd-datagrid.wo';
+export * from './datagrid/vcd-datagrid.wo';
 export * from './activity-reporter/banner-activity-reporter.wo';
 export * from './activity-reporter/spinner-activity-reporter.wo';
 export * from './widget-object';

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -48,6 +48,13 @@ export abstract class WidgetObject<T> {
     }
 
     /**
+     * Destroys the fixture of this widget object.
+     */
+    destroy(): void {
+        this.fixture.destroy();
+    }
+
+    /**
      * Finds first element within this widget matching the given selector
      * @param selector What to search for
      * @param parent Where to start the search; defaults to the root of this component
@@ -99,7 +106,7 @@ export abstract class WidgetObject<T> {
         // The || '' is because textContent could technically be null when passed in the document
         // element object. We know that cannot be pased in here, so we ignore it for coverage
         // but we still need the line there to make strictNullChecks work
-        return el.nativeElement.textContent || /* istanbul ignore next */ '';
+        return el.nativeElement.textContent.trim() || /* istanbul ignore next */ '';
     }
 }
 

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -48,13 +48,6 @@ export abstract class WidgetObject<T> {
     }
 
     /**
-     * Destroys the fixture of this widget object.
-     */
-    destroy(): void {
-        this.fixture.destroy();
-    }
-
-    /**
      * Finds first element within this widget matching the given selector
      * @param selector What to search for
      * @param parent Where to start the search; defaults to the root of this component
@@ -88,10 +81,11 @@ export abstract class WidgetObject<T> {
      * Returns text content of this widget
      * If the element cannot be found, gives empty string.
      * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.
+     * @param parent Where to start the search; defaults to the root of this component
      */
 
-    protected getText(cssSelector: string): string {
-        const element = this.findElement(cssSelector);
+    protected getText(cssSelector: string, parent: DebugElement = this.root): string {
+        const element = this.findElement(cssSelector, parent);
         return element ? this.getNodeText(element) : '';
     }
 

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
@@ -64,6 +64,7 @@ export class DatagridActivityReporterExampleComponent {
                             throw error;
                         });
                 },
+                class: 'start',
             },
         ],
         contextualButtonConfig: {

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -56,6 +56,7 @@ export class DatagridLinkExampleComponent {
                     console.log('Adding stuff!');
                 },
                 isActive: () => true,
+                class: 'add',
             },
             {
                 label: 'Delete All',
@@ -63,6 +64,7 @@ export class DatagridLinkExampleComponent {
                     console.log('Deleting stuff!');
                 },
                 isActive: () => false,
+                class: 'delete',
             },
         ],
         contextualButtonConfig: {
@@ -74,7 +76,7 @@ export class DatagridLinkExampleComponent {
                         rec[0].paused = false;
                     },
                     isActive: (rec: Data[]) => rec.length === 1 && rec[0].paused,
-                    id: 'a',
+                    class: 'a',
                     icon: 'play',
                     inactiveDisplayMode: InactiveButtonDisplayMode.Hide,
                 },
@@ -85,7 +87,7 @@ export class DatagridLinkExampleComponent {
                         rec[0].paused = true;
                     },
                     isActive: (rec: Data[]) => rec.length === 1 && !rec[0].paused,
-                    id: 'b',
+                    class: 'b',
                     icon: 'pause',
                     inactiveDisplayMode: InactiveButtonDisplayMode.Hide,
                 },
@@ -95,7 +97,7 @@ export class DatagridLinkExampleComponent {
                         console.log('Adding ' + rec[0].value);
                     },
                     isActive: (rec: Data[]) => rec.length === 1 && rec[0].value === 'a',
-                    id: 'c',
+                    class: 'c',
                     icon: 'warn',
                 },
             ],


### PR DESCRIPTION
# Description:
1. Improves the methods in the datagrid widget object for full testing capabilities.
2. Uses class and removed ID for the buttons
3. Featured + featured count defaults to all the buttons when undefined
4. Fixed the alignment of "..." in the button dropdown
5. Column visibility defaults to SHOWN

# Testing:
1. Updated the unit tests + used in VCD-UI

# Notes:
1. Switched to clrDgItems. When this is not used (and instead we use ngFor), selection in VCD-UI breaks. The code for the clrDgItems directive doesn't suggest that this directive enforces any client side sorting or filtering (https://github.com/vmware/clarity/blob/master/src/clr-angular/data/datagrid/datagrid-items.ts), but I'm not totally sure.