### PR TITLE
Fixed messageformat version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9136,17 +9136,17 @@
       }
     },
     "make-plural": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
-      "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-3.0.6.tgz",
+      "integrity": "sha1-IDOgO6wpC487uRJY9lud9+iwHKc=",
       "requires": {
         "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "optional": true
         }
       }
@@ -9340,24 +9340,36 @@
       "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
     },
     "messageformat": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
-      "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-1.0.2.tgz",
+      "integrity": "sha1-kI9GkfKf8o2uNcRUNqJM/5NAI4g=",
       "requires": {
-        "make-plural": "^4.3.0",
-        "messageformat-formatters": "^2.0.1",
-        "messageformat-parser": "^4.1.2"
+        "glob": "~7.0.6",
+        "make-plural": "~3.0.6",
+        "messageformat-parser": "^1.0.0",
+        "nopt": "~3.0.6",
+        "reserved-words": "^0.1.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
-    "messageformat-formatters": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
-      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg=="
-    },
     "messageformat-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.2.tgz",
-      "integrity": "sha512-7dWuifeyldz7vhEuL96Kwq1fhZXBW+TUfbnHN4UCrCxoXQTYjHnR78eI66Gk9LaLLsAvzPNVJBaa66DRfFNaiA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-1.1.0.tgz",
+      "integrity": "sha512-Hwem6G3MsKDLS1FtBRGIs8T50P1Q00r3srS6QJePCFbad9fq0nYxwf3rnU2BreApRGhmpKMV7oZI06Sy1c9TPA=="
     },
     "methods": {
       "version": "1.1.2",
@@ -11706,6 +11718,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
+    },
+    "reserved-words": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE="
     },
     "resolve": {
       "version": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "codecov.io": "0.1.6",
     "karma-coverage": "2.0.1",
     "lit-html": "1.1.2",
-    "messageformat": "2.3.0",
+    "messageformat": "1.0.2",
     "prismjs": "1.17.1",
     "properties": "1.2.1",
     "rxjs": "6.4.0",

--- a/projects/i18n/package.json
+++ b/projects/i18n/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@vcd/i18n",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "peerDependencies": {
     "@angular/common": ">6.0.0",
     "@angular/core": ">6.0.0"
   },
   "dependencies": {
-    "messageformat": "2.3.0"
+    "messageformat": "1.0.2"
   }
 }

--- a/projects/i18n/src/lib/i18n.module.spec.ts
+++ b/projects/i18n/src/lib/i18n.module.spec.ts
@@ -30,6 +30,8 @@ describe('I18nModule', () => {
         (TestBed.get(TranslationService) as TranslationService).registerTranslations({
             en: {
                 'vcd.cc.cancel': 'cancel',
+                // tslint:disable-next-line: quotemark
+                'vcd.cc.interp': "'{0}'",
             },
         });
 
@@ -38,6 +40,8 @@ describe('I18nModule', () => {
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('h2')).nativeElement.textContent).toEqual('cancel');
         expect(fixture.debugElement.query(By.css('h4')).nativeElement.textContent).toEqual('cancel');
+        // tslint:disable-next-line: quotemark
+        expect(fixture.debugElement.query(By.css('h5')).nativeElement.textContent).toEqual("'name'");
     }));
 
     it('translates correctly with forChild', fakeAsync(async () => {
@@ -76,6 +80,7 @@ describe('I18nModule', () => {
         <h2>{{ 'vcd.cc.cancel' | translate }}</h2>
         <h3>{{ 'unloaded' | translate }}</h3>
         <h4>{{ text | lazyString }}</h4>
+        <h5>{{ 'vcd.cc.interp' | translate: 'name' }}</h5>
     `,
     selector: 'lib-translate-test',
 })

--- a/projects/i18n/src/lib/i18n.module.spec.ts
+++ b/projects/i18n/src/lib/i18n.module.spec.ts
@@ -15,72 +15,69 @@ import { TranslationService } from './service/translation-service';
 import { CanTranslate } from './service/translation-service.mixin';
 
 describe('I18nModule', () => {
-    it('translates correctly with forRoot', fakeAsync(async () => {
-        await TestBed.configureTestingModule({
-            imports: [I18nModule.forRoot(), BrowserAnimationsModule],
-            providers: [
-                {
-                    provide: LOCALE_ID,
-                    useValue: 'en',
+    describe('forRoot', () => {
+        it('provides translate and lazyString pipe', fakeAsync(async () => {
+            await TestBed.configureTestingModule({
+                imports: [I18nModule.forRoot(), BrowserAnimationsModule],
+                providers: [
+                    {
+                        provide: LOCALE_ID,
+                        useValue: 'en',
+                    },
+                ],
+                declarations: [TestClassComponent],
+            }).compileComponents();
+
+            (TestBed.get(TranslationService) as TranslationService).registerTranslations({
+                en: {
+                    'vcd.cc.cancel': 'cancel',
                 },
-            ],
-            declarations: [TestClassComponent],
-        }).compileComponents();
+            });
 
-        (TestBed.get(TranslationService) as TranslationService).registerTranslations({
-            en: {
-                'vcd.cc.cancel': 'cancel',
-                // tslint:disable-next-line: quotemark
-                'vcd.cc.interp': "'{0}'",
-            },
-        });
+            const fixture = TestBed.createComponent(TestClassComponent);
+            tick();
+            fixture.detectChanges();
+            expect(fixture.debugElement.query(By.css('h2')).nativeElement.textContent).toEqual('cancel');
+            expect(fixture.debugElement.query(By.css('h4')).nativeElement.textContent).toEqual('cancel');
+        }));
+    });
 
-        const fixture = TestBed.createComponent(TestClassComponent);
-        tick();
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('h2')).nativeElement.textContent).toEqual('cancel');
-        expect(fixture.debugElement.query(By.css('h4')).nativeElement.textContent).toEqual('cancel');
-        // tslint:disable-next-line: quotemark
-        expect(fixture.debugElement.query(By.css('h5')).nativeElement.textContent).toEqual("'name'");
-    }));
+    describe('forChild', () => {
+        it('provides translate and lazyString pipe', fakeAsync(async () => {
+            const route = new InjectionToken('ROUTE');
+            await TestBed.configureTestingModule({
+                imports: [I18nModule.forChild(route, true), BrowserAnimationsModule, HttpClientTestingModule],
+                providers: [
+                    {
+                        provide: LOCALE_ID,
+                        useValue: 'en',
+                    },
+                    {
+                        provide: route,
+                        useValue: 'route',
+                    },
+                ],
+                declarations: [TestClassComponent],
+            }).compileComponents();
 
-    it('translates correctly with forChild', fakeAsync(async () => {
-        const route = new InjectionToken('ROUTE');
-        await TestBed.configureTestingModule({
-            imports: [I18nModule.forChild(route, true), BrowserAnimationsModule, HttpClientTestingModule],
-            providers: [
-                {
-                    provide: LOCALE_ID,
-                    useValue: 'en',
-                },
-                {
-                    provide: route,
-                    useValue: 'route',
-                },
-            ],
-            declarations: [TestClassComponent],
-        }).compileComponents();
+            const service = TestBed.get(TranslationService) as MessageFormatTranslationService;
+            const observable = new BehaviorSubject({ en: { 'vcd.cc.cancel': 'cancel' } });
+            spyOn((service as any).translationLoader, 'getCombinedTranslation').and.returnValue(observable);
+            service.registerTranslations();
 
-        const service = TestBed.get(TranslationService) as MessageFormatTranslationService;
-        const observable = new BehaviorSubject({ en: { 'vcd.cc.cancel': 'cancel' } });
-        spyOn((service as any).translationLoader, 'getCombinedTranslation').and.returnValue(observable);
-        service.registerTranslations();
-
-        const fixture = TestBed.createComponent(TestClassComponent);
-        tick();
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('h2')).nativeElement.textContent).toEqual('cancel');
-        expect(fixture.debugElement.query(By.css('h4')).nativeElement.textContent).toEqual('cancel');
-        expect(fixture.debugElement.query(By.css('h3')).nativeElement.textContent).toEqual('?unloaded');
-    }));
+            const fixture = TestBed.createComponent(TestClassComponent);
+            tick();
+            fixture.detectChanges();
+            expect(fixture.debugElement.query(By.css('h2')).nativeElement.textContent).toEqual('cancel');
+            expect(fixture.debugElement.query(By.css('h4')).nativeElement.textContent).toEqual('cancel');
+        }));
+    });
 });
 
 @Component({
     template: `
         <h2>{{ 'vcd.cc.cancel' | translate }}</h2>
-        <h3>{{ 'unloaded' | translate }}</h3>
         <h4>{{ text | lazyString }}</h4>
-        <h5>{{ 'vcd.cc.interp' | translate: 'name' }}</h5>
     `,
     selector: 'lib-translate-test',
 })

--- a/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
+++ b/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
@@ -37,6 +37,7 @@ describe('MessageFormatTranslationService', () => {
                 '{count, plural, =0{VM does not comply with compute policies}' +
                 'one{VM does not comply with compute policy "{0}"}' +
                 'other{VM does not comply with compute policies "{0}" and "{1}"}}',
+            'quoted.param': `'{0}'`,
         },
         fr: {},
     };
@@ -123,6 +124,12 @@ describe('MessageFormatTranslationService', () => {
         expect(translationService.translate('vm.computePolicy.compliance', getPolicySize(2))).toBe(
             `VM does not comply with compute policies "Oracle Sizing" and "Oracle Placement"`
         );
+    });
+
+    it('doesnt treat single quote as an escape character', () => {
+        const translationService = new MessageFormatTranslationService('en', 'en');
+        translationService.registerTranslations(translationSet);
+        expect(translationService.translate('quoted.param', ['name'])).toEqual(`'name'`);
     });
 
     it('can format dates properly', () => {


### PR DESCRIPTION
# Description

In messageformat 2.0.0, they introduced a breaking change where single-quote became an escape character our of interpolation. This change downgrades messageformat to use the same version as listed in VCD-UI's package.json.

# Testing

Added a unit test to test that the interpolation now works. Also, confirmed that this test failed when using messageformat 2.3.0. 

Signed-off-by: Ryan Bradford <rbradford@vmware.com>