### PR TITLE
Use LOCALE_ID for singleton factory

### DIFF
--- a/projects/examples/src/assets/our-translations.json
+++ b/projects/examples/src/assets/our-translations.json
@@ -3,7 +3,7 @@
         "data-exporter.title": "Data Exporter!!",
         "app.title": "VCD UI Common Components"
     },
-    "gr": {
+    "de": {
         "select.all": "Wählen Sie Alle",
         "cancel": "Stornieren",
         "export": "Export",

--- a/projects/examples/src/main.ts
+++ b/projects/examples/src/main.ts
@@ -16,7 +16,7 @@ if (environment.production) {
 platformBrowserDynamic([
     {
         provide: LOCALE_ID,
-        useValue: 'en',
+        useValue: navigator.language,
     },
 ])
     .bootstrapModule(AppModule)

--- a/projects/i18n/package.json
+++ b/projects/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/i18n",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "peerDependencies": {
     "@angular/common": ">6.0.0",
     "@angular/core": ">6.0.0"

--- a/projects/i18n/src/lib/i18n.module.spec.ts
+++ b/projects/i18n/src/lib/i18n.module.spec.ts
@@ -21,14 +21,14 @@ describe('I18nModule', () => {
                 providers: [
                     {
                         provide: LOCALE_ID,
-                        useValue: 'en',
+                        useValue: 'de',
                     },
                 ],
                 declarations: [TestClassComponent],
             }).compileComponents();
 
             (TestBed.get(TranslationService) as TranslationService).registerTranslations({
-                en: {
+                de: {
                     'vcd.cc.cancel': 'cancel',
                 },
             });
@@ -49,7 +49,7 @@ describe('I18nModule', () => {
                 providers: [
                     {
                         provide: LOCALE_ID,
-                        useValue: 'en',
+                        useValue: 'de',
                     },
                     {
                         provide: route,
@@ -60,7 +60,7 @@ describe('I18nModule', () => {
             }).compileComponents();
 
             const service = TestBed.get(TranslationService) as MessageFormatTranslationService;
-            const observable = new BehaviorSubject({ en: { 'vcd.cc.cancel': 'cancel' } });
+            const observable = new BehaviorSubject({ de: { 'vcd.cc.cancel': 'cancel' } });
             spyOn((service as any).translationLoader, 'getCombinedTranslation').and.returnValue(observable);
             service.registerTranslations();
 

--- a/projects/i18n/src/lib/i18n.module.ts
+++ b/projects/i18n/src/lib/i18n.module.ts
@@ -15,9 +15,9 @@ import { TranslationService } from './service/translation-service';
 
 let singletonService: TranslationService = null;
 
-export function genericSingletonFactory(details: { locale: string }): TranslationService {
+export function genericSingletonFactory(locale: string): TranslationService {
     if (singletonService === null) {
-        singletonService = new MessageFormatTranslationService(details.locale, 'en');
+        singletonService = new MessageFormatTranslationService(locale, 'en');
     }
     return singletonService;
 }


### PR DESCRIPTION
# Description

Fixes a bug where translations were not properly used in any language other than English when the application loaded the I18nModule as forRoot. This was because we did not have the correct type of data input to the singletonFactory.

# Testing

- Changed Unit tests to test some language other than English. Verified this test failed without this change. 
- Ran VCD-UI with this new I18n module and in the dev environment switched the locale to DE. Made sure the translations were correct/present. Verified the translations displayed incorrectly without this change. 

Signed-off-by: Ryan Bradford <rbradford@vmware.com>