### PR TITLE
Support Clarity 3 detail pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2764,9 +2764,9 @@
       "optional": true
     },
     "@clr/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@clr/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-YwzW/Pj222h2o1oL00ectH9B5ir3EcmcBMxaI0KWWp4Aciy/I7NvWQ15UStM7/bAX6Qli1YGvkTj1mB8AKaYUQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@clr/core/-/core-3.1.3.tgz",
+      "integrity": "sha512-gdhgiUZiHO7j11hhdqRxLXGZLoGrWBYwU1x4rpAjUgod8HBC+OxnWa2bPvfZKs9Avf5msJWr5tUiqGu+FNv0vw==",
       "requires": {
         "@clr/city": "^1.0.0",
         "@webcomponents/custom-elements": "^1.3.1",
@@ -3622,9 +3622,9 @@
       "optional": true
     },
     "@webcomponents/shadycss": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.6.tgz",
-      "integrity": "sha512-5fFjvP0jQJZoXK6YzYeYcIDGJ5oEsdjr1L9VaYLw5yxNd4aRz4srMpwCwldeNG0A6Hvr9igbG7fCsBeiiCXd7A==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.0.tgz",
+      "integrity": "sha512-UMS+dF4DXDrcUmQqK6aLd/3mFyfGktKG/hZR6FtrsQK/INO07G0H8FxElLkuvHj0iePeZGpR7R4lWFTvX7rc9g==",
       "optional": true
     },
     "@webcomponents/webcomponentsjs": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser-dynamic": "9.1.9",
     "@angular/router": "9.1.9",
     "@clr/angular": "3.1.3",
-    "@clr/core": "3.0.0",
+    "@clr/core": "3.1.3",
     "@clr/icons": "3.1.3",
     "@clr/ui": "3.1.3",
     "@stackblitz/sdk": "1.3.0",

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.20",
+    "version": "0.0.21",
     "peerDependencies": {
         "@angular/common": ">6.0.0",
         "@angular/core": ">6.0.0",

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -97,13 +97,27 @@
             <clr-dg-row-detail *clrIfExpanded>
                 <ng-template
                     [vcdComponentRendererOutlet]="{
-                        rendererSpec: getDetailRenderSpec(restItem, i, count)
+                        rendererSpec: getDetailRowRenderSpec(restItem, i, count)
                     }"
                 >
                 </ng-template>
             </clr-dg-row-detail>
         </ng-container>
     </clr-dg-row>
+
+    <ng-container ngProjectAs="clr-dg-detail" *ngIf="detailPane">
+        <clr-dg-detail *clrIfDetail="let restItem">
+            <clr-dg-detail-header>{{ detailPane.header }}</clr-dg-detail-header>
+            <clr-dg-detail-body>
+                <ng-template
+                    [vcdComponentRendererOutlet]="{
+                        rendererSpec: getDetailPaneRenderSpec(restItem)
+                    }"
+                >
+                </ng-template>
+            </clr-dg-detail-body>
+        </clr-dg-detail>
+    </ng-container>
 
     <clr-dg-footer>
         <clr-dg-pagination

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -255,6 +255,11 @@ describe('DatagridComponent', () => {
 
             describe('@Input() pagination', () => {
                 describe('pageSize', () => {
+                    it('can set the page size before AfterViewInit', function(this: HasFinderAndGrid): void {
+                        this.finder.detectChanges();
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 5 of 150 items');
+                    });
+
                     it('finds the most rows that can fit in the set height with magic pagination', function(this: HasFinderAndGrid): void {
                         this.finder.hostComponent.parentHeight = '2000px';
                         this.finder.detectChanges();
@@ -372,7 +377,7 @@ describe('DatagridComponent', () => {
 
             describe('@Input() paginationCallback', () => {
                 it('displays pagination callback information on page one', function(this: HasFinderAndGrid): void {
-                    expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 15 of 150 items');
+                    expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 5 of 150 items');
                 });
             });
 
@@ -582,7 +587,7 @@ describe('DatagridComponent', () => {
                         name: 'a',
                         reverse: false,
                     },
-                    pagination: { pageNumber: 1, itemsPerPage: 15 },
+                    pagination: { pageNumber: 1, itemsPerPage: 5 },
                 });
                 this.clrGridWidget.sortColumn(0);
                 expect(refreshMethod).toHaveBeenCalledWith({
@@ -590,7 +595,7 @@ describe('DatagridComponent', () => {
                         name: 'a',
                         reverse: true,
                     },
-                    pagination: { pageNumber: 1, itemsPerPage: 15 },
+                    pagination: { pageNumber: 1, itemsPerPage: 5 },
                 });
             });
 
@@ -606,7 +611,7 @@ describe('DatagridComponent', () => {
                 expect(refreshMethod).toHaveBeenCalledWith({
                     pagination: {
                         pageNumber: 2,
-                        itemsPerPage: 15,
+                        itemsPerPage: 5,
                     },
                 });
             });
@@ -616,7 +621,7 @@ describe('DatagridComponent', () => {
                 this.clrGridWidget.nextPage();
                 this.clrGridWidget.sortColumn(0);
                 expect(refreshMethod).toHaveBeenCalledWith({
-                    pagination: { pageNumber: 1, itemsPerPage: 15 },
+                    pagination: { pageNumber: 1, itemsPerPage: 5 },
                     sortColumn: { name: 'a', reverse: false },
                 });
             });

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -354,6 +354,18 @@ describe('DatagridComponent', () => {
                     });
                 });
 
+                describe('pageSizeOptions', () => {
+                    it('allows the user to input undefined', function(this: HasFinderAndGrid): void {
+                        this.finder.hostComponent.pagination = {
+                            ...this.finder.hostComponent.pagination,
+                            shouldShowPageSizeSelector: true,
+                            pageSizeOptions: undefined,
+                        };
+                        this.finder.detectChanges();
+                        expect(this.clrGridWidget.getPaginationSizeSelectorText()).toEqual('Total Items5');
+                    });
+                });
+
                 describe('shouldShowPageSizeSelector', () => {
                     it('hides the dropdown when set to false', function(this: HasFinderAndGrid): void {
                         this.finder.hostComponent.pagination = {
@@ -761,6 +773,36 @@ describe('DatagridComponent', () => {
                         position: ContextualButtonPosition.TOP,
                     };
                     this.finder.detectChanges();
+                });
+
+                it('allows the user to not set featured', function(this: HasFinderAndGrid): void {
+                    this.finder.hostComponent.buttonConfig.contextualButtonConfig = {
+                        buttons: [
+                            {
+                                label: 'Add',
+                                isActive: (row: MockRecord[]) => true,
+                                handler: () => {},
+                                class: 'a',
+                                icon: 'play',
+                            },
+                            {
+                                label: 'Remove',
+                                isActive: () => false,
+                                handler: () => {},
+                                class: 'b',
+                                icon: 'pause',
+                            },
+                            {
+                                label: 'Other',
+                                isActive: (row: MockRecord[]) => row.length && row[0].name === 'Person 1',
+                                handler: () => {},
+                                class: 'c',
+                                icon: 'pause',
+                            },
+                        ],
+                        position: ContextualButtonPosition.TOP,
+                    };
+                    expect(this.finder.hostComponent.grid.featuredButtons.size).toEqual(3);
                 });
 
                 it('throws an error if a featured button cannot be found', function(this: HasFinderAndGrid): void {

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -55,7 +55,7 @@ describe('DatagridComponent', () => {
                 },
                 ActivityPromiseResolver,
             ],
-            declarations: [HostWithDatagridComponent, DatagridDetailsComponent],
+            declarations: [HostWithDatagridComponent, DatagridDetailsComponent, DatagridDetailsPaneComponent],
         }).compileComponents();
 
         this.finder = new WidgetFinder(HostWithDatagridComponent);
@@ -518,12 +518,31 @@ describe('DatagridComponent', () => {
                         renderer: 'name',
                     },
                 ];
+                this.finder.hostComponent.detailPane = undefined;
                 this.finder.detectChanges();
             });
 
             it('opens one detail pane when you click the button', function(this: HasFinderAndGrid): void {
-                this.clrGridWidget.clickDetailsButton(0);
-                expect(this.clrGridWidget.getAllDetailContents().length).toEqual(1);
+                this.clrGridWidget.clickDetailRowButton(0);
+                expect(this.clrGridWidget.getAllDetailRowContents().length).toEqual(1);
+            });
+        });
+
+        describe('@Input() detailPane', () => {
+            beforeEach(function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.columns = [
+                    {
+                        displayName: 'Column',
+                        renderer: 'name',
+                    },
+                ];
+                this.finder.detectChanges();
+            });
+
+            it('opens one detail pane when you click the button', function(this: HasFinderAndGrid): void {
+                this.clrGridWidget.clickDetailPaneButton(0);
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.getAllDetailPaneContents().length).toEqual(1);
             });
         });
 
@@ -1079,6 +1098,7 @@ describe('DatagridComponent', () => {
                 [trackBy]="trackBy"
                 [detailComponent]="details"
                 [emptyGridPlaceholder]="placeholder"
+                [detailPane]="detailPane"
             >
             </vcd-datagrid>
         </div>
@@ -1119,6 +1139,11 @@ export class HostWithDatagridComponent {
 
     details = DatagridDetailsComponent;
 
+    detailPane = {
+        header: 'Pane!',
+        component: DatagridDetailsPaneComponent,
+    };
+
     paginationText = 'Total Items';
 
     placeholder = 'Placeholder';
@@ -1154,4 +1179,13 @@ export class HostWithDatagridComponent {
 })
 class DatagridDetailsComponent {
     constructor(public loadingListener: LoadingListener) {}
+}
+
+@Component({
+    template: `
+        DETAILS
+    `,
+})
+class DatagridDetailsPaneComponent {
+    constructor() {}
 }

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -137,7 +137,7 @@ export interface PaginationConfiguration {
     /**
      * Available page size options in the dropdown
      */
-    pageSizeOptions: number[];
+    pageSizeOptions?: number[];
 
     /**
      * Number of items to be displayed on one page. As a result, the server will return a set of pages with the defined
@@ -355,6 +355,9 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
      */
     @Input() set pagination(pagination: PaginationConfiguration) {
         this._pagination = { ...pagination };
+        if (this._pagination.pageSizeOptions === undefined) {
+            this._pagination.pageSizeOptions = [];
+        }
         if (this._pagination.shouldShowPageSizeSelector === undefined) {
             this._pagination.shouldShowPageSizeSelector = false;
         }
@@ -851,7 +854,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
         if (typeof this.pagination.pageSize === 'number') {
             return this.pagination.pageSize;
         }
-        if (this.pagination.pageSize === 'Magic') {
+        if (this.pagination.pageSize === 'Magic' && this.viewInitted) {
             return this.calculatePageSize();
         }
         return DEFAULT_SIZE;
@@ -901,10 +904,8 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
      * Updates the pagination information by recalculating pageSize if needed.
      */
     private updatePagination(): void {
-        if (this.viewInitted) {
-            this.pageSize = this.getPageSize();
-            this.pageSizeOptions = this.getPageSizeOptions();
-        }
+        this.pageSize = this.getPageSize();
+        this.pageSizeOptions = this.getPageSizeOptions();
     }
 
     /**

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -182,6 +182,30 @@ export interface DetailRowConfig<R> {
 }
 
 /**
+ * The configuration object that is passed to the detail pane component.
+ */
+export interface DetailPaneConfig<R> {
+    /**
+     * The record that this detail pane should render.
+     */
+    record: R;
+}
+
+/**
+ * The configuration objet used to create the detail pane on the datagrid.
+ */
+export interface DetailPane<R> {
+    /**
+     * The header that goes on top of this detail pane.
+     */
+    header: string;
+    /**
+     * The contents that go within this detail pane.
+     */
+    component: ComponentRendererConstructor<DetailPaneConfig<R>>;
+}
+
+/**
  * The current state of various features of the grid like filtering, sorting, pagination. This object is emitted as
  * part of the event {@link DatagridComponent.gridRefresh}. The handler then used this object to construct a query.
  */
@@ -410,6 +434,13 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
      * @param R The type of record that this detail component will display.
      */
     @Input() detailComponent: ComponentRendererConstructor<DetailRowConfig<R>>;
+
+    /**
+     * A detail pane that will be displayed when a user selects to expand a row.
+     *
+     * @param R The type of record that this detail pane will display.
+     */
+    @Input() detailPane: DetailPane<R>;
     private _selectionType: GridSelectionType = GridSelectionType.None;
 
     /**
@@ -693,10 +724,17 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
      * Gives the render spec to create the detail row for the row with the given record, at the given index, and
      * in a datagrid with the given count of total items.
      */
-    getDetailRenderSpec(record: R, index: number, count: number): ComponentRendererSpec<DetailRowConfig<R>> {
+    getDetailRowRenderSpec(record: R, index: number, count: number): ComponentRendererSpec<DetailRowConfig<R>> {
         return {
             type: this.detailComponent,
             config: { record, index, count },
+        };
+    }
+
+    getDetailPaneRenderSpec(record: R): ComponentRendererSpec<DetailPaneConfig<R>> {
+        return {
+            type: this.detailPane.component,
+            config: { record },
         };
     }
 

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -133,15 +133,29 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     /**
      * Returns the native element contents within all the detail pane open.
      */
-    getAllDetailContents(): string[] {
+    getAllDetailRowContents(): string[] {
         return this.findElements('clr-dg-row-detail').map(detail => detail.nativeElement);
     }
 
     /**
-     * Clicks the given details button.
+     * Returns the native element contents within all the detail pane open.
      */
-    clickDetailsButton(row: number): void {
-        this.detailsButtons[row].nativeElement.click();
+    getAllDetailPaneContents(): string[] {
+        return this.findElements('.datagrid-detail-pane-content').map(detail => detail.nativeElement);
+    }
+
+    /**
+     * Clicks the given detail row button.
+     */
+    clickDetailRowButton(row: number): void {
+        this.detailRowButtons[row].nativeElement.click();
+    }
+
+    /**
+     * Clicks the given detail pane button.
+     */
+    clickDetailPaneButton(row: number): void {
+        this.detailPaneButtons[row].nativeElement.click();
     }
 
     /**
@@ -290,8 +304,12 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
         return this.findElements(COLUMN_CSS_SELECTOR);
     }
 
-    private get detailsButtons(): DebugElement[] {
+    private get detailRowButtons(): DebugElement[] {
         return this.findElements('.datagrid-expandable-caret-button');
+    }
+
+    private get detailPaneButtons(): DebugElement[] {
+        return this.findElements('.datagrid-detail-caret-button');
     }
 
     private openFilter(): void {

--- a/projects/examples/src/components/datagrid/datagrid-detail-pane.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-pane.example.component.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, Input, OnInit } from '@angular/core';
+import { ComponentRenderer, DetailPaneConfig, GridColumn, GridDataFetchResult, GridState } from '@vcd/ui-components';
+
+interface Data {
+    value: string;
+}
+
+/**
+ * Shows an expandable detail pane next to the rows.
+ */
+@Component({
+    selector: 'vcd-datagrid-detail-pane-example',
+    template: `
+        <p>
+            The datagrid allows the client to pass in an arbitrary component to be rendered as the expandable detail
+            pane for a row. This is passed in as <code>[detailPane]</code>
+        </p>
+        <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns" [detailPane]="pane">
+        </vcd-datagrid>
+    `,
+})
+export class DatagridDetailPaneExampleComponent {
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    pane = {
+        header: 'Pane!',
+        component: DatagridDetailPaneSubComponent,
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Column',
+            renderer: 'value',
+            queryFieldName: 'column',
+        },
+    ];
+
+    refresh(eventData: GridState<Data>): void {
+        this.gridData = {
+            items: [{ value: 'a' }, { value: 'b' }],
+            totalItems: 2,
+        };
+    }
+}
+
+@Component({
+    selector: 'vcd-datagrid-detail-pane-sub-example',
+    template: `
+        <div>
+            <dl>
+                <dt>Record</dt>
+                <dd>{{ JSON.stringify(config.record) }}</dd>
+            </dl>
+        </div>
+    `,
+})
+export class DatagridDetailPaneSubComponent implements ComponentRenderer<DetailPaneConfig<Data>> {
+    JSON = JSON;
+
+    @Input() config: DetailPaneConfig<Data>;
+}

--- a/projects/examples/src/components/datagrid/datagrid-detail-pane.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-pane.example.module.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { VcdComponentsModule } from '@vcd/ui-components';
+import {
+    DatagridDetailPaneExampleComponent,
+    DatagridDetailPaneSubComponent,
+} from './datagrid-detail-pane.example.component';
+
+@NgModule({
+    declarations: [DatagridDetailPaneExampleComponent, DatagridDetailPaneSubComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
+    exports: [DatagridDetailPaneExampleComponent],
+    entryComponents: [
+        DatagridDetailPaneExampleComponent,
+        DatagridDetailPaneSubComponent,
+        DatagridDetailPaneSubComponent,
+    ],
+})
+export class DatagridDetailPaneExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -12,6 +12,8 @@ import { DatagridCliptextExampleComponent } from './datagrid-cliptext.example.co
 import { DatagridCliptextExampleModule } from './datagrid-cliptext.example.module';
 import { DatagridCssClassesExampleComponent } from './datagrid-css-classes.example.component';
 import { DatagridCssClassesExampleModule } from './datagrid-css-classes.example.module';
+import { DatagridDetailPaneExampleComponent } from './datagrid-detail-pane.example.component';
+import { DatagridDetailPaneExampleModule } from './datagrid-detail-pane.example.module';
 import { DatagridDetailRowExampleComponent } from './datagrid-detail-row.example.component';
 import { DatagridDetailRowExampleModule } from './datagrid-detail-row.example.module';
 import { DatagridFilterExampleComponent } from './datagrid-filter.example.component';
@@ -117,6 +119,11 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Shows the loading icon + placeholder capabilities',
         },
+        {
+            component: DatagridDetailPaneExampleComponent,
+            forComponent: null,
+            title: 'A Clarity 3 Detail Pane Example',
+        },
     ],
 });
 /**
@@ -139,6 +146,7 @@ Documentation.registerDocumentationEntry({
         DatagridActivityReporterExampleModule,
         DatagridRowIconExampleModule,
         DatagridLoadingPlaceholderExampleModule,
+        DatagridDetailPaneExampleModule,
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
# Description

1. Adds support for the detail pane in Clarity 3.
2. Fixes a bug reported by Bryan where if we set the `[pagination]` before the grid is rendered, it is overriden and reset to the default. This results in pagination mostly not working.

# Testing

1. Added an example to show that the detail pane functions in the datagrid.
2. Added a test to make sure you can click the expand button to show the content.

# Gif

![detail-pane](https://user-images.githubusercontent.com/7528512/83910622-e201d700-a738-11ea-9fb1-730cd0179452.gif)


Signed-off-by: Ryan Bradford <rbradford@vmware.com>