### PR TITLE
Implemented lazy loading detail expansions

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -52,7 +52,7 @@
         Whereas the trackBy in ngForTrackBy is to inform Clarity on how to track changes to it's
         items. -->
     <clr-dg-row
-        *ngFor="let restItem of items; let i = index; trackBy: trackBy"
+        *ngFor="let restItem of items; let i = index; let count = count; trackBy: trackBy"
         [ngForTrackBy]="trackBy"
         [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
         [clrDgItem]="restItem"
@@ -91,9 +91,15 @@
             >
             </ng-template>
         </clr-dg-cell>
-        <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="detailTemplate !== undefined">
+
+        <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="detailComponent !== undefined">
             <clr-dg-row-detail *clrIfExpanded>
-                <ng-content *ngTemplateOutlet="detailTemplate; context: { record: restItem }"> </ng-content>
+                <ng-template
+                    [vcdComponentRendererOutlet]="{
+                        rendererSpec: getDetailRenderSpec(restItem, i, count)
+                    }"
+                >
+                </ng-template>
             </clr-dg-row-detail>
         </ng-container>
     </clr-dg-row>

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, HostBinding, ViewChild } from '@angular/core';
+import { Component, HostBinding, InjectionToken, Type, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { LoadingListener } from '@clr/angular';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import { ActivityPromiseResolver } from '../common/activity-reporter/activity-promise-resolver';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
@@ -54,7 +55,7 @@ describe('DatagridComponent', () => {
                 },
                 ActivityPromiseResolver,
             ],
-            declarations: [HostWithDatagridComponent],
+            declarations: [HostWithDatagridComponent, DatagridDetailsComponent],
         }).compileComponents();
 
         this.finder = new WidgetFinder(HostWithDatagridComponent);
@@ -478,7 +479,7 @@ describe('DatagridComponent', () => {
             });
         });
 
-        describe('Row expansion functionality', () => {
+        describe('@Input() detailComponent', () => {
             beforeEach(function(this: HasFinderAndGrid): void {
                 this.finder.hostComponent.columns = [
                     {
@@ -492,6 +493,18 @@ describe('DatagridComponent', () => {
             it('opens one detail pane when you click the button', function(this: HasFinderAndGrid): void {
                 this.clrGridWidget.clickDetailsButton(0);
                 expect(this.clrGridWidget.getAllDetailContents().length).toEqual(1);
+            });
+        });
+
+        describe('getRowLoadingListenerInjector()', () => {
+            beforeEach(function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.columns = [
+                    {
+                        displayName: 'Column',
+                        renderer: 'name',
+                    },
+                ];
+                this.finder.detectChanges();
             });
         });
 
@@ -935,8 +948,8 @@ describe('DatagridComponent', () => {
                 [header]="header"
                 [indicatorType]="indicatorType"
                 [trackBy]="trackBy"
+                [detailComponent]="details"
             >
-                <ng-template let-record="record"> DETAILS: {{ record.name }} </ng-template>
             </vcd-datagrid>
         </div>
     `,
@@ -974,6 +987,8 @@ export class HostWithDatagridComponent {
         },
     };
 
+    details = DatagridDetailsComponent;
+
     paginationText = 'Total Items';
 
     pagination: PaginationConfiguration = {
@@ -998,4 +1013,13 @@ export class HostWithDatagridComponent {
     getSelection(): MockRecord[] {
         return this.grid.datagridSelection;
     }
+}
+
+@Component({
+    template: `
+        DETAILS
+    `,
+})
+class DatagridDetailsComponent {
+    constructor(public loadingListener: LoadingListener) {}
 }

--- a/projects/components/src/datagrid/directives/component-renderer-outlet.directive.ts
+++ b/projects/components/src/datagrid/directives/component-renderer-outlet.directive.ts
@@ -31,6 +31,11 @@ export class ComponentRendererOutletDirective<R, T> {
 
     constructor(private viewContainerRef: ViewContainerRef, private cfr: ComponentFactoryResolver) {}
 
+    /**
+     * Sets the component that this outlet should render. Where rendererSpec is the
+     * {@link ComponentRendererSpec} that details how to render the component and context
+     * is any information that the component needs to render.
+     */
     @Input()
     set vcdComponentRendererOutlet(renderer: { rendererSpec: ComponentRendererSpec<T>; context?: R }) {
         if (this.componentType !== renderer.rendererSpec.type) {

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component } from '@angular/core';
-import { GridColumn, GridDataFetchResult, GridState } from '@vcd/ui-components';
+import { Component, Input, OnInit } from '@angular/core';
+import { ComponentRenderer, DetailRowConfig, GridColumn, GridDataFetchResult, GridState } from '@vcd/ui-components';
 
 interface Data {
     value: string;
@@ -14,10 +14,27 @@ interface Data {
  * Shows an expandable detail template within the rows.
  */
 @Component({
-    selector: 'vcd-datagrid-show-hide-example',
+    selector: 'vcd-datagrid-detail-row-example',
     template: `
-        <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns">
-            <ng-template let-record="record"> DETAILS: {{ record.value }} </ng-template>
+        <p>
+            The datagrid allows the client to pass in an arbitrary component to be rendered as the expandable detail
+            content of the rows. This is passed in as <code>[detailComponent]</code> and has support for using
+            <code>[clrLoading]</code> to make the content lazy loaded.
+        </p>
+        <vcd-datagrid
+            [gridData]="gridData"
+            (gridRefresh)="refresh($event)"
+            [columns]="columns"
+            [detailComponent]="lazyDetails"
+        >
+        </vcd-datagrid>
+        <p>The user can also chose to not specify <code>[clrLoading]</code> and the row will no longer be lazy.</p>
+        <vcd-datagrid
+            [gridData]="gridData"
+            (gridRefresh)="refresh($event)"
+            [columns]="columns"
+            [detailComponent]="noLazyDetails"
+        >
         </vcd-datagrid>
     `,
 })
@@ -25,6 +42,9 @@ export class DatagridDetailRowExampleComponent {
     gridData: GridDataFetchResult<Data> = {
         items: [],
     };
+
+    lazyDetails = DatagridDetailRowSubComponent;
+    noLazyDetails = DatagridDetailRowSubNoLazyComponent;
 
     columns: GridColumn<Data>[] = [
         {
@@ -40,4 +60,53 @@ export class DatagridDetailRowExampleComponent {
             totalItems: 2,
         };
     }
+}
+
+@Component({
+    selector: 'vcd-datagrid-detail-row-sub-example',
+    template: `
+        <div [clrLoading]="loading">
+            <dl>
+                <dt>Record</dt>
+                <dd>{{ JSON.stringify(config.record) }}</dd>
+                <dt>Index</dt>
+                <dd>{{ config.index }}</dd>
+                <dt>Count</dt>
+                <dd>{{ config.count }}</dd>
+            </dl>
+        </div>
+    `,
+})
+export class DatagridDetailRowSubComponent implements OnInit, ComponentRenderer<DetailRowConfig<Data>> {
+    loading = true;
+    JSON = JSON;
+
+    @Input() config: DetailRowConfig<Data>;
+
+    ngOnInit(): void {
+        setTimeout(() => {
+            this.loading = false;
+        }, 2000);
+    }
+}
+
+@Component({
+    selector: 'vcd-datagrid-detail-row-sub-example',
+    template: `
+        <div>
+            <dl>
+                <dt>Record</dt>
+                <dd>{{ JSON.stringify(config.record) }}</dd>
+                <dt>Index</dt>
+                <dd>{{ config.index }}</dd>
+                <dt>Count</dt>
+                <dd>{{ config.count }}</dd>
+            </dl>
+        </div>
+    `,
+})
+export class DatagridDetailRowSubNoLazyComponent implements ComponentRenderer<DetailRowConfig<Data>> {
+    JSON = JSON;
+
+    @Input() config: DetailRowConfig<Data>;
 }

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.module.ts
@@ -8,12 +8,24 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { VcdComponentsModule } from '@vcd/ui-components';
-import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
+import {
+    DatagridDetailRowExampleComponent,
+    DatagridDetailRowSubComponent,
+    DatagridDetailRowSubNoLazyComponent,
+} from './datagrid-detail-row.example.component';
 
 @NgModule({
-    declarations: [DatagridDetailRowExampleComponent],
+    declarations: [
+        DatagridDetailRowExampleComponent,
+        DatagridDetailRowSubComponent,
+        DatagridDetailRowSubNoLazyComponent,
+    ],
     imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
     exports: [DatagridDetailRowExampleComponent],
-    entryComponents: [DatagridDetailRowExampleComponent],
+    entryComponents: [
+        DatagridDetailRowExampleComponent,
+        DatagridDetailRowSubComponent,
+        DatagridDetailRowSubNoLazyComponent,
+    ],
 })
 export class DatagridDetailRowExampleModule {}


### PR DESCRIPTION
# Description:

Adds the ability for a row detail to use the [clrLoading] directive to make the detail contents lazy loaded. It does this by requiring the row detail to be input as a component rather than a template, and then when it creates the component it provides the LoadingListener as a provider.

# Testing:

1. Added a unit test to test the LoadingListener provider
2. Updated the existing detail row test to work.
3. Ran the app with a lazy loaded detail row and assured it works.

![detail-lazy](https://user-images.githubusercontent.com/7528512/80025455-af648d80-84ae-11ea-81c0-fce78b76673c.gif)


Signed-off-by: Ryan Bradford <rbradford@vmware.com>