### PR TITLE
Removed BOOTSTRAP_DETAILS

### DIFF
--- a/projects/examples/src/main.ts
+++ b/projects/examples/src/main.ts
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { enableProdMode } from '@angular/core';
+import { enableProdMode, LOCALE_ID } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-import { BOOTSTRAP_DETAILS } from '@vcd/i18n';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
@@ -16,10 +15,8 @@ if (environment.production) {
 
 platformBrowserDynamic([
     {
-        provide: BOOTSTRAP_DETAILS,
-        useValue: {
-            locale: 'en',
-        },
+        provide: LOCALE_ID,
+        useValue: 'en',
     },
 ])
     .bootstrapModule(AppModule)

--- a/projects/i18n/package.json
+++ b/projects/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/i18n",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "peerDependencies": {
     "@angular/common": ">6.0.0",
     "@angular/core": ">6.0.0"

--- a/projects/i18n/src/lib/i18n.module.spec.ts
+++ b/projects/i18n/src/lib/i18n.module.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { Component, InjectionToken } from '@angular/core';
+import { Component, InjectionToken, LOCALE_ID } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -13,7 +13,6 @@ import { I18nModule } from './i18n.module';
 import { MessageFormatTranslationService } from './service/message-format-translation-service';
 import { TranslationService } from './service/translation-service';
 import { CanTranslate } from './service/translation-service.mixin';
-import { BOOTSTRAP_DETAILS } from './utils/tokens';
 
 describe('I18nModule', () => {
     it('translates correctly with forRoot', fakeAsync(async () => {
@@ -21,8 +20,8 @@ describe('I18nModule', () => {
             imports: [I18nModule.forRoot(), BrowserAnimationsModule],
             providers: [
                 {
-                    provide: BOOTSTRAP_DETAILS,
-                    useValue: { locale: 'en' },
+                    provide: LOCALE_ID,
+                    useValue: 'en',
                 },
             ],
             declarations: [TestClassComponent],
@@ -47,8 +46,8 @@ describe('I18nModule', () => {
             imports: [I18nModule.forChild(route, true), BrowserAnimationsModule, HttpClientTestingModule],
             providers: [
                 {
-                    provide: BOOTSTRAP_DETAILS,
-                    useValue: { locale: 'en' },
+                    provide: LOCALE_ID,
+                    useValue: 'en',
                 },
                 {
                     provide: route,

--- a/projects/i18n/src/lib/i18n.module.ts
+++ b/projects/i18n/src/lib/i18n.module.ts
@@ -4,7 +4,7 @@
  */
 
 import { HttpClient } from '@angular/common/http';
-import { ModuleWithProviders, Optional } from '@angular/core';
+import { LOCALE_ID, ModuleWithProviders, Optional } from '@angular/core';
 import { Inject, InjectionToken, NgModule } from '@angular/core';
 import { TranslationLoader } from './loader/translation-loader';
 import { FormatDateTimePipe } from './pipe/format-date-time-pipe';
@@ -12,7 +12,6 @@ import { LazyStringPipe } from './pipe/lazy-string.pipe';
 import { TranslationPipe } from './pipe/translation-pipe';
 import { MessageFormatTranslationService } from './service/message-format-translation-service';
 import { TranslationService } from './service/translation-service';
-import { BOOTSTRAP_DETAILS } from './utils/tokens';
 
 let singletonService: TranslationService = null;
 
@@ -27,11 +26,8 @@ export function genericSingletonFactory(details: { locale: string }): Translatio
  * An implementation of {@link TranslationService} that can inject all of its dependencies.
  */
 export class InjectedTranslationService extends MessageFormatTranslationService {
-    constructor(
-        @Inject(BOOTSTRAP_DETAILS) details: { locale: string },
-        @Inject(TranslationLoader) @Optional() loader: TranslationLoader
-    ) {
-        super(details.locale, 'en', loader, false);
+    constructor(@Inject(LOCALE_ID) locale: string, @Inject(TranslationLoader) @Optional() loader: TranslationLoader) {
+        super(locale, 'en', loader, false);
     }
 }
 /**
@@ -39,11 +35,8 @@ export class InjectedTranslationService extends MessageFormatTranslationService 
  * and has combined set to true.
  */
 export class CombinedInjectedTranslationService extends MessageFormatTranslationService {
-    constructor(
-        @Inject(BOOTSTRAP_DETAILS) details: { locale: string },
-        @Inject(TranslationLoader) @Optional() loader: TranslationLoader
-    ) {
-        super(details.locale, 'en', loader, true);
+    constructor(@Inject(LOCALE_ID) locale: string, @Inject(TranslationLoader) @Optional() loader: TranslationLoader) {
+        super(locale, 'en', loader, true);
     }
 }
 
@@ -67,7 +60,7 @@ export class I18nModule {
                 {
                     provide: TranslationService,
                     useFactory: genericSingletonFactory,
-                    deps: [BOOTSTRAP_DETAILS],
+                    deps: [LOCALE_ID],
                 },
             ],
         };

--- a/projects/i18n/src/lib/utils/index.ts
+++ b/projects/i18n/src/lib/utils/index.ts
@@ -4,4 +4,3 @@
  */
 
 export * from './platform-util';
-export * from './tokens';

--- a/projects/i18n/src/lib/utils/tokens.ts
+++ b/projects/i18n/src/lib/utils/tokens.ts
@@ -1,8 +1,0 @@
-/*!
- * Copyright 2020 VMware, Inc.
- * SPDX-License-Identifier: BSD-2-Clause
- */
-
-import { InjectionToken } from '@angular/core';
-
-export const BOOTSTRAP_DETAILS = new InjectionToken('BOOTSTRAP_DETAILS');


### PR DESCRIPTION
# Description

Removed the BOOTSTRAP_DETAILS injection token and instead uses LOCALE_ID provided by Angular.

# Testing

1. Updated the examples app to use LOCALE_ID and made sure it functions in both dev and prod modes. 
2. Updated VCD_UI to use LOCALE_ID and made sure it still functions. 
3. Did a search, and there are no references to BOOTSTRAP_DETAILS in our project anymore.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>