### PR TITLE
Adds trackBy to datagrid rows ngFor

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -48,6 +48,9 @@
         </clr-dg-filter>
     </clr-dg-column>
 
+    <!--The trackBy in the ngFor is to inform Angular on how to track changes to clrDgRow.
+        Whereas the trackBy in ngForTrackBy is to inform Clarity on how to track changes to it's
+        items. -->
     <clr-dg-row
         *ngFor="let restItem of items; let i = index; trackBy: trackBy"
         [ngForTrackBy]="trackBy"

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -49,7 +49,7 @@
     </clr-dg-column>
 
     <clr-dg-row
-        *ngFor="let restItem of items; let i = index"
+        *ngFor="let restItem of items; let i = index; trackBy: trackBy"
         [ngForTrackBy]="trackBy"
         [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
         [clrDgItem]="restItem"

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -932,6 +932,7 @@ describe('DatagridComponent', () => {
                 [height]="height"
                 [header]="header"
                 [indicatorType]="indicatorType"
+                [trackBy]="trackBy"
             >
                 <ng-template let-record="record"> DETAILS: {{ record.name }} </ng-template>
             </vcd-datagrid>
@@ -977,6 +978,8 @@ export class HostWithDatagridComponent {
         pageSize: 5,
         pageSizeOptions: [5, 20, 50, 100],
     };
+
+    trackBy = (index, record: MockRecord) => record.name;
 
     selectionChanged(selection: MockRecord[]): void {}
 

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
@@ -30,6 +30,7 @@ export class DatagridDetailRowExampleComponent {
         {
             displayName: 'Column',
             renderer: 'value',
+            queryFieldName: 'column',
         },
     ];
 


### PR DESCRIPTION
# Description:

Adds back in a trackBy clause to ngFor and fixes the related selection bugs that it causes.

# Details:

There is a known and open bug in Clarity that using trackBy and refreshing the data breaks the select all functionality (https://github.com/vmware/clarity/issues/2265). This is due to orphaned selected items/rows in the datagrid. 

The fix to the problem is either to remove trackBy (which we tried and cannot do), use clrDgItems (which we tried and cannot do), or follow the solution in this Stackblitz linked from the above GitHub issue (https://stackblitz.com/edit/issue-2265-workaround?file=src%2Fapp%2Fapp.component.ts). This solution involves adding a detectChanges when you update the grid data and manually calling grid.rows.notifyOnChanges. Not totally ideal, but it seems to be the only way. 

# Testing:

1. Used the grid selection example and made sure selection worked for both multi and single selection.
2. Ran the example that shows a grid where pressing a button opens a modal and also refreshes the data. Showed that the modal remains open.
3. Updated the expandable row example to refresh the row on sorting and showed that the detail row stays open.
4. Used this build in the IPsec page and assured that it fixes the details-close-on-polling bug.

# Selection Gif

As you can see in the gif, when the grid data is refreshed, the clr-dg-row is not recreated and the selection maintains as it should.

![grid-selection](https://user-images.githubusercontent.com/7528512/80140346-cfab4f80-8575-11ea-84ea-c6f17fe032d7.gif)



Signed-off-by: Ryan Bradford <rbradford@vmware.com>