### PR TITLE
Fix Component Name, Rework Activity Reporter, Rename Modules

### DIFF
--- a/projects/components/src/common/activity-reporter/activity-promise-resolver.ts
+++ b/projects/components/src/common/activity-reporter/activity-promise-resolver.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/**
+ * The response that was given with some resource.
+ */
+export interface ActivityResponse {
+    /**
+     * The error message, if any, from the activity.
+     *
+     * A response without an error is assumed to have succeeded.
+     */
+    error?: string;
+    /**
+     * The response message, if any, from the activity.
+     */
+    success?: string;
+}
+
+/**
+ * A combination of some object and the response that gave that object.
+ */
+export interface ObjectAndResponse<T> {
+    /**
+     * The data that was returned from a given activity, if any.
+     */
+    object?: T;
+    /**
+     * The response that an activity returned.
+     */
+    response: ActivityResponse;
+}
+
+/**
+ * A class that understands how to take a promise and turn it into some response message for display.
+ * A client of this library will override {@link ActivityPromiseResolver} to process their specific type of promise.
+ * This override will know how to generate a {@link ObjectAndResponse} from the type of promise it processes.
+ *
+ * @param T The type that is returned from a promise that this resolver processes.
+ */
+export class ActivityPromiseResolver<T> {
+    /**
+     * Takes a Promise and turns it to some activity status
+     * @param activityResolutionPromise The activity that this resolver will generate a response from. It generates
+     * either a sucesss or a failure condition.
+     * @param successMessage The success message this method should return if the activity succeeds. If undefined is passed,
+     * a succeeded promise will return an empty response parameter which is assumed to mean success.
+     */
+    resolveActivity(activityResolutionPromise: Promise<T>, successMessage?: string): Promise<ObjectAndResponse<T>> {
+        return activityResolutionPromise
+            .then(result => {
+                return {
+                    object: result,
+                    response: { ...result, success: successMessage || result },
+                };
+            })
+            .catch(error => {
+                return { response: { error } };
+            });
+    }
+
+    /**
+     * Takes a Promise of many items and turns it to some activity status
+     * @param activityResolutionPromise The activity that this resolver will generate a response from. It generates
+     * either a sucesss or a failure condition. There are many entities contained in this response.
+     * @param successMessage The success message this method should return if the activity succeeds. If undefined is passed,
+     * a succeeded promise will return an empty response parameter which is assumed to mean success.
+     */
+    resolveActivities(
+        activityResolutionPromises: Promise<T[]>,
+        successMessage?: string
+    ): Promise<(ObjectAndResponse<T>)[]> {
+        return activityResolutionPromises
+            .then(result => {
+                return [
+                    {
+                        object: result[0],
+                        response: { ...result, success: successMessage },
+                    },
+                ];
+            })
+            .catch(error => {
+                return [{ response: { error } }];
+            });
+    }
+}

--- a/projects/components/src/common/activity-reporter/activity-reporter.module.ts
+++ b/projects/components/src/common/activity-reporter/activity-reporter.module.ts
@@ -7,15 +7,15 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
-import { ErrorBannerModule } from '../error/error-banner.module';
-import { LoadingIndicatorModule } from '../loading/loading-indicator.module';
+import { VcdErrorBannerModule } from '../error/error-banner.module';
+import { VcdLoadingIndicatorModule } from '../loading/loading-indicator.module';
 import { BannerActivityReporterComponent } from './banner-activity-reporter.component';
 import { SpinnerActivityReporterComponent } from './spinner-activity-reporter.component';
 
 @NgModule({
     declarations: [BannerActivityReporterComponent, SpinnerActivityReporterComponent],
-    imports: [CommonModule, ClarityModule, I18nModule, ErrorBannerModule, LoadingIndicatorModule],
+    imports: [CommonModule, ClarityModule, I18nModule, VcdErrorBannerModule, VcdLoadingIndicatorModule],
     exports: [BannerActivityReporterComponent, SpinnerActivityReporterComponent],
     entryComponents: [BannerActivityReporterComponent, SpinnerActivityReporterComponent],
 })
-export class ActivityReporterModule {}
+export class VcdActivityReporterModule {}

--- a/projects/components/src/common/activity-reporter/activity-reporter.ts
+++ b/projects/components/src/common/activity-reporter/activity-reporter.ts
@@ -3,57 +3,82 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-type Response = string | undefined;
+import { ActivityPromiseResolver } from './activity-promise-resolver';
 
 /**
  * Expresses the contract between a activity status and the UI displaying a loading message, reporting
  * success or errors
  * Currently, only one concurrent activity is supported.
- *
- * This classs should be abstract, but becuase mixins currently cannot use abstract classes, we chose
- * to make this class concrete.
  */
-export class ActivityReporter {
+export abstract class ActivityReporter {
+    /**
+     * Creates this reporter with the performer that it will use to monitor events.
+     */
+    constructor(private promiseResolver: ActivityPromiseResolver<unknown>) {}
+    /*
+     * Override this method to provide custom error activity starting behavior.
+     */
+    abstract startActivity(): void;
     /**
      * Override this method to provide custom error reporting behavior.
      *
-     * N.B. this should not be called from outside a subclass of {@link ActivityReporter}
-     *
      *  @param errorText The text to display in the error alert.
      */
-    reportError(errorText: string): void {}
-
+    abstract reportError(errorText: string): void;
     /**
      * Override this method to provide custom success reporting behavior.
      *
-     * N.B. this should not be called from outside a subclass of {@link ActivityReporter}
-     *
      * @param successMessage A message to display to the user.
      */
-    reportSuccess(successMessage?: string): void {}
-
-    /*
-     * Override this method to provide custom error activity starting behavior.
-     *
-     * N.B. this should not be called from outside a subclass of {@link ActivityReporter}
-     */
-    startActivity(): void {}
+    abstract reportSuccess(successMessage: string): void;
 
     /**
-     * Monitors an activity passed as a Promise
-     * @param activityResolutionPromise Observable of the task representation
-     * don't need a special finish indicator because other parts of the UI get updated
+     * Monitors a promise that returns an entity using {@link ActivityPromiseResolver.monitorActivity}.
      */
-    monitorActivity(activityResolutionPromise: Promise<Response>): Promise<Response> {
+    async monitorGet<T>(activityResolutionPromise: Promise<T>): Promise<T> {
         this.startActivity();
-        return activityResolutionPromise
-            .then(activityResolution => {
-                this.reportSuccess(activityResolution);
-                return activityResolution;
-            })
-            .catch(error => {
-                this.reportError(error);
-                return error;
-            });
+        const performer = this.promiseResolver as ActivityPromiseResolver<T>;
+        const response = await performer.resolveActivity(activityResolutionPromise);
+        if (response.response.error) {
+            this.reportError(response.response.error);
+        } else {
+            this.reportSuccess(response.response.success);
+        }
+        return response.object;
+    }
+
+    /**
+     * Monitors a promise that returns many entities using {@link ActivityPromiseResolver.monitorActivities}.
+     */
+    async monitorGetAll<T>(activityResolutionPromises: Promise<T[]>): Promise<T[]> {
+        this.startActivity();
+        const performer = this.promiseResolver as ActivityPromiseResolver<T>;
+        const response = await performer.resolveActivities(activityResolutionPromises);
+        const returnValue = response.map(item => item.object);
+        if (response.length) {
+            for (const item of response) {
+                if (item.response.error) {
+                    this.reportError(item.response.error);
+                    return returnValue;
+                }
+            }
+            this.reportSuccess(response[0].response.success);
+        }
+        return returnValue;
+    }
+
+    /**
+     * Monitors a promise that returns an entity and posts a successMessage using {@link ActivityPromiseResolver.monitorActivity}.
+     */
+    async monitorEdit<T>(activityResolutionPromise: Promise<T>, successMessage?: string): Promise<T> {
+        this.startActivity();
+        const performer = this.promiseResolver as ActivityPromiseResolver<T>;
+        const response = await performer.resolveActivity(activityResolutionPromise, successMessage);
+        if (response.response.error) {
+            this.reportError(response.response.error);
+        } else {
+            this.reportSuccess(response.response.success);
+        }
+        return response.object;
     }
 }

--- a/projects/components/src/common/activity-reporter/banner-activity-reporter.component.ts
+++ b/projects/components/src/common/activity-reporter/banner-activity-reporter.component.ts
@@ -5,14 +5,14 @@
 
 import { Component, Inject, Input } from '@angular/core';
 import { TranslationService } from '@vcd/i18n';
-import { LazyString } from '@vcd/i18n';
+import { ActivityPromiseResolver } from './activity-promise-resolver';
 import { ActivityReporter } from './activity-reporter';
 
 /**
  * Shows a banner to the user to represent the state of an activity.
  */
 @Component({
-    selector: 'vcd-temp-banner-activity-reporter',
+    selector: 'vcd-banner-activity-reporter',
     templateUrl: './banner-activity-reporter.component.html',
 })
 export class BannerActivityReporterComponent extends ActivityReporter {
@@ -26,8 +26,11 @@ export class BannerActivityReporterComponent extends ActivityReporter {
     @Input()
     loadingMessage = this.translationService.translateAsync('vcd.cc.loading');
 
-    constructor(private translationService: TranslationService) {
-        super();
+    constructor(
+        private translationService: TranslationService,
+        @Inject(ActivityPromiseResolver) promiseResolver: ActivityPromiseResolver<any>
+    ) {
+        super(promiseResolver);
     }
 
     /**

--- a/projects/components/src/common/activity-reporter/banner-activity-reporter.spec.ts
+++ b/projects/components/src/common/activity-reporter/banner-activity-reporter.spec.ts
@@ -8,12 +8,13 @@ import { TestBed } from '@angular/core/testing';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import { BannerActivityReporterWidgetObject } from '../../utils/test/activity-reporter/banner-activity-reporter.wo';
 import { WidgetFinder } from '../../utils/test/widget-object';
-import { ActivityReporterModule } from './activity-reporter.module';
+import { ActivityPromiseResolver } from './activity-promise-resolver';
+import { VcdActivityReporterModule } from './activity-reporter.module';
 import { BannerActivityReporterComponent } from './banner-activity-reporter.component';
 
 @Component({
     template: `
-        <vcd-temp-banner-activity-reporter [loadingMessage]="loadingMessage"></vcd-temp-banner-activity-reporter>
+        <vcd-banner-activity-reporter [loadingMessage]="loadingMessage"></vcd-banner-activity-reporter>
     `,
 })
 class TestBannerComponent {
@@ -36,13 +37,14 @@ interface HasFinderAndBanner {
 describe('BannerActivityReporterComponent', () => {
     beforeEach(async function(this: HasFinderAndBanner): Promise<void> {
         await TestBed.configureTestingModule({
-            imports: [ActivityReporterModule],
+            imports: [VcdActivityReporterModule],
             declarations: [TestBannerComponent],
             providers: [
                 {
                     provide: TranslationService,
                     useValue: new MockTranslationService(),
                 },
+                ActivityPromiseResolver,
             ],
         }).compileComponents();
 
@@ -57,7 +59,7 @@ describe('BannerActivityReporterComponent', () => {
 
     it('displays a custom message while the promise is pending', function(this: HasFinderAndBanner): Promise<string> {
         this.finder.hostComponent.loadingMessage = 'loader';
-        const promise = this.banner.component.monitorActivity(this.promise);
+        const promise = this.banner.component.monitorGet(this.promise);
         this.finder.detectChanges();
         expect(this.banner.running).toBeTruthy();
         expect(this.banner.loadingText).toEqual('loader'); // Because of mock translation service
@@ -68,7 +70,7 @@ describe('BannerActivityReporterComponent', () => {
     it('removes the activity reporter from the screen after the promise resolves', function(this: HasFinderAndBanner): Promise<
         void
     > {
-        const promise = this.banner.component.monitorActivity(this.promise).then(() => {
+        const promise = this.banner.component.monitorGet(this.promise).then(() => {
             expect(this.banner.running).toBeFalsy();
             expect(this.banner.sucessText).toEqual('winning!');
             this.banner.component.onSuccessClosed();
@@ -82,7 +84,7 @@ describe('BannerActivityReporterComponent', () => {
     });
 
     it('displays an error on the screen if the promise is rejected', function(this: HasFinderAndBanner): Promise<void> {
-        const promise = this.banner.component.monitorActivity(this.promise).then(() => {
+        const promise = this.banner.component.monitorGet(this.promise).then(() => {
             expect(this.banner.running).toBeFalsy();
             expect(this.banner.errorText).toEqual('Bad!');
             this.banner.component.onErrorClosed();
@@ -98,7 +100,7 @@ describe('BannerActivityReporterComponent', () => {
     });
 
     it('clears all content when reset', function(this: HasFinderAndBanner): Promise<string> {
-        const promise = this.banner.component.monitorActivity(this.promise);
+        const promise = this.banner.component.monitorGet(this.promise);
         this.finder.detectChanges();
         expect(this.banner.running).toBeTruthy();
         this.banner.component.reset();

--- a/projects/components/src/common/activity-reporter/index.ts
+++ b/projects/components/src/common/activity-reporter/index.ts
@@ -5,5 +5,6 @@
 
 export * from './activity-reporter.module';
 export * from './activity-reporter';
+export * from './activity-promise-resolver';
 export * from './banner-activity-reporter.component';
 export * from './spinner-activity-reporter.component';

--- a/projects/components/src/common/activity-reporter/spinner-activity-reporter.component.html
+++ b/projects/components/src/common/activity-reporter/spinner-activity-reporter.component.html
@@ -1,2 +1,2 @@
-<vcd-temp-error-banner *ngIf="errorText" [(errorMessage)]="errorText"></vcd-temp-error-banner>
-<vcd-temp-loading-indicator [isLoading]="running"></vcd-temp-loading-indicator>
+<vcd-error-banner *ngIf="errorText" [(errorMessage)]="errorText"></vcd-error-banner>
+<vcd-loading-indicator [isLoading]="running"></vcd-loading-indicator>

--- a/projects/components/src/common/activity-reporter/spinner-activity-reporter.component.ts
+++ b/projects/components/src/common/activity-reporter/spinner-activity-reporter.component.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { ActivityPromiseResolver } from './activity-promise-resolver';
 import { ActivityReporter } from './activity-reporter';
 
 /**
@@ -11,7 +12,7 @@ import { ActivityReporter } from './activity-reporter';
  * An error message is displayed through the error banner.
  */
 @Component({
-    selector: 'vcd-temp-spinner-activity-reporter',
+    selector: 'vcd-spinner-activity-reporter',
     templateUrl: './spinner-activity-reporter.component.html',
 })
 export class SpinnerActivityReporterComponent extends ActivityReporter {
@@ -25,8 +26,8 @@ export class SpinnerActivityReporterComponent extends ActivityReporter {
      */
     public errorText: string = null;
 
-    constructor() {
-        super();
+    constructor(@Inject(ActivityPromiseResolver) promiseResolver: ActivityPromiseResolver<any>) {
+        super(promiseResolver);
     }
 
     /**

--- a/projects/components/src/common/activity-reporter/spinner-activity-reporter.spec.ts
+++ b/projects/components/src/common/activity-reporter/spinner-activity-reporter.spec.ts
@@ -7,12 +7,13 @@ import { Component, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { SpinnerActivityReporterWidgetObject } from '../../utils/test/activity-reporter/spinner-activity-reporter.wo';
 import { WidgetFinder } from '../../utils/test/widget-object';
-import { ActivityReporterModule } from './activity-reporter.module';
+import { ActivityPromiseResolver } from './activity-promise-resolver';
+import { VcdActivityReporterModule } from './activity-reporter.module';
 import { SpinnerActivityReporterComponent } from './spinner-activity-reporter.component';
 
 @Component({
     template: `
-        <vcd-temp-spinner-activity-reporter #activityReporter></vcd-temp-spinner-activity-reporter>
+        <vcd-spinner-activity-reporter #activityReporter></vcd-spinner-activity-reporter>
     `,
 })
 class TestSpinnerComponent {
@@ -34,8 +35,9 @@ interface HasFinderAndSpinner {
 describe('SpinnerActivityReporterComponent', () => {
     beforeEach(async function(this: HasFinderAndSpinner): Promise<void> {
         await TestBed.configureTestingModule({
-            imports: [ActivityReporterModule],
+            imports: [VcdActivityReporterModule],
             declarations: [TestSpinnerComponent],
+            providers: [ActivityPromiseResolver],
         }).compileComponents();
 
         this.finder = new WidgetFinder(TestSpinnerComponent);
@@ -48,7 +50,7 @@ describe('SpinnerActivityReporterComponent', () => {
     });
 
     it('displays the spinner while the promise is pending', function(this: HasFinderAndSpinner): Promise<string> {
-        const promise = this.spinner.component.monitorActivity(this.promise);
+        const promise = this.spinner.component.monitorGet(this.promise);
         this.finder.detectChanges();
         expect(this.spinner.isSpinnerSpinning()).toBeTruthy();
         this.resolve('wow!');
@@ -58,7 +60,7 @@ describe('SpinnerActivityReporterComponent', () => {
     it('removes the activity reporter from the screen after the promise resolves', function(this: HasFinderAndSpinner): Promise<
         void
     > {
-        const promise = this.spinner.component.monitorActivity(this.promise).then(() => {
+        const promise = this.spinner.component.monitorGet(this.promise).then(() => {
             this.finder.detectChanges();
             expect(this.spinner.running).toBeFalsy();
             expect(this.spinner.isSpinnerSpinning()).toBeFalsy();
@@ -72,7 +74,7 @@ describe('SpinnerActivityReporterComponent', () => {
     it('displays an error on the screen if the promise is rejected', function(this: HasFinderAndSpinner): Promise<
         void
     > {
-        const promise = this.spinner.component.monitorActivity(this.promise).then(() => {
+        const promise = this.spinner.component.monitorGet(this.promise).then(() => {
             expect(this.spinner.running).toBeFalsy();
             expect(this.spinner.errorText).toEqual('Woah there!');
         });

--- a/projects/components/src/common/error/error-banner.component.spec.ts
+++ b/projects/components/src/common/error/error-banner.component.spec.ts
@@ -7,11 +7,11 @@ import { Component, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { WidgetFinder } from '../../utils/test/widget-object';
 import { ErrorBannerComponent } from './error-banner.component';
-import { ErrorBannerModule } from './error-banner.module';
+import { VcdErrorBannerModule } from './error-banner.module';
 
 @Component({
     template: `
-        <vcd-temp-error-banner #banner [errorMessage]="message"></vcd-temp-error-banner>
+        <vcd-error-banner #banner [errorMessage]="message"></vcd-error-banner>
     `,
 })
 class TestErrorComponent {
@@ -26,7 +26,7 @@ interface HasFinderAndError {
 describe('ErrorBannerComponent', () => {
     beforeEach(async function(this: HasFinderAndError): Promise<void> {
         await TestBed.configureTestingModule({
-            imports: [ErrorBannerModule],
+            imports: [VcdErrorBannerModule],
             declarations: [TestErrorComponent],
         }).compileComponents();
 

--- a/projects/components/src/common/error/error-banner.component.ts
+++ b/projects/components/src/common/error/error-banner.component.ts
@@ -9,7 +9,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
  * Component that displays the error message only if a non empty errorMessage is passed in
  */
 @Component({
-    selector: 'vcd-temp-error-banner',
+    selector: 'vcd-error-banner',
     templateUrl: './error-banner.component.html',
     styleUrls: ['./error-banner.component.scss'],
 })

--- a/projects/components/src/common/error/error-banner.module.ts
+++ b/projects/components/src/common/error/error-banner.module.ts
@@ -15,4 +15,4 @@ import { ErrorBannerComponent } from './error-banner.component';
     exports: [ErrorBannerComponent],
     entryComponents: [ErrorBannerComponent],
 })
-export class ErrorBannerModule {}
+export class VcdErrorBannerModule {}

--- a/projects/components/src/common/loading/loading-indicator.component.spec.ts
+++ b/projects/components/src/common/loading/loading-indicator.component.spec.ts
@@ -7,11 +7,11 @@ import { Component, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { WidgetFinder } from '../../utils/test/widget-object';
 import { LoadingIndicatorComponent } from './loading-indicator.component';
-import { LoadingIndicatorModule } from './loading-indicator.module';
+import { VcdLoadingIndicatorModule } from './loading-indicator.module';
 
 @Component({
     template: `
-        <vcd-temp-loading-indicator #loading [isLoading]="loadingVal" [size]="size"></vcd-temp-loading-indicator>
+        <vcd-loading-indicator #loading [isLoading]="loadingVal" [size]="size"></vcd-loading-indicator>
     `,
 })
 class TestErrorComponent {
@@ -27,7 +27,7 @@ interface HasFinderAndLoading {
 describe('LoadingIndicatorReporterComponent', () => {
     beforeEach(async function(this: HasFinderAndLoading): Promise<void> {
         await TestBed.configureTestingModule({
-            imports: [LoadingIndicatorModule],
+            imports: [VcdLoadingIndicatorModule],
             declarations: [TestErrorComponent],
         }).compileComponents();
 

--- a/projects/components/src/common/loading/loading-indicator.component.ts
+++ b/projects/components/src/common/loading/loading-indicator.component.ts
@@ -16,7 +16,7 @@ export type SpinnerSize = keyof typeof SIZES;
  * Loading indicator for blocking modal dialogs while loading.
  */
 @Component({
-    selector: 'vcd-temp-loading-indicator',
+    selector: 'vcd-loading-indicator',
     templateUrl: 'loading-indicator.component.html',
     styleUrls: ['loading-indicator.component.scss'],
 })

--- a/projects/components/src/common/loading/loading-indicator.module.ts
+++ b/projects/components/src/common/loading/loading-indicator.module.ts
@@ -15,4 +15,4 @@ import { LoadingIndicatorComponent } from './loading-indicator.component';
     exports: [LoadingIndicatorComponent],
     entryComponents: [LoadingIndicatorComponent],
 })
-export class LoadingIndicatorModule {}
+export class VcdLoadingIndicatorModule {}

--- a/projects/components/src/components.module.ts
+++ b/projects/components/src/components.module.ts
@@ -4,32 +4,23 @@
  */
 
 import { NgModule } from '@angular/core';
-import { ActivityReporterModule } from './common/activity-reporter/activity-reporter.module';
-import { ErrorBannerModule } from './common/error/error-banner.module';
-import { LoadingIndicatorModule } from './common/loading/loading-indicator.module';
-import { DataExporterModule } from './data-exporter/data-exporter.module';
-import { DatagridModule } from './datagrid/datagrid.module';
-import { FormModule } from './form/form.module';
+import { VcdActivityReporterModule } from './common/activity-reporter/activity-reporter.module';
+import { VcdErrorBannerModule } from './common/error/error-banner.module';
+import { VcdLoadingIndicatorModule } from './common/loading/loading-indicator.module';
+import { VcdDataExporterModule } from './data-exporter/data-exporter.module';
+import { VcdDatagridModule } from './datagrid/datagrid.module';
+import { VcdFormModule } from './form/form.module';
 import { ShowClippedTextDirectiveModule } from './lib/directives/show-clipped-text.directive.module';
 
 @NgModule({
-    imports: [
-        DataExporterModule,
-        DatagridModule,
-        ShowClippedTextDirectiveModule,
-        ErrorBannerModule,
-        LoadingIndicatorModule,
-        ActivityReporterModule,
-        FormModule,
-    ],
     exports: [
-        DataExporterModule,
-        DatagridModule,
+        VcdDataExporterModule,
+        VcdDatagridModule,
         ShowClippedTextDirectiveModule,
-        ErrorBannerModule,
-        LoadingIndicatorModule,
-        ActivityReporterModule,
-        FormModule,
+        VcdErrorBannerModule,
+        VcdLoadingIndicatorModule,
+        VcdActivityReporterModule,
+        VcdFormModule,
     ],
 })
-export class ComponentsModule {}
+export class VcdComponentsModule {}

--- a/projects/components/src/data-exporter/data-exporter.component.spec.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.spec.ts
@@ -11,7 +11,7 @@ import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import { HasFinder, WidgetFinder } from '../utils/test/widget-object';
 import { CsvExporterService } from './csv-exporter.service';
 import { DataExportRequestEvent, ExportColumn } from './data-exporter.component';
-import { DataExporterModule } from './data-exporter.module';
+import { VcdDataExporterModule } from './data-exporter.module';
 import { DataExporterWidgetObject } from './data-exporter.wo';
 
 type TestHostFinder = HasFinder<TestHostComponent>;
@@ -19,7 +19,7 @@ type TestHostFinder = HasFinder<TestHostComponent>;
 describe('VcdExportTableComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [DataExporterModule, NoopAnimationsModule],
+            imports: [VcdDataExporterModule, NoopAnimationsModule],
             providers: [
                 {
                     provide: TranslationService,

--- a/projects/components/src/data-exporter/data-exporter.module.ts
+++ b/projects/components/src/data-exporter/data-exporter.module.ts
@@ -15,4 +15,4 @@ import { DataExporterComponent } from './data-exporter.component';
     imports: [CommonModule, ReactiveFormsModule, ClarityModule, I18nModule],
     exports: [DataExporterComponent],
 })
-export class DataExporterModule {}
+export class VcdDataExporterModule {}

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -1,8 +1,8 @@
 <h3 *ngIf="this.header" class="vcd-header">{{ header }}</h3>
-<vcd-temp-spinner-activity-reporter #actionReporter *ngIf="ActivityIndicatorType.SPINNER === indicatorType">
-</vcd-temp-spinner-activity-reporter>
-<vcd-temp-banner-activity-reporter #actionReporter *ngIf="ActivityIndicatorType.BANNER === indicatorType">
-</vcd-temp-banner-activity-reporter>
+<vcd-spinner-activity-reporter #actionReporter *ngIf="ActivityIndicatorType.SPINNER === indicatorType">
+</vcd-spinner-activity-reporter>
+<vcd-banner-activity-reporter #actionReporter *ngIf="ActivityIndicatorType.BANNER === indicatorType">
+</vcd-banner-activity-reporter>
 <clr-datagrid
     [clrDgLoading]="isLoading"
     [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent-grid']"

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -7,13 +7,14 @@ import { Component, HostBinding, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
+import { ActivityPromiseResolver } from '../common/activity-reporter/activity-promise-resolver';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { ClrDatagridWidgetObject } from '../utils/test/datagrid/datagrid.wo';
 import { VcdDatagridWidgetObject } from '../utils/test/datagrid/vcd-datagrid.wo';
 import { WidgetFinder } from '../utils/test/widget-object';
 import { ActivityIndicatorType, GridSelectionType, PaginationConfiguration } from './datagrid.component';
 import { DatagridComponent, GridDataFetchResult, GridState } from './datagrid.component';
-import { DatagridModule } from './datagrid.module';
+import { VcdDatagridModule } from './datagrid.module';
 import { DatagridStringFilter, WildCardPosition } from './filters/datagrid-string-filter.component';
 import {
     ButtonConfig,
@@ -45,12 +46,13 @@ interface HasFinderAndGrid {
 describe('DatagridComponent', () => {
     beforeEach(async function(this: HasFinderAndGrid): Promise<void> {
         await TestBed.configureTestingModule({
-            imports: [DatagridModule, BrowserAnimationsModule],
+            imports: [VcdDatagridModule, BrowserAnimationsModule],
             providers: [
                 {
                     provide: TranslationService,
                     useValue: new MockTranslationService(),
                 },
+                ActivityPromiseResolver,
             ],
             declarations: [HostWithDatagridComponent],
         }).compileComponents();
@@ -800,7 +802,7 @@ describe('DatagridComponent', () => {
                 it('is able to show the spinner indicator', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.indicatorType = ActivityIndicatorType.SPINNER;
                     this.finder.detectChanges();
-                    const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
+                    const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorGet');
                     this.clrGridWidget.pressTopButton('button');
                     expect(spy).toHaveBeenCalledTimes(1);
                 });
@@ -808,7 +810,7 @@ describe('DatagridComponent', () => {
                 it('is able to show the banner indicator', function(this: HasFinderAndGrid): void {
                     this.finder.hostComponent.indicatorType = ActivityIndicatorType.BANNER;
                     this.finder.detectChanges();
-                    const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorActivity');
+                    const spy = spyOn(this.finder.hostComponent.grid.actionReporter, 'monitorGet');
                     this.clrGridWidget.pressTopButton('button');
                     expect(spy).toHaveBeenCalledTimes(1);
                 });

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -21,14 +21,13 @@ import {
 import { ClrDatagrid, ClrDatagridFilter, ClrDatagridPagination, ClrDatagridStateInterface } from '@clr/angular';
 import { LazyString, TranslationService } from '@vcd/i18n';
 import { Observable } from 'rxjs';
-import { ActivityReporter } from '../common/activity-reporter/activity-reporter';
+import { ActivityReporter } from '../common/activity-reporter';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { DatagridFilter } from './filters/datagrid-filter';
 import {
     Button,
     ButtonConfig,
     ColumnRendererSpec,
-    ContextualButtonConfig,
     ContextualButtonPosition,
     FunctionRenderer,
     GridColumn,
@@ -621,7 +620,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
     runButtonHandler(button: Button<R>, selection?: R[]): void {
         const response = button.handler(selection);
         if (response && this.actionReporter) {
-            this.actionReporter.monitorActivity(response);
+            this.actionReporter.monitorGet(response);
         }
     }
 

--- a/projects/components/src/datagrid/datagrid.module.ts
+++ b/projects/components/src/datagrid/datagrid.module.ts
@@ -10,7 +10,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
-import { ActivityReporterModule } from '../common/activity-reporter/activity-reporter.module';
+import { VcdActivityReporterModule } from '../common/activity-reporter/activity-reporter.module';
 import { PipesModule } from '../common/pipes/pipes.module';
 import { ShowClippedTextDirectiveModule } from '../lib/directives/show-clipped-text.directive.module';
 import { DatagridComponent } from './datagrid.component';
@@ -42,11 +42,11 @@ const filters = [
         ShowClippedTextDirectiveModule,
         FormsModule,
         I18nModule,
-        ActivityReporterModule,
+        VcdActivityReporterModule,
     ],
     declarations: [DatagridComponent, ...directives, ...renderers, ...pipes, ...filters],
     providers: [],
     exports: [DatagridComponent, ...renderers],
     entryComponents: [...renderers, ...filters],
 })
-export class DatagridModule {}
+export class VcdDatagridModule {}

--- a/projects/components/src/datagrid/index.ts
+++ b/projects/components/src/datagrid/index.ts
@@ -7,7 +7,7 @@ export * from './datagrid.module';
 export * from './datagrid.component';
 export * from './interfaces/datagrid-column.interface';
 export * from './interfaces/component-renderer.interface';
-export * from './renderers';
+export * from './renderers/index';
 export * from './filters/datagrid-filter';
 export * from './filters/datagrid-numeric-filter.component';
 export * from './filters/datagrid-string-filter.component';

--- a/projects/components/src/form/base-form-control.spec.ts
+++ b/projects/components/src/form/base-form-control.spec.ts
@@ -10,7 +10,7 @@ import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import { WidgetFinder } from '../utils/test';
 import { FormInputComponent } from './form-input/form-input.component';
 import { VcdFormInputWidgetObject } from './form-input/form-input.component.spec';
-import { FormModule } from './form.module';
+import { VcdFormModule } from './form.module';
 
 /**
  * Tests for the BaseFormControl base class use the sub class VcdFormInputComponent instead of writing a dummy
@@ -103,7 +103,7 @@ class TestHostComponent {
 
 export async function configureFormInputTestingModule(testHostComponent: Type<unknown>): Promise<void> {
     await TestBed.configureTestingModule({
-        imports: [FormModule, ReactiveFormsModule],
+        imports: [VcdFormModule, ReactiveFormsModule],
         declarations: [testHostComponent],
         providers: [
             {

--- a/projects/components/src/form/form-input/form-input.component.spec.ts
+++ b/projects/components/src/form/form-input/form-input.component.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { WidgetFinder, WidgetObject } from '../../utils/test';
 import { configureFormInputTestingModule } from '../base-form-control.spec';
 import { FormInputComponent, getFormattedDateValue } from './form-input.component';
@@ -76,6 +76,11 @@ describe('FormInputComponent', () => {
                 numberInput.enter('70.9');
                 expect(hostComponent.formGroup.get('numberInput').value).toEqual(70.9);
             });
+
+            it('is not valid when set to null', () => {
+                numberInput.enter(null);
+                expect(hostComponent.formGroup.get('numberInput').valid).toBeFalsy();
+            });
         });
         describe('type datetime-local', () => {
             it('updates the form control with string input converted into a ISO formatted date string', () => {
@@ -102,7 +107,7 @@ class TestHostComponent {
     constructor(private fb: FormBuilder) {
         this.formGroup = this.fb.group({
             stringInput: ['test'],
-            numberInput: [70.9],
+            numberInput: [[70.9], Validators.required],
             dateInput: [new Date().toISOString()],
         });
     }

--- a/projects/components/src/form/form-input/form-input.component.ts
+++ b/projects/components/src/form/form-input/form-input.component.ts
@@ -108,7 +108,11 @@ export class FormInputComponent extends BaseFormControl implements AfterViewInit
         this.initialValue = value;
 
         if (this.type === 'number') {
-            this.onChange(parseFloat(value));
+            if (!value) {
+                this.onChange(value);
+            } else {
+                this.onChange(parseFloat(value));
+            }
             return;
         }
         if (this.type === 'datetime-local' && value !== '') {

--- a/projects/components/src/form/form-select/form-select.component.ts
+++ b/projects/components/src/form/form-select/form-select.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, Input, Optional, Self } from '@angular/core';
+import { Component, ElementRef, Input, Optional, Self, ViewChild } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { SelectOption } from '../../common/interfaces/select-option';
 import { BaseFormControl } from '../base-form-control';
@@ -27,6 +27,9 @@ export class FormSelectComponent extends BaseFormControl {
     }
 
     get selectedOption(): SelectOption {
+        if (!this.options) {
+            return undefined;
+        }
         return this.options.find(option => option.value === this.formControl.value);
     }
 }

--- a/projects/components/src/form/form.module.ts
+++ b/projects/components/src/form/form.module.ts
@@ -31,4 +31,4 @@ const declarations = [
     providers: [UnitFormatter],
     exports: [...declarations],
 })
-export class FormModule {}
+export class VcdFormModule {}

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -12,7 +12,7 @@ import { I18nModule, MockTranslationService, TranslationService } from '@vcd/i18
 import { WidgetFinder } from '../../utils/test';
 import { Hertz, Percent, Unit } from '../../utils/unit/unit';
 import { UnitFormatter } from '../../utils/unit/unit-formatter';
-import { FormModule } from '../form.module';
+import { VcdFormModule } from '../form.module';
 import { UNLIMITED } from './number-with-unit-form-input.component';
 import { NumberWithUnitFormInputWidgetObject } from './number-with-unit-form-input.widget-object';
 
@@ -47,7 +47,14 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
 
     beforeEach(fakeAsync(async () => {
         await TestBed.configureTestingModule({
-            imports: [BrowserAnimationsModule, I18nModule, FormsModule, ReactiveFormsModule, ClarityModule, FormModule],
+            imports: [
+                BrowserAnimationsModule,
+                I18nModule,
+                FormsModule,
+                ReactiveFormsModule,
+                ClarityModule,
+                VcdFormModule,
+            ],
             declarations: [TestHostComponent],
             providers: [
                 {

--- a/projects/components/src/index.ts
+++ b/projects/components/src/index.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+export * from './components.module';
+export * from './data-exporter/data-exporter.module';
+export * from './datagrid/datagrid.module';
+export * from './form/form.module';
+export * from './common/activity-reporter/activity-reporter.module';
+export * from './common/error/error-banner.module';
+export * from './common/loading/loading-indicator.module';
+
+export * from './common/subscription/index';
+export * from './common/error/index';
+export * from './common/loading/index';
+export * from './common/interfaces/index';
+export * from './common/activity-reporter/index';
+export * from './data-exporter/index';
+export * from './lib/directives/index';
+export * from './datagrid/index';
+export * from './utils/index';
+export * from './form/index';

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -3,19 +3,4 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-/*
- * Public API Surface of components
- */
-export * from './common/subscription';
-export * from './common/error';
-export * from './common/loading';
-export * from './common/interfaces';
-export * from './common/activity-reporter/index';
-export * from './data-exporter';
-export * from './lib/directives';
-export * from './datagrid';
-export * from './datagrid/datagrid.module';
-export * from './components.module';
-export * from './utils';
-export * from './form';
-export * from './form/form.module';
+export * from './index';

--- a/projects/components/src/utils/index.ts
+++ b/projects/components/src/utils/index.ts
@@ -4,7 +4,7 @@
  */
 
 export * from './id-generator/id-generator';
-export * from './test';
+export * from './test/index';
 export * from './unit/unit';
 export * from './unit/unit-formatter';
 export * from './common-util';

--- a/projects/components/src/utils/test/activity-reporter/banner-activity-reporter.wo.ts
+++ b/projects/components/src/utils/test/activity-reporter/banner-activity-reporter.wo.ts
@@ -7,7 +7,7 @@ import { BannerActivityReporterComponent } from '../../../common/activity-report
 import { WidgetObject } from '../widget-object';
 
 export class BannerActivityReporterWidgetObject extends WidgetObject<BannerActivityReporterComponent> {
-    static tagName = 'vcd-temp-banner-activity-reporter';
+    static tagName = 'vcd-banner-activity-reporter';
 
     get running(): boolean {
         return this.component.running;

--- a/projects/components/src/utils/test/activity-reporter/spinner-activity-reporter.wo.ts
+++ b/projects/components/src/utils/test/activity-reporter/spinner-activity-reporter.wo.ts
@@ -8,7 +8,7 @@ import { SpinnerActivityReporterComponent } from '../../../common/activity-repor
 import { WidgetObject } from '../widget-object';
 
 export class SpinnerActivityReporterWidgetObject extends WidgetObject<SpinnerActivityReporterComponent> {
-    static tagName = 'vcd-temp-spinner-activity-reporter';
+    static tagName = 'vcd-spinner-activity-reporter';
 
     get running(): boolean {
         return this.component.running;

--- a/projects/components/src/utils/test/datagrid/filter-utils.ts
+++ b/projects/components/src/utils/test/datagrid/filter-utils.ts
@@ -8,10 +8,10 @@ import { TestBed } from '@angular/core/testing';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import {
     DatagridFilter,
-    DatagridModule,
     FilterComponentRendererSpec,
     GridColumn,
     GridDataFetchResult,
+    VcdDatagridModule,
 } from '../../../datagrid';
 import { MockRecord } from '../../../datagrid/mock-data';
 import { IdGenerator } from '../../id-generator/id-generator';
@@ -40,7 +40,7 @@ export function createDatagridFilterTestHelper<V, C>(
     config?: C
 ): DatagridFilter<V, C> {
     TestBed.configureTestingModule({
-        imports: [DatagridModule],
+        imports: [VcdDatagridModule],
         declarations: [FilterTestHostComponent],
         providers: [
             {

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -14,7 +14,7 @@ import localeFr from '@angular/common/locales/fr';
 import { FormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule, TranslationService } from '@vcd/i18n';
-import { ComponentsModule } from '@vcd/ui-components';
+import { ActivityPromiseResolver, VcdComponentsModule } from '@vcd/ui-components';
 import { CompodocSchema, DocLibModule, StackBlitzInfo } from '@vcd/ui-doc-lib';
 import { AppRoutingModule } from './app-routing.module';
 
@@ -63,7 +63,7 @@ export const sbInfo: StackBlitzInfo = {
         ClarityModule,
         BrowserAnimationsModule,
         DocLibModule.forRoot([docJson1, docJson2], sbInfo),
-        ComponentsModule,
+        VcdComponentsModule,
         FormsModule,
         DatagridExamplesModule,
         DataExporterExamplesModule,
@@ -79,6 +79,7 @@ export const sbInfo: StackBlitzInfo = {
             provide: ASSET_URL,
             useValue: 'assets/translations',
         },
+        ActivityPromiseResolver,
     ],
     bootstrap: [AppComponent],
 })

--- a/projects/examples/src/app/components/show-clipped-text/positioning/show-clipped-text-positioning-example.module.ts
+++ b/projects/examples/src/app/components/show-clipped-text/positioning/show-clipped-text-positioning-example.module.ts
@@ -5,12 +5,12 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { ShowClippedTextPositioningExampleComponent } from './show-clipped-text-positioning-example.component';
 
 @NgModule({
     declarations: [ShowClippedTextPositioningExampleComponent],
-    imports: [CommonModule, ComponentsModule],
+    imports: [CommonModule, VcdComponentsModule],
     exports: [ShowClippedTextPositioningExampleComponent],
     entryComponents: [ShowClippedTextPositioningExampleComponent],
 })

--- a/projects/examples/src/app/components/show-clipped-text/sizing/show-clipped-text-sizing-example.module.ts
+++ b/projects/examples/src/app/components/show-clipped-text/sizing/show-clipped-text-sizing-example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { ShowClippedTextSizingExampleComponent } from './show-clipped-text-sizing-example.component';
 
 @NgModule({
     declarations: [ShowClippedTextSizingExampleComponent],
-    imports: [CommonModule, FormsModule, ComponentsModule],
+    imports: [CommonModule, FormsModule, VcdComponentsModule],
     exports: [ShowClippedTextSizingExampleComponent],
     entryComponents: [ShowClippedTextSizingExampleComponent],
 })

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.html
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.html
@@ -1,4 +1,4 @@
 <button *ngIf="!showBanner" (click)="startActivity()">Start Activity Reporter</button>
 <button *ngIf="showBanner" (click)="throwError()">Throw Error</button>
 <button *ngIf="showBanner" (click)="reportSuccess()">Report Success</button>
-<vcd-temp-banner-activity-reporter></vcd-temp-banner-activity-reporter>
+<vcd-banner-activity-reporter></vcd-banner-activity-reporter>

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.component.ts
@@ -23,7 +23,7 @@ export class BannerActivityReporterExampleComponent {
     startActivity(): void {
         this.showBanner = true;
         this.reporter
-            .monitorActivity(
+            .monitorGet(
                 new Promise((resolve, reject) => {
                     this.reject = reject;
                     this.resolve = resolve;

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { BannerActivityReporterExampleComponent } from './banner-activity-reporter.example.component';
 
 @NgModule({
     declarations: [BannerActivityReporterExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [BannerActivityReporterExampleComponent],
     entryComponents: [BannerActivityReporterExampleComponent],
 })

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.html
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.html
@@ -1,4 +1,4 @@
 <button *ngIf="!showSpinner" (click)="startActivity()">Start Activity Reporter</button>
 <button *ngIf="showSpinner" (click)="throwError()">Throw Error</button>
 <button *ngIf="showSpinner" (click)="reportSuccess()">Report Success</button>
-<vcd-temp-spinner-activity-reporter></vcd-temp-spinner-activity-reporter>
+<vcd-spinner-activity-reporter></vcd-spinner-activity-reporter>

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.component.ts
@@ -10,7 +10,7 @@ import { ActivityReporter, SpinnerActivityReporterComponent } from '@vcd/ui-comp
  * Press the button to show/hide the spinner activity reporter
  */
 @Component({
-    selector: 'vcd-temp-spinner-activity-reporter-example',
+    selector: 'vcd-spinner-activity-reporter-example',
     templateUrl: './spinner-activity-reporter.example.component.html',
 })
 export class SpinnerActivityReporterExampleComponent {
@@ -23,7 +23,7 @@ export class SpinnerActivityReporterExampleComponent {
     startActivity(): void {
         this.showSpinner = true;
         this.reporter
-            .monitorActivity(
+            .monitorGet(
                 new Promise((resolve, reject) => {
                     this.reject = reject;
                     this.resolve = resolve;

--- a/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/spinner-activity-reporter.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { SpinnerActivityReporterExampleComponent } from './spinner-activity-reporter.example.component';
 
 @NgModule({
     declarations: [SpinnerActivityReporterExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [SpinnerActivityReporterExampleComponent],
     entryComponents: [SpinnerActivityReporterExampleComponent],
 })

--- a/projects/examples/src/components/data-exporter/data-exporter.example.module.ts
+++ b/projects/examples/src/components/data-exporter/data-exporter.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DataExporterExampleComponent } from './data-exporter.example.component';
 
 @NgModule({
     declarations: [DataExporterExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DataExporterExampleComponent],
     entryComponents: [DataExporterExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';
 
 @NgModule({
     declarations: [DatagridActivityReporterExampleComponent],
-    imports: [CommonModule, ClarityModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, VcdComponentsModule],
     exports: [DatagridActivityReporterExampleComponent],
     entryComponents: [DatagridActivityReporterExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-cliptext.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-cliptext.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridCliptextExampleComponent } from './datagrid-cliptext.example.component';
 
 @NgModule({
     declarations: [DatagridCliptextExampleComponent],
-    imports: [CommonModule, ClarityModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, VcdComponentsModule],
     exports: [DatagridCliptextExampleComponent],
     entryComponents: [DatagridCliptextExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-css-classes.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-css-classes.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridCssClassesExampleComponent } from './datagrid-css-classes.example.component';
 
 @NgModule({
     declarations: [DatagridCssClassesExampleComponent],
-    imports: [CommonModule, ClarityModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, VcdComponentsModule],
     exports: [DatagridCssClassesExampleComponent],
     entryComponents: [DatagridCssClassesExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 
 @NgModule({
     declarations: [DatagridDetailRowExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridDetailRowExampleComponent],
     entryComponents: [DatagridDetailRowExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-filter.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-filter.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
 
 @NgModule({
     declarations: [DatagridFilterExampleComponent],
-    imports: [CommonModule, ClarityModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, VcdComponentsModule],
     exports: [DatagridFilterExampleComponent],
     entryComponents: [DatagridFilterExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-header.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-header.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridHeaderExampleComponent } from './datagrid-header.example.component';
 
 @NgModule({
     declarations: [DatagridHeaderExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridHeaderExampleComponent],
     entryComponents: [DatagridHeaderExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-height.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-height.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridHeightExampleComponent } from './datagrid-height.example.component';
 
 @NgModule({
     declarations: [DatagridHeightExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridHeightExampleComponent],
     entryComponents: [DatagridHeightExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-link.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
 
 @NgModule({
     declarations: [DatagridLinkExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridLinkExampleComponent],
     entryComponents: [DatagridLinkExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-pagination-example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-pagination-example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
 
 @NgModule({
     declarations: [DatagridPaginationExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridPaginationExampleComponent],
     entryComponents: [DatagridPaginationExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-row-icon.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-icon.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridRowIconExampleComponent, RowIconRendererComponent } from './datagrid-row-icon.example.component';
 
 @NgModule({
     declarations: [DatagridRowIconExampleComponent, RowIconRendererComponent],
-    imports: [CommonModule, ClarityModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, VcdComponentsModule],
     exports: [DatagridRowIconExampleComponent],
     entryComponents: [DatagridRowIconExampleComponent, RowIconRendererComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-row-select.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-select.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridRowSelectExampleComponent } from './datagrid-row-select.example.component';
 
 @NgModule({
     declarations: [DatagridRowSelectExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridRowSelectExampleComponent],
     entryComponents: [DatagridRowSelectExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-show-hide.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-show-hide.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridShowHideExampleComponent } from './datagrid-show-hide.example.component';
 
 @NgModule({
     declarations: [DatagridShowHideExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridShowHideExampleComponent],
     entryComponents: [DatagridShowHideExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-sort.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-sort.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridSortExampleComponent } from './datagrid-sort.example.component';
 
 @NgModule({
     declarations: [DatagridSortExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridSortExampleComponent],
     entryComponents: [DatagridSortExampleComponent],
 })

--- a/projects/examples/src/components/datagrid/datagrid-three-renderers.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-three-renderers.example.module.ts
@@ -6,12 +6,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { DatagridThreeRenderersExampleComponent } from './datagrid-three-renderers.example.component';
 
 @NgModule({
     declarations: [DatagridThreeRenderersExampleComponent],
-    imports: [CommonModule, ClarityModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, VcdComponentsModule],
     exports: [DatagridThreeRenderersExampleComponent],
     entryComponents: [DatagridThreeRenderersExampleComponent],
 })

--- a/projects/examples/src/components/error/error-banner.example.component.html
+++ b/projects/examples/src/components/error/error-banner.example.component.html
@@ -1,2 +1,2 @@
 <button (click)="showError = !showError">Show/Hide Error</button>
-<vcd-temp-error-banner [errorMessage]="showError ? 'Error!' : undefined"></vcd-temp-error-banner>
+<vcd-error-banner [errorMessage]="showError ? 'Error!' : undefined"></vcd-error-banner>

--- a/projects/examples/src/components/error/error-banner.example.component.ts
+++ b/projects/examples/src/components/error/error-banner.example.component.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
  * Press the button to show/hide the error banner.
  */
 @Component({
-    selector: 'vcd-temp-error-banner-example',
+    selector: 'vcd-error-banner-example',
     templateUrl: './error-banner.example.component.html',
 })
 export class ErrorBannerExampleComponent {

--- a/projects/examples/src/components/error/error-banner.example.module.ts
+++ b/projects/examples/src/components/error/error-banner.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { ErrorBannerExampleComponent } from './error-banner.example.component';
 
 @NgModule({
     declarations: [ErrorBannerExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [ErrorBannerExampleComponent],
     entryComponents: [ErrorBannerExampleComponent],
 })

--- a/projects/examples/src/components/form-input/form-checkbox.example.module.ts
+++ b/projects/examples/src/components/form-input/form-checkbox.example.module.ts
@@ -5,12 +5,12 @@
 
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { FormModule } from '@vcd/ui-components';
+import { VcdFormModule } from '@vcd/ui-components';
 import { FormCheckboxExampleComponent } from './form-checkbox.example.component';
 
 @NgModule({
     declarations: [FormCheckboxExampleComponent],
-    imports: [FormModule, ReactiveFormsModule],
+    imports: [VcdFormModule, ReactiveFormsModule],
     exports: [FormCheckboxExampleComponent],
     entryComponents: [FormCheckboxExampleComponent],
 })

--- a/projects/examples/src/components/form-input/form-input.example.component.ts
+++ b/projects/examples/src/components/form-input/form-input.example.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 @Component({
@@ -15,7 +15,7 @@ export class FormInputExampleComponent {
     constructor(private fb: FormBuilder) {
         this.formGroup = this.fb.group({
             ['stringInput']: ['test@vcd.com', [Validators.required, Validators.email, Validators.maxLength(15)]],
-            ['numberInput']: [75],
+            ['numberInput']: [75, [Validators.required]],
             ['dateInput']: [new Date().toISOString()],
         });
     }

--- a/projects/examples/src/components/form-input/form-input.example.module.ts
+++ b/projects/examples/src/components/form-input/form-input.example.module.ts
@@ -5,12 +5,12 @@
 
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { FormModule } from '@vcd/ui-components';
+import { VcdFormModule } from '@vcd/ui-components';
 import { FormInputExampleComponent } from './form-input.example.component';
 
 @NgModule({
     declarations: [FormInputExampleComponent],
-    imports: [FormModule, ReactiveFormsModule],
+    imports: [VcdFormModule, ReactiveFormsModule],
     exports: [FormInputExampleComponent],
     entryComponents: [FormInputExampleComponent],
 })

--- a/projects/examples/src/components/form-input/form-select.example.module.ts
+++ b/projects/examples/src/components/form-input/form-select.example.module.ts
@@ -5,12 +5,12 @@
 
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { FormModule } from '@vcd/ui-components';
+import { VcdFormModule } from '@vcd/ui-components';
 import { FormSelectExampleComponent } from './form-select.example.component';
 
 @NgModule({
     declarations: [FormSelectExampleComponent],
-    imports: [FormModule, ReactiveFormsModule],
+    imports: [VcdFormModule, ReactiveFormsModule],
     exports: [FormSelectExampleComponent],
     entryComponents: [FormSelectExampleComponent],
 })

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.module.ts
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.module.ts
@@ -6,12 +6,12 @@
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { I18nModule } from '@vcd/i18n';
-import { FormModule } from '@vcd/ui-components';
+import { VcdFormModule } from '@vcd/ui-components';
 import { NumberWithUnitFormInputExampleComponent } from './number-with-unit-form-input.example.component';
 
 @NgModule({
     declarations: [NumberWithUnitFormInputExampleComponent],
-    imports: [FormModule, ReactiveFormsModule, I18nModule],
+    imports: [VcdFormModule, ReactiveFormsModule, I18nModule],
     exports: [NumberWithUnitFormInputExampleComponent],
     entryComponents: [NumberWithUnitFormInputExampleComponent],
 })

--- a/projects/examples/src/components/loading/loading-indicator.example.component.html
+++ b/projects/examples/src/components/loading/loading-indicator.example.component.html
@@ -1,2 +1,2 @@
 <button (click)="isLoading = !isLoading">Start/Stop Loading</button>
-<vcd-temp-loading-indicator [isLoading]="isLoading"></vcd-temp-loading-indicator>
+<vcd-loading-indicator [isLoading]="isLoading"></vcd-loading-indicator>

--- a/projects/examples/src/components/loading/loading-indicator.example.component.ts
+++ b/projects/examples/src/components/loading/loading-indicator.example.component.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
  * Press the button to start/stop the loading indicator.
  */
 @Component({
-    selector: 'vcd-temp-loading-indicator-example',
+    selector: 'vcd-loading-indicator-example',
     templateUrl: './loading-indicator.example.component.html',
 })
 export class LoadingIndicatorExampleComponent {

--- a/projects/examples/src/components/loading/loading-indicator.example.module.ts
+++ b/projects/examples/src/components/loading/loading-indicator.example.module.ts
@@ -7,12 +7,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import { LoadingIndicatorExampleComponent } from './loading-indicator.example.component';
 
 @NgModule({
     declarations: [LoadingIndicatorExampleComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [LoadingIndicatorExampleComponent],
     entryComponents: [LoadingIndicatorExampleComponent],
 })

--- a/projects/examples/src/components/subscription/subscription-tracker.example.module.ts
+++ b/projects/examples/src/components/subscription/subscription-tracker.example.module.ts
@@ -7,7 +7,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
-import { ComponentsModule } from '@vcd/ui-components';
+import { VcdComponentsModule } from '@vcd/ui-components';
 import {
     SubscriptionTrackerExampleComponent,
     SubscriptionTrackerExampleSubComponent,
@@ -15,7 +15,7 @@ import {
 
 @NgModule({
     declarations: [SubscriptionTrackerExampleComponent, SubscriptionTrackerExampleSubComponent],
-    imports: [CommonModule, ClarityModule, ReactiveFormsModule, ComponentsModule],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [SubscriptionTrackerExampleComponent],
     entryComponents: [SubscriptionTrackerExampleComponent],
 })


### PR DESCRIPTION
# Description:

1. Removes the ```-temp``` string added to the tag names of a few components for compability with vcd-ui.
2. Reworks how we export from our package to be modeled after Clarity.
3. Exports all top level modules and prefixed all of them with ```Vcd```
4.  Reworks the ActivityReporter. Now, there are two classes that have the previous functionality split between them.
- ActivityReporter: responsible for receiving requests and displaying them to the screen.
- ActivityPerformer: responsible for converting from a request to some understandable response. 
This allows us to delete the Banner and Spinner activity reporters from VCD-UI!!
5. Added logic to ```selectedOption``` in FormSelectComponents because there were times when VCD-UI bound undefined to the options. 

# Testing
1. Added unit tests to test new activity reporter logic + ran previous unit tests to assure passage.
2. Ran the examples app in prod mode and made sure things functioned.
3. Added to VCD-UI and was able to delete their Error Banner, Loading Indicator, Form Input, Form Select, Banner Reporter, and Spinner reporter. Everything continued to function perfectly.  

# App Functions!

<img width="1680" alt="Screen Shot 2020-04-17 at 2 45 14 PM" src="https://user-images.githubusercontent.com/7528512/79603309-18689180-80ba-11ea-809a-06152865074c.png">
