### PR TITLE
Add disabled functionality to number with form input control value accessor

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "peerDependencies": {
         "@angular/common": "^8.2.14",
         "@angular/core": "^8.2.14"

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -200,4 +200,21 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             expect(numberWithUnitInput.formControl.value).toEqual(98 / 100);
         });
     });
+
+    describe('setDisabledState', () => {
+        it(
+            'disables or enables comboUnitOptions and limited formControls when cpuLimit formControl is disabled or' +
+                'enabled',
+            () => {
+                numberWithUnitInput.formControl.disable();
+                numberWithUnitInput.detectChanges();
+                expect(numberWithUnitInput.valueFormControl.disabled).toBe(true);
+                expect(numberWithUnitInput.unitFormControl.disabled).toBe(true);
+                numberWithUnitInput.formControl.enable();
+                numberWithUnitInput.detectChanges();
+                expect(numberWithUnitInput.valueFormControl.enabled).toBe(true);
+                expect(numberWithUnitInput.unitFormControl.enabled).toBe(true);
+            }
+        );
+    });
 });

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -301,4 +301,17 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
     ngOnDestroy(): void {
         this.tracker.unsubscribeAll();
     }
+
+    setDisabledState(isDisabled: boolean): void {
+        if (this.formGroup) {
+            if (isDisabled) {
+                this.formGroup.get('comboUnitOptions').disable();
+                this.formGroup.get('limited').disable();
+            } else {
+                this.formGroup.get('comboUnitOptions').enable();
+                this.formGroup.get('limited').enable();
+            }
+        }
+        this.disabled = isDisabled;
+    }
 }


### PR DESCRIPTION
Disabling the formControl of number-with-form input component should disable the underlying input and select t form controls.

This functionality was missing before. Found this while integrating the component in vcd-ui.