### PR TITLE
Fixed the subscription tracker mixin

### DIFF
--- a/projects/components/src/common/subscription/subscription-tracker.mixin.spec.ts
+++ b/projects/components/src/common/subscription/subscription-tracker.mixin.spec.ts
@@ -6,9 +6,12 @@
 import createSpy = jasmine.createSpy;
 import { Subject } from 'rxjs';
 import { SubscriptionTrackerMixin } from './subscription-tracker.mixin';
+import { OnDestroy } from '@angular/core';
 
 describe('SubscriptionTrackerMixin', () => {
-    class SubscribeObject extends SubscriptionTrackerMixin(class {}) {}
+    class SubscribeObject extends SubscriptionTrackerMixin(class {}) implements OnDestroy {
+        ngOnDestroy(): void {}
+    }
 
     describe('subscribing', () => {
         it('adds a subscription', () => {

--- a/projects/components/src/common/subscription/subscription-tracker.mixin.ts
+++ b/projects/components/src/common/subscription/subscription-tracker.mixin.ts
@@ -15,7 +15,7 @@ import { ISubscriptionTracker, SubscriptionTracker } from './subscription-tracke
  */
 // tslint:disable-next-line: typedef
 export function SubscriptionTrackerMixin<TBase extends Type<{}>>(Base: TBase) {
-    return class extends Base implements ISubscriptionTracker, OnDestroy {
+    abstract class Mixin extends Base implements ISubscriptionTracker, OnDestroy {
         tracker = new SubscriptionTracker(this);
 
         public subscribe<T>(
@@ -35,8 +35,7 @@ export function SubscriptionTrackerMixin<TBase extends Type<{}>>(Base: TBase) {
             this.tracker.unsubscribeAll();
         }
 
-        ngOnDestroy(): void {
-            this.unsubscribeAll();
-        }
-    };
+        abstract ngOnDestroy(): void;
+    }
+    return Mixin;
 }

--- a/projects/components/src/datagrid/filters/datagrid-filter.ts
+++ b/projects/components/src/datagrid/filters/datagrid-filter.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Input, OnInit } from '@angular/core';
+import { Input, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ClrDatagridFilter } from '@clr/angular';
 import { ClrDatagridFilterInterface } from '@clr/angular/data/datagrid/interfaces/filter.interface';
@@ -55,7 +55,7 @@ export interface FilterRendererSpec<C> extends ComponentRendererSpec<C> {
  * C extends FilterConfig<V> is configuration of a filter that contains queryField and a value of type V
  */
 export abstract class DatagridFilter<V, C extends FilterConfig<V>> extends SubscriptionTrackerMixin(class {})
-    implements OnInit, ClrDatagridFilterInterface<V>, ComponentRenderer<C> {
+    implements OnInit, OnDestroy, ClrDatagridFilterInterface<V>, ComponentRenderer<C> {
     formGroup = this.createFormGroup();
 
     protected constructor(filterContainer: ClrDatagridFilter) {
@@ -92,6 +92,8 @@ export abstract class DatagridFilter<V, C extends FilterConfig<V>> extends Subsc
             : this.formGroup.valueChanges;
         this.subscribe(obs, () => this.changes.next());
     }
+
+    ngOnDestroy(): void {}
 
     /**
      * To override the default delay time for emission of changes

--- a/projects/examples/src/components/subscription/subscription-tracker-mixin.example.component.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker-mixin.example.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { SubscriptionTrackerMixin } from '@vcd/ui-components';
 import { BehaviorSubject, Observable } from 'rxjs';
 
@@ -18,13 +18,16 @@ import { BehaviorSubject, Observable } from 'rxjs';
 })
 // Use an empty class as its base class instead of Object to support IE11
 // See https://github.com/microsoft/TypeScript/issues/37601
-export class SubscriptionTrackerMixinExampleSubComponent extends SubscriptionTrackerMixin(class {}) implements OnInit {
+export class SubscriptionTrackerMixinExampleSubComponent extends SubscriptionTrackerMixin(class {})
+    implements OnInit, OnDestroy {
     @Input()
     observable: Observable<number>;
 
     ngOnInit(): void {
         this.subscribe(this.observable, value => console.log(value));
     }
+
+    ngOnDestroy(): void {}
 }
 
 /**


### PR DESCRIPTION
# Description

Updates the subscription tracker mixin to be abstract and require a ngOnDestroy method. Also, changes the subscription tracker mixin example to have an empty implementation of ngOnDestroy.

# Testing

Ran the examples app in prod mode and made sure the mixin worked. 

# Future Work

https://jira.eng.vmware.com/browse/VDUCC-140

Signed-off-by: Ryan Bradford <rbradford@vmware.com>