### PR TITLE
Implemented a placeholder on the datagrid

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -8,6 +8,7 @@
     [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent-grid']"
     (clrDgRefresh)="gridStateChanged($event)"
 >
+    <clr-dg-placeholder>{{ emptyGridPlaceholder }}</clr-dg-placeholder>
     <clr-dg-action-bar *ngIf="shouldShowActionBar()">
         <div class="btn-group" *ngFor="let button of buttonConfig.globalButtons">
             <button

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -214,15 +214,6 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() gridData', () => {
-                it('shows a placeholder when no data is present', function(this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.gridData = {
-                        items: [],
-                        totalItems: 0,
-                    };
-                    this.finder.detectChanges();
-                    expect(this.clrGridWidget.hasPlaceholder).toBeTruthy();
-                });
-
                 describe('when data is refreshed unselects a row if the row is removed', () => {
                     it('in single selection', function(this: HasFinderAndGrid): void {
                         this.finder.hostComponent.selectionType = GridSelectionType.Single;
@@ -411,6 +402,38 @@ describe('DatagridComponent', () => {
                     expect(this.clrGridWidget.gridContainerClasses).toContain('fill-parent');
                     expect(this.clrGridWidget.gridHeight).toEqual('unset');
                 });
+            });
+        });
+
+        describe('@Input() emptyGridPlaceholder', () => {
+            it('does not show the placeholder while the grid is loading', function(this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.loading).toBeTruthy();
+                expect(this.clrGridWidget.placeholder).toEqual('');
+            });
+
+            it('shows the placeholder if the grid is empty', function(this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.loading).toBeTruthy();
+                this.finder.hostComponent.gridData = {
+                    items: [],
+                    totalItems: 0,
+                };
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.loading).toBeFalsy();
+                expect(this.clrGridWidget.placeholder).toEqual('Placeholder');
+            });
+
+            it('does not show the placeholder if the grid has data', function(this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.loading).toBeTruthy();
+                this.finder.hostComponent.gridData = {
+                    items: mockData,
+                    totalItems: 2,
+                };
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.loading).toBeFalsy();
+                expect(this.clrGridWidget.placeholder).toEqual('');
             });
         });
 
@@ -1047,6 +1070,7 @@ describe('DatagridComponent', () => {
                 [indicatorType]="indicatorType"
                 [trackBy]="trackBy"
                 [detailComponent]="details"
+                [emptyGridPlaceholder]="placeholder"
             >
             </vcd-datagrid>
         </div>
@@ -1088,6 +1112,8 @@ export class HostWithDatagridComponent {
     details = DatagridDetailsComponent;
 
     paginationText = 'Total Items';
+
+    placeholder = 'Placeholder';
 
     pagination: PaginationConfiguration = {
         pageSize: 5,

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -447,10 +447,9 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
 
     /**
      * When there is no data, show this message.
-     *
-     * TODO: Try to avoid showing this before initial load.
      */
-    emptyGridPlaceholder: string;
+    @Input()
+    emptyGridPlaceholder;
 
     private _pagination: PaginationConfiguration = {
         pageSize: 'Magic',

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -102,10 +102,10 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
-     * Says if the datagrid is showing a placeholder.
+     * Gives the placeholder present on the datagrid.
      */
-    get hasPlaceholder(): boolean {
-        return !!this.findElement('clr-dg-placeholder');
+    get placeholder(): string {
+        return this.getText('clr-dg-placeholder');
     }
 
     /**

--- a/projects/examples/src/components/datagrid/datagrid-loading-placeholder.example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-loading-placeholder.example.component.html
@@ -1,0 +1,2 @@
+<button (click)="setData()" class="button">Stop Loading</button>
+<vcd-datagrid [gridData]="gridData" [columns]="columns" [emptyGridPlaceholder]="'placeholder'"> </vcd-datagrid>

--- a/projects/examples/src/components/datagrid/datagrid-loading-placeholder.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-loading-placeholder.example.component.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { GridColumn, GridDataFetchResult, GridState } from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+}
+
+/**
+ * Press the first button to stop loading and show the placeholder.
+ */
+@Component({
+    selector: 'vcd-datagrid-loading-placeholder-example',
+    templateUrl: './datagrid-loading-placeholder.example.component.html',
+})
+export class DatagridLoadingPlaceholderExampleComponent {
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Column',
+            renderer: 'value',
+        },
+    ];
+
+    setData(): void {
+        this.gridData = {
+            items: [],
+            totalItems: 0,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-loading-placeholder.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-loading-placeholder.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { VcdComponentsModule } from '@vcd/ui-components';
+import { DatagridLoadingPlaceholderExampleComponent } from './datagrid-loading-placeholder.example.component';
+
+@NgModule({
+    declarations: [DatagridLoadingPlaceholderExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
+    exports: [DatagridLoadingPlaceholderExampleComponent],
+    entryComponents: [DatagridLoadingPlaceholderExampleComponent],
+})
+export class DatagridLoadingPlaceholderExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -22,6 +22,8 @@ import { DatagridHeightExampleComponent } from './datagrid-height.example.compon
 import { DatagridHeightExampleModule } from './datagrid-height.example.module';
 import { DatagridLinkExampleComponent } from './datagrid-link.example.component';
 import { DatagridLinkExampleModule } from './datagrid-link.example.module';
+import { DatagridLoadingPlaceholderExampleComponent } from './datagrid-loading-placeholder.example.component';
+import { DatagridLoadingPlaceholderExampleModule } from './datagrid-loading-placeholder.example.module';
 import { DatagridPaginationExampleComponent } from './datagrid-pagination-example.component';
 import { DatagridPagionationExampleModule } from './datagrid-pagination-example.module';
 import { DatagridRowIconExampleComponent } from './datagrid-row-icon.example.component';
@@ -110,6 +112,11 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Data row icon that reloads the row',
         },
+        {
+            component: DatagridLoadingPlaceholderExampleComponent,
+            forComponent: null,
+            title: 'Shows the loading icon + placeholder capabilities',
+        },
     ],
 });
 /**
@@ -131,6 +138,7 @@ Documentation.registerDocumentationEntry({
         DatagridCliptextExampleModule,
         DatagridActivityReporterExampleModule,
         DatagridRowIconExampleModule,
+        DatagridLoadingPlaceholderExampleModule,
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
# Description

Makes it so the emptyGridPlaceholder input is displayed on the grid placeholder.

# Testing

Added unit tests to test that the placeholder is only displayed when the grid is not loading but the data is present.
Added an example to show the loading + placeholder abilities.

# Gif:

![datagrid-placeholder](https://user-images.githubusercontent.com/7528512/81830204-c88ab800-9509-11ea-9395-249308df0678.gif)


Signed-off-by: Ryan Bradford <rbradford@vmware.com>