### PR TITLE
Fix selectedOption returning undefined because of mismatching primitives

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "peerDependencies": {
         "@angular/common": ">6.0.0",
         "@angular/core": ">6.0.0",

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -50,11 +50,11 @@ describe('FormSelectComponent', () => {
         });
         it('is of number type, when the select formControl is set with same number value', () => {
             selectInput.component.formControl.setValue(4);
-            expect(hostComponent.selectInputComponent.selectedOption).toEqual(optionWithValueAsNumber);
+            expect(hostComponent.selectInputComponent.selectedOption).toEqual(getOptionWithValueAsNumber());
         });
         it('is of number type, when it is selected', () => {
             selectInput.select(hostComponent.options.length - 1);
-            expect(hostComponent.selectInputComponent.selectedOption).toEqual(optionWithValueAsNumber);
+            expect(hostComponent.selectInputComponent.selectedOption).toEqual(getOptionWithValueAsNumber());
         });
     });
 
@@ -102,7 +102,7 @@ class TestHostComponent {
             value: 'two',
         },
         {
-            ...optionWithValueAsNumber,
+            ...getOptionWithValueAsNumber(),
         },
     ];
 
@@ -113,7 +113,6 @@ class TestHostComponent {
     }
 }
 
-const optionWithValueAsNumber: SelectOption = {
-    display: 'option4',
-    value: 4,
-};
+function getOptionWithValueAsNumber(): SelectOption {
+    return { display: 'option4', value: 4 };
+}

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -42,11 +42,19 @@ describe('FormSelectComponent', () => {
         selectInput = finder.find({ woConstructor: VcdFormSelectWidgetObject });
     });
 
-    describe('selectedOption', () => {
-        it('returns the option whose value matches with form control value', () => {
+    describe('selectedOption returns the option whose value', () => {
+        it('matches with form control value', () => {
             expect(hostComponent.selectInputComponent.selectedOption.value).toEqual(
                 hostComponent.selectInputComponent.formControl.value
             );
+        });
+        it('is of number type, when the select formControl is set with same number value', () => {
+            selectInput.component.formControl.setValue(4);
+            expect(hostComponent.selectInputComponent.selectedOption).toEqual(optionWithValueAsNumber);
+        });
+        it('is of number type, when it is selected', () => {
+            selectInput.select(hostComponent.options.length - 1);
+            expect(hostComponent.selectInputComponent.selectedOption).toEqual(optionWithValueAsNumber);
         });
     });
 
@@ -94,8 +102,7 @@ class TestHostComponent {
             value: 'two',
         },
         {
-            display: 'option3',
-            value: 'three',
+            ...optionWithValueAsNumber,
         },
     ];
 
@@ -105,3 +112,8 @@ class TestHostComponent {
         });
     }
 }
+
+const optionWithValueAsNumber: SelectOption = {
+    display: 'option4',
+    value: 4,
+};

--- a/projects/components/src/form/form-select/form-select.component.ts
+++ b/projects/components/src/form/form-select/form-select.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, ElementRef, Input, Optional, Self, ViewChild } from '@angular/core';
+import { Component, Input, Optional, Self } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { SelectOption } from '../../common/interfaces/select-option';
 import { BaseFormControl } from '../base-form-control';
@@ -30,6 +30,9 @@ export class FormSelectComponent extends BaseFormControl {
         if (!this.options) {
             return undefined;
         }
-        return this.options.find(option => option.value === this.formControl.value);
+        // option.value is string | number. Also, formControl.value is string when the dropdown value is manually chosen
+        // from the view. It can also be a number when the formControl's value is set from outside to be number. So,
+        // we convert both to strings before doing a strict equality.
+        return this.options.find(option => option.value.toString() === this.formControl.value.toString());
     }
 }

--- a/projects/components/src/form/form-select/form-select.component.ts
+++ b/projects/components/src/form/form-select/form-select.component.ts
@@ -30,9 +30,7 @@ export class FormSelectComponent extends BaseFormControl {
         if (!this.options) {
             return undefined;
         }
-        // option.value is string | number. Also, formControl.value is string when the dropdown value is manually chosen
-        // from the view. It can also be a number when the formControl's value is set from outside to be number. So,
-        // we convert both to strings before doing a strict equality.
+        // option.value and formControl.value can be of type number or string
         return this.options.find(option => option.value.toString() === this.formControl.value.toString());
     }
 }


### PR DESCRIPTION
The selectedOption of FormSelect component is returning undefined when there is a mismatch between string and number types of values between option.value and formControl.value even though the values are equal.

For Example: `this.options.find(option => option.value === this.formControl.value);` resulting in...
1000 === "1000" or "1000" === 1000