### PR TITLE
Examples improvements + stackblitz pre-loading

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -120,7 +120,7 @@ jobs:
                   npm run build-examples-doc
                   npm run generate-translations
                   npm run generate-example-translations
-                  npm run build:examples-prod-aot
+                  npm run build:examples-prod
 
     unit-testing:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -120,7 +120,7 @@ jobs:
                   npm run build-examples-doc
                   npm run generate-translations
                   npm run generate-example-translations
-                  npm run build:examples-prod
+                  npm run build:examples-prod-aot
 
     unit-testing:
         runs-on: ubuntu-latest

--- a/angular.json
+++ b/angular.json
@@ -120,7 +120,7 @@
               "sourceMap": false,
               "extractCss": true,
               "namedChunks": false,
-              "aot": false,
+              "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": false,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:examples": "ng build examples",
     "build:examples-prod": "ng build examples --prod=true --base-href=/vmware-cloud-director-ui-components/",
     "build:examples-aot": "ng build examples --aot=true",
+    "build:examples-prod-aot": "ng build examples --aot=true --prod=true --base-href=/vmware-cloud-director-ui-components/",
     "build:components": "ng build components",
     "postbuild:components": "npm run generate-translations; cp projects/components/src/assets/i18n.json dist/components/i18n.json",
     "build:doc-lib": "ng build doc-lib; tsc -p projects/doc-lib/scripts/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build:examples": "ng build examples",
     "build:examples-prod": "ng build examples --prod=true --base-href=/vmware-cloud-director-ui-components/",
     "build:examples-aot": "ng build examples --aot=true",
-    "build:examples-prod-aot": "ng build examples --aot=true --prod=true --base-href=/vmware-cloud-director-ui-components/",
     "build:components": "ng build components",
     "postbuild:components": "npm run generate-translations; cp projects/components/src/assets/i18n.json dist/components/i18n.json",
     "build:doc-lib": "ng build doc-lib; tsc -p projects/doc-lib/scripts/tsconfig.json",

--- a/projects/components/src/components.module.ts
+++ b/projects/components/src/components.module.ts
@@ -4,12 +4,29 @@
  */
 
 import { NgModule } from '@angular/core';
+import { ActivityReporterModule } from './common/activity-reporter/activity-reporter.module';
+import { ErrorBannerModule } from './common/error/error-banner.module';
+import { LoadingIndicatorModule } from './common/loading/loading-indicator.module';
 import { DataExporterModule } from './data-exporter/data-exporter.module';
 import { DatagridModule } from './datagrid/datagrid.module';
 import { ShowClippedTextDirectiveModule } from './lib/directives/show-clipped-text.directive.module';
 
 @NgModule({
-    imports: [DataExporterModule, DatagridModule, ShowClippedTextDirectiveModule],
-    exports: [DataExporterModule, DatagridModule, ShowClippedTextDirectiveModule],
+    imports: [
+        DataExporterModule,
+        DatagridModule,
+        ShowClippedTextDirectiveModule,
+        ErrorBannerModule,
+        LoadingIndicatorModule,
+        ActivityReporterModule,
+    ],
+    exports: [
+        DataExporterModule,
+        DatagridModule,
+        ShowClippedTextDirectiveModule,
+        ErrorBannerModule,
+        LoadingIndicatorModule,
+        ActivityReporterModule,
+    ],
 })
 export class ComponentsModule {}

--- a/projects/doc-lib/src/stack-blitz-writer.service.ts
+++ b/projects/doc-lib/src/stack-blitz-writer.service.ts
@@ -74,8 +74,7 @@ export class StackBlitzWriterService {
         @Inject(STACKBLITZ_INFO) private stackBlitzInfo: StackBlitzInfo,
         private docRetriever: DocumentationRetrieverService
     ) {
-        // Temporary until VDCUCC-75
-        // this.fetchSbTemplate();
+        this.fetchSbTemplate();
     }
 
     private template: [StackBlitzFileSystem, StackBlitzDependencies] = null;

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ActivityReporterModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { BannerActivityReporterExampleComponent } from './banner-activity-reporter.example.component';
 
 @NgModule({
     declarations: [BannerActivityReporterExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ActivityReporterModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [BannerActivityReporterExampleComponent],
     entryComponents: [BannerActivityReporterExampleComponent],
 })

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ActivityReporterModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { SpinnerActivityReporterExampleComponent } from './spinner-activity-reporter.example.component';
 
 @NgModule({
     declarations: [SpinnerActivityReporterExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ActivityReporterModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [SpinnerActivityReporterExampleComponent],
     entryComponents: [SpinnerActivityReporterExampleComponent],
 })

--- a/projects/examples/src/components/data-exporter/data-exporter.example.module.ts
+++ b/projects/examples/src/components/data-exporter/data-exporter.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DataExporterModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DataExporterExampleComponent } from './data-exporter.example.component';
 
 @NgModule({
     declarations: [DataExporterExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DataExporterModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DataExporterExampleComponent],
     entryComponents: [DataExporterExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.html
@@ -1,5 +1,5 @@
 <button *ngIf="started" (click)="this.reject('Woah there!')">Throw Error</button>
-<button *ngIf="started" (click)="this.resolve('Good!')">Sucess</button>
+<button *ngIf="started" (click)="this.resolve()">Sucess</button>
 <vcd-datagrid
     [gridData]="gridData"
     (gridRefresh)="refresh($event)"

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
@@ -40,7 +40,7 @@ export class DatagridActivityReporterExampleComponent {
     ];
 
     resolve: () => void;
-    reject: (error: Error) => void;
+    reject: (error: string) => void;
     started = false;
     indicatorType = ActivityIndicatorType.BANNER;
 

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';
 
 @NgModule({
     declarations: [DatagridActivityReporterExampleComponent],
-    imports: [CommonModule, ClarityModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ComponentsModule],
     exports: [DatagridActivityReporterExampleComponent],
     entryComponents: [DatagridActivityReporterExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-cliptext.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-cliptext.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridCliptextExampleComponent } from './datagrid-cliptext.example.component';
 
 @NgModule({
     declarations: [DatagridCliptextExampleComponent],
-    imports: [CommonModule, ClarityModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ComponentsModule],
     exports: [DatagridCliptextExampleComponent],
     entryComponents: [DatagridCliptextExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-css-classes.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-css-classes.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridCssClassesExampleComponent } from './datagrid-css-classes.example.component';
 
 @NgModule({
     declarations: [DatagridCssClassesExampleComponent],
-    imports: [CommonModule, ClarityModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ComponentsModule],
     exports: [DatagridCssClassesExampleComponent],
     entryComponents: [DatagridCssClassesExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 
 @NgModule({
     declarations: [DatagridDetailRowExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DatagridDetailRowExampleComponent],
     entryComponents: [DatagridDetailRowExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-filter.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-filter.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
 
 @NgModule({
     declarations: [DatagridFilterExampleComponent],
-    imports: [CommonModule, ClarityModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ComponentsModule],
     exports: [DatagridFilterExampleComponent],
     entryComponents: [DatagridFilterExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-header.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-header.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
 
 @NgModule({
     declarations: [DatagridHeaderExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DatagridHeaderExampleComponent],
     entryComponents: [DatagridHeaderExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-height.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
 
 @NgModule({
     declarations: [DatagridHeightExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DatagridHeightExampleComponent],
     entryComponents: [DatagridHeightExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-link.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
 
 @NgModule({
     declarations: [DatagridLinkExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DatagridLinkExampleComponent],
     entryComponents: [DatagridLinkExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-pagination-example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-pagination-example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
 
 @NgModule({
     declarations: [DatagridPaginationExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DatagridPaginationExampleComponent],
     entryComponents: [DatagridPaginationExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-row-icon.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-icon.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridRowIconExampleComponent, RowIconRendererComponent } from './datagrid-row-icon.example.component';
 
 @NgModule({
     declarations: [DatagridRowIconExampleComponent, RowIconRendererComponent],
-    imports: [CommonModule, ClarityModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ComponentsModule],
     exports: [DatagridRowIconExampleComponent],
     entryComponents: [DatagridRowIconExampleComponent, RowIconRendererComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-row-select.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-select.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
 
 @NgModule({
     declarations: [DatagridRowSelectExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DatagridRowSelectExampleComponent],
     entryComponents: [DatagridRowSelectExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-show-hide.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-show-hide.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridShowHideExampleComponent } from './datagrid-show-hide.example.component';
 
 @NgModule({
     declarations: [DatagridShowHideExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DatagridShowHideExampleComponent],
     entryComponents: [DatagridShowHideExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-sort.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-sort.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
 
 @NgModule({
     declarations: [DatagridSortExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [DatagridSortExampleComponent],
     entryComponents: [DatagridSortExampleComponent],
 })

--- a/projects/examples/src/components/error/error-banner.example.module.ts
+++ b/projects/examples/src/components/error/error-banner.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ErrorBannerModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { ErrorBannerExampleComponent } from './error-banner.example.component';
 
 @NgModule({
     declarations: [ErrorBannerExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ErrorBannerModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [ErrorBannerExampleComponent],
     entryComponents: [ErrorBannerExampleComponent],
 })

--- a/projects/examples/src/components/loading/loading-indicator.example.module.ts
+++ b/projects/examples/src/components/loading/loading-indicator.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { LoadingIndicatorModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import { LoadingIndicatorExampleComponent } from './loading-indicator.example.component';
 
 @NgModule({
     declarations: [LoadingIndicatorExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, LoadingIndicatorModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [LoadingIndicatorExampleComponent],
     entryComponents: [LoadingIndicatorExampleComponent],
 })

--- a/projects/examples/src/components/subscription/subscription-tracker-mixin.example.module.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker-mixin.example.module.ts
@@ -7,7 +7,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { DatagridModule } from '@vcd/ui-components';
+import { ComponentsModule } from '@vcd/ui-components';
 import {
     SubscriptionTrackerMixinExampleComponent,
     SubscriptionTrackerMixinExampleSubComponent,
@@ -15,7 +15,7 @@ import {
 
 @NgModule({
     declarations: [SubscriptionTrackerMixinExampleComponent, SubscriptionTrackerMixinExampleSubComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, DatagridModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
     exports: [SubscriptionTrackerMixinExampleComponent],
     entryComponents: [SubscriptionTrackerMixinExampleComponent],
 })

--- a/projects/i18n/package.json
+++ b/projects/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/i18n",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "peerDependencies": {
     "@angular/common": ">6.0.0",
     "@angular/core": ">6.0.0"


### PR DESCRIPTION
# Description:

Updates the examples application to import only the ComponentsModule rather than the individual modules. Also, makes it so the Stackblitz writer service pre-loads the template. 

# Testing

Ran the unit tests + made sure the examples app was still functional. 

Signed-off-by: Ryan Bradford <rbradford@vmware.com>