### PR TITLE
Vcd formly module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2965,6 +2965,14 @@
         }
       }
     },
+    "@ngx-formly/core": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ngx-formly/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-Ki4pL7B+DbJ7xynm2QmP7Dp+Ax2OjpuAEF0XEyJZtEsUAgoOyRnOJormBhIVbAr9ycAUE9FVSp5kv3RpJeeP3w==",
+      "requires": {
+        "tslib": "^1.7.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -4689,7 +4697,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -8361,8 +8368,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8380,13 +8386,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8399,18 +8403,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8513,8 +8514,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8524,7 +8524,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8537,20 +8536,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8567,7 +8563,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8640,8 +8635,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8651,7 +8645,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8727,8 +8720,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8758,7 +8750,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8776,7 +8767,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8815,13 +8805,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -9239,8 +9227,7 @@
     "hoek": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "optional": true
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
     },
     "hosted-git-info": {
       "version": "2.8.5",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@vmw/ng-live-docs": "0.0.6",
     "@vmw/plain-js-live-docs": "0.0.2",
     "@webcomponents/webcomponentsjs": "2.0.0",
+    "@ngx-formly/core": "5.6.1",
     "angular-cli-ghpages": "0.6.2",
     "classlist.js": "1.1.20150312",
     "codecov.io": "0.1.6",

--- a/projects/components/src/components.module.ts
+++ b/projects/components/src/components.module.ts
@@ -10,6 +10,7 @@ import { VcdLoadingIndicatorModule } from './common/loading/loading-indicator.mo
 import { VcdDataExporterModule } from './data-exporter/data-exporter.module';
 import { VcdDatagridModule } from './datagrid/datagrid.module';
 import { VcdFormModule } from './form/form.module';
+import { VcdFormlyModule } from './formly/vcd/index';
 import { ShowClippedTextDirectiveModule } from './lib/directives/show-clipped-text.directive.module';
 
 @NgModule({
@@ -21,6 +22,7 @@ import { ShowClippedTextDirectiveModule } from './lib/directives/show-clipped-te
         VcdLoadingIndicatorModule,
         VcdActivityReporterModule,
         VcdFormModule,
+        VcdFormlyModule,
     ],
 })
 export class VcdComponentsModule {}

--- a/projects/components/src/form/validators.ts
+++ b/projects/components/src/form/validators.ts
@@ -29,7 +29,7 @@ export class FormValidators {
      * Also checks that the value is numeric
      * Accepts a translation key to display proper error messaging
      */
-    static isNumberInRange(min: number, max: number, translationKey: string): ValidatorFn {
+    static isNumberInRange(min: number, max: number, translationKey = 'vcd.cc.warning.numRange'): ValidatorFn {
         const res = FormValidators.createNullSafeValidator((control: any) => {
             const isNumber = !isNaN(parseFloat(control.value)) && isFinite(control.value);
             return control.value >= min && control.value <= max && isNumber ? null : { [translationKey]: true };

--- a/projects/components/src/formly/vcd/index.ts
+++ b/projects/components/src/formly/vcd/index.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+export * from './vcd-formly.module';
+export * from './vcd-formly.config';
+export * from './inputs/input/formly-input.component';
+export * from './inputs/select/formly-select.component';
+export * from './inputs/number-with-unit-input/formly-number-with-unit-input.component';

--- a/projects/components/src/formly/vcd/inputs/input/formly-input.component.spec.ts
+++ b/projects/components/src/formly/vcd/inputs/input/formly-input.component.spec.ts
@@ -1,0 +1,109 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormlyFieldConfig, FormlyForm, FormlyModule } from '@ngx-formly/core';
+import { MockTranslationService, TranslationService } from '@vcd/i18n';
+import { CommonUtil, WidgetFinder, WidgetObject } from '../../../../utils';
+import {
+    VCD_FORMLY_CONFIG,
+    VCD_FORMLY_INPUT_TYPES,
+    VcdFormlyFieldConfig,
+    VcdFormlyTemplateOptions,
+} from '../../vcd-formly.config';
+import { VcdFormlyModule } from '../../vcd-formly.module';
+import { FormlyInputComponent } from './formly-input.component';
+
+export class VcdFormlyInputWidgetObject extends WidgetObject<FormlyInputComponent> {
+    static tagName = `vcd-formly-input`;
+}
+
+describe('vcd-formly-input', () => {
+    let testHostComponent: TestHostComponent;
+    let finder: WidgetFinder<TestHostComponent>;
+    let vcdFormlyInputWidgetObject: VcdFormlyInputWidgetObject;
+    let vcdFormlyInputComponent: FormlyInputComponent;
+    let templateOptions: VcdFormlyTemplateOptions;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [FormlyModule.forRoot(), VcdFormlyModule],
+            declarations: [TestHostComponent],
+            providers: [
+                {
+                    provide: TranslationService,
+                    useValue: new MockTranslationService(),
+                },
+            ],
+        }).compileComponents();
+
+        finder = new WidgetFinder(TestHostComponent);
+        finder.detectChanges();
+
+        testHostComponent = finder.hostComponent;
+        vcdFormlyInputWidgetObject = finder.find(VcdFormlyInputWidgetObject);
+        vcdFormlyInputComponent = vcdFormlyInputWidgetObject.component;
+    });
+    beforeEach(() => {
+        templateOptions = CommonUtil.getNewObj(VCD_FORM_INPUT_TEMPLATE_OPTIONS);
+    });
+    it('getters return correct values for passing them as inputs to vcd-form-input', () => {
+        expect(vcdFormlyInputComponent.min).toEqual(Number.MIN_SAFE_INTEGER);
+        expect(vcdFormlyInputComponent.max).toEqual(Number.MAX_SAFE_INTEGER);
+        expect(vcdFormlyInputComponent.type).toEqual('text');
+        expect(vcdFormlyInputComponent.hintPosition).toEqual('top-left');
+        expect(vcdFormlyInputComponent.errorLabels).toEqual([]);
+        templateOptions.min = 1;
+        templateOptions.max = 10;
+        testHostComponent.fields[0].templateOptions = CommonUtil.getNewObj(templateOptions);
+        finder.detectChanges();
+        expect(vcdFormlyInputComponent.min).toEqual(templateOptions.min);
+        expect(vcdFormlyInputComponent.max).toEqual(templateOptions.max);
+    });
+    it('onEnterClicked and onEscapeClicked call the corresponding methods on templateOptions to', () => {
+        expect(vcdFormlyInputComponent.onEnterClicked()).toEqual(
+            templateOptions.onEnterClicked(vcdFormlyInputComponent.field)
+        );
+
+        expect(vcdFormlyInputComponent.onEscapeClicked()).toEqual(
+            templateOptions.onEscapeClicked(vcdFormlyInputComponent.field)
+        );
+    });
+});
+
+@Component({
+    template: `
+        <div class="clr-form-horizontal">
+            <formly-form [model]="model" [fields]="fields"></formly-form>
+        </div>
+    `,
+})
+export class TestHostComponent {
+    @ViewChild(FormlyForm) formlyForm: FormlyForm;
+
+    model: any = {};
+    fields: VcdFormlyFieldConfig[] = [
+        {
+            key: 'formlyInput',
+            type: VCD_FORMLY_INPUT_TYPES.input,
+            templateOptions: CommonUtil.getNewObj(VCD_FORM_INPUT_TEMPLATE_OPTIONS),
+        },
+    ];
+}
+
+const VCD_FORM_INPUT_TEMPLATE_OPTIONS = {
+    label: 'Hint position',
+    placeholder: 'Enter position of the hint',
+    required: true,
+    showAsterisk: '',
+    onEnterClicked: (field: FormlyFieldConfig) => {
+        return `Enter clicked on ${field.key}`;
+    },
+    onEscapeClicked: (field: FormlyFieldConfig) => {
+        return `Escape clicked on ${field.key}`;
+    },
+    hint: 'blah',
+};

--- a/projects/components/src/formly/vcd/inputs/input/formly-input.component.ts
+++ b/projects/components/src/formly/vcd/inputs/input/formly-input.component.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+import { FormlyAttributeEvent } from '@ngx-formly/core/lib/components/formly.field.config';
+
+@Component({
+    selector: 'vcd-formly-input',
+    template: `
+        <vcd-form-input
+            [label]="to.label"
+            [description]="to.description"
+            [showAsterisk]="to.required"
+            [isReadOnly]="to.isReadOnly"
+            [errorLabels]="errorLabels"
+            [placeholder]="to.placeholder"
+            [min]="min"
+            [max]="max"
+            [type]="type"
+            [formControl]="formControl"
+            [size]="to.size"
+            [maxlength]="to.maxlength"
+            [hintPosition]="hintPosition"
+            [hint]="to.hint"
+            (enterClicked)="onEnterClicked()"
+            (escapeClicked)="onEscapeClicked()"
+        >
+        </vcd-form-input>
+    `,
+})
+export class FormlyInputComponent extends FieldType {
+    /**
+     * {@link FormInputComponent.min}
+     */
+    get min(): number {
+        return this.to.min || Number.MIN_SAFE_INTEGER;
+    }
+    /**
+     * {@link FormInputComponent.max}
+     */
+    get max(): number {
+        return this.to.max || Number.MAX_SAFE_INTEGER;
+    }
+    /**
+     * {@link FormInputComponent.type}
+     */
+    get type(): string {
+        return this.to.type || 'text';
+    }
+    /**
+     * {@link FormInputComponent.hintPosition}
+     */
+    get hintPosition(): string {
+        return this.to.hintPosition || 'top-left';
+    }
+    /**
+     * {@link FormInputComponent.errorLabels}
+     */
+    get errorLabels(): string[] {
+        return this.to.errorLabels || [];
+    }
+    /**
+     * {@link FormInputComponent.enterClicked}
+     */
+    onEnterClicked(): any {
+        if (this.to.onEnterClicked) {
+            return (this.to.onEnterClicked as FormlyAttributeEvent)(this.field);
+        }
+    }
+    /**
+     * {@link FormInputComponent.escapeClicked}
+     */
+    onEscapeClicked(): any {
+        if (this.to.onEscapeClicked) {
+            return (this.to.onEscapeClicked as FormlyAttributeEvent)(this.field);
+        }
+    }
+}

--- a/projects/components/src/formly/vcd/inputs/number-with-unit-input/formly-number-with-unit-input.component.spec.ts
+++ b/projects/components/src/formly/vcd/inputs/number-with-unit-input/formly-number-with-unit-input.component.spec.ts
@@ -1,0 +1,91 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormlyForm, FormlyModule } from '@ngx-formly/core';
+import { MockTranslationService, TranslationService } from '@vcd/i18n';
+import { UNLIMITED } from '../../../../form/number-with-unit-input/number-with-unit-form-input.component';
+import { Bytes, CommonUtil, WidgetFinder, WidgetObject } from '../../../../utils';
+import { VCD_FORMLY_INPUT_TYPES, VcdFormlyFieldConfig, VcdFormlyTemplateOptions } from '../../vcd-formly.config';
+import { VcdFormlyModule } from '../../vcd-formly.module';
+import { FormlyNumberWithUnitInputComponent } from './formly-number-with-unit-input.component';
+
+export class VcdFormlyNumberWithUnitInputWidgetObject extends WidgetObject<FormlyNumberWithUnitInputComponent> {
+    static tagName = `vcd-formly-number-with-unit-input`;
+}
+
+describe('FormlyNumberWithUnitInputComponent', () => {
+    let testHostComponent: TestHostComponent;
+    let finder: WidgetFinder<TestHostComponent>;
+    let vcdFormlyNumberWithUnitInputWidgetObject: VcdFormlyNumberWithUnitInputWidgetObject;
+    let formlyNumberWithUnitInputComponent: FormlyNumberWithUnitInputComponent;
+    let templateOptions: VcdFormlyTemplateOptions;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [FormlyModule.forRoot(), VcdFormlyModule],
+            declarations: [TestHostComponent],
+            providers: [
+                {
+                    provide: TranslationService,
+                    useValue: new MockTranslationService(),
+                },
+            ],
+        }).compileComponents();
+
+        finder = new WidgetFinder(TestHostComponent);
+        finder.detectChanges();
+
+        testHostComponent = finder.hostComponent;
+        vcdFormlyNumberWithUnitInputWidgetObject = finder.find(VcdFormlyNumberWithUnitInputWidgetObject);
+        formlyNumberWithUnitInputComponent = vcdFormlyNumberWithUnitInputWidgetObject.component;
+    });
+    beforeEach(() => {
+        templateOptions = CommonUtil.getNewObj(VCD_NUMBER_WITH_UNIT_INPUT_TEMPLATE_OPTIONS);
+    });
+    it('getters return correct values for passing them as inputs to vcd-number-with-unit-form-input', () => {
+        expect(formlyNumberWithUnitInputComponent.min).toEqual(UNLIMITED);
+        expect(formlyNumberWithUnitInputComponent.max).toEqual(Number.MAX_SAFE_INTEGER);
+        expect(formlyNumberWithUnitInputComponent.hintPosition).toEqual('top-left');
+        expect(formlyNumberWithUnitInputComponent.errorLabels).toEqual([]);
+        expect(formlyNumberWithUnitInputComponent.showUnlimitedOption).toEqual(true);
+        expect(formlyNumberWithUnitInputComponent.unlimitedValue).toEqual(UNLIMITED);
+        templateOptions.showUnlimitedOption = false;
+        templateOptions.unlimitedValue = 1000;
+        testHostComponent.fields[0].templateOptions = CommonUtil.getNewObj(templateOptions);
+        finder.detectChanges();
+        expect(formlyNumberWithUnitInputComponent.showUnlimitedOption).toEqual(false);
+        expect(formlyNumberWithUnitInputComponent.unlimitedValue).toEqual(1000);
+    });
+});
+
+@Component({
+    template: `
+        <div class="clr-form-horizontal">
+            <formly-form [model]="model" [fields]="fields"></formly-form>
+        </div>
+    `,
+})
+export class TestHostComponent {
+    @ViewChild(FormlyForm) formlyForm: FormlyForm;
+
+    model: any = {};
+    fields: VcdFormlyFieldConfig[] = [
+        {
+            key: 'formlyInput4',
+            type: VCD_FORMLY_INPUT_TYPES.number_with_unit_input,
+            templateOptions: CommonUtil.getNewObj(VCD_NUMBER_WITH_UNIT_INPUT_TEMPLATE_OPTIONS),
+        },
+    ];
+}
+
+const VCD_NUMBER_WITH_UNIT_INPUT_TEMPLATE_OPTIONS = {
+    label: 'Number with unit input',
+    required: true,
+    showAsterisk: true,
+    inputValueUnit: Bytes.MB,
+    unitOptions: Bytes.types,
+};

--- a/projects/components/src/formly/vcd/inputs/number-with-unit-input/formly-number-with-unit-input.component.ts
+++ b/projects/components/src/formly/vcd/inputs/number-with-unit-input/formly-number-with-unit-input.component.ts
@@ -1,0 +1,75 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+import { UNLIMITED } from '../../../../form';
+
+@Component({
+    selector: 'vcd-formly-number-with-unit-input',
+    template: `
+        <vcd-number-with-unit-form-input
+            [label]="to.label"
+            [description]="to.description"
+            [showAsterisk]="to.required"
+            [isReadOnly]="to.isReadOnly"
+            [errorLabels]="errorLabels"
+            [placeholder]="to.placeholder"
+            [min]="min"
+            [max]="max"
+            [formControl]="formControl"
+            [size]="to.size"
+            [maxlength]="to.maxlength"
+            [hintPosition]="hintPosition"
+            [hint]="to.hint"
+            [showUnlimitedOption]="showUnlimitedOption"
+            [unlimitedValue]="unlimitedValue"
+            [inputValueUnit]="to.inputValueUnit"
+            [unitOptions]="to.unitOptions"
+        >
+        </vcd-number-with-unit-form-input>
+    `,
+})
+export class FormlyNumberWithUnitInputComponent extends FieldType {
+    /**
+     * {@link NumberWithUnitFormInputComponent.errorLabels}
+     */
+    get errorLabels(): string[] {
+        return this.to.errorLabels || [];
+    }
+    /**
+     * {@link NumberWithUnitFormInputComponent.min}
+     */
+    get min(): number {
+        return this.to.min || UNLIMITED;
+    }
+    /**
+     * {@link NumberWithUnitFormInputComponent.max}
+     */
+    get max(): number {
+        return this.to.max || Number.MAX_SAFE_INTEGER;
+    }
+    /**
+     * {@link NumberWithUnitFormInputComponent.hintPosition}
+     */
+    get hintPosition(): string {
+        return this.to.hintPosition || 'top-left';
+    }
+    /**
+     * {@link NumberWithUnitFormInputComponent.showUnlimitedOption}
+     */
+    get showUnlimitedOption(): boolean {
+        if (typeof this.to.showUnlimitedOption !== 'boolean') {
+            return true;
+        }
+        return this.to.showUnlimitedOption;
+    }
+    /**
+     * {@link NumberWithUnitFormInputComponent.unlimitedValue}
+     */
+    get unlimitedValue(): number {
+        return this.to.unlimitedValue || UNLIMITED;
+    }
+}

--- a/projects/components/src/formly/vcd/inputs/select/formly-select.component.spec.ts
+++ b/projects/components/src/formly/vcd/inputs/select/formly-select.component.spec.ts
@@ -1,0 +1,97 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormlyForm, FormlyModule } from '@ngx-formly/core';
+import { MockTranslationService, TranslationService } from '@vcd/i18n';
+import { of } from 'rxjs';
+import { SelectOption } from '../../../../common/interfaces';
+import { CommonUtil } from '../../../../utils';
+import { WidgetFinder, WidgetObject } from '../../../../utils/test';
+import { VCD_FORMLY_INPUT_TYPES, VcdFormlyFieldConfig, VcdFormlyTemplateOptions } from '../../vcd-formly.config';
+import { VcdFormlyModule } from '../../vcd-formly.module';
+import { FormlySelectComponent } from './formly-select.component';
+
+export class VcdFormlySelectWidgetObject extends WidgetObject<FormlySelectComponent> {
+    static tagName = `vcd-formly-select`;
+}
+
+describe('FormlySelectComponent', () => {
+    let testHostComponent: TestHostComponent;
+    let finder: WidgetFinder<TestHostComponent>;
+    let formlySelectWidgetObject: VcdFormlySelectWidgetObject;
+    let formlySelectComponent: FormlySelectComponent;
+    let templateOptions: VcdFormlyTemplateOptions;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [FormlyModule.forRoot(), VcdFormlyModule],
+            declarations: [TestHostComponent],
+            providers: [
+                {
+                    provide: TranslationService,
+                    useValue: new MockTranslationService(),
+                },
+            ],
+        }).compileComponents();
+
+        finder = new WidgetFinder(TestHostComponent);
+        finder.detectChanges();
+
+        testHostComponent = finder.hostComponent;
+        formlySelectWidgetObject = finder.find(VcdFormlySelectWidgetObject);
+        formlySelectComponent = formlySelectWidgetObject.component;
+    });
+    beforeEach(() => {
+        templateOptions = CommonUtil.getNewObj(SELECT_TEMPLATE_OPTIONS);
+    });
+    it('getters return correct values for passing them as inputs to vcd-formly-select', async () => {
+        expect(formlySelectComponent.errorLabels).toEqual([]);
+        const selectOptions = await formlySelectComponent.selectOptions.toPromise();
+        expect(selectOptions).toEqual(templateOptions.options as SelectOption[]);
+    });
+    it('options can take an observable', async () => {
+        const templateOptionsWithSelectOptionsAsObservable = CommonUtil.getNewObj(
+            templateOptions
+        ) as VcdFormlyTemplateOptions;
+        templateOptionsWithSelectOptionsAsObservable.options = of(templateOptions.options as SelectOption[]);
+        testHostComponent.fields[0].templateOptions = templateOptionsWithSelectOptionsAsObservable;
+        finder.detectChanges();
+        const selectOptions = await formlySelectComponent.selectOptions.toPromise();
+        expect(selectOptions).toEqual(templateOptions.options as SelectOption[]);
+    });
+});
+
+@Component({
+    template: `
+        <div class="clr-form-horizontal">
+            <formly-form [model]="model" [fields]="fields"></formly-form>
+        </div>
+    `,
+})
+export class TestHostComponent {
+    @ViewChild(FormlyForm) formlyForm: FormlyForm;
+
+    model: any = {};
+    fields: VcdFormlyFieldConfig[] = [
+        {
+            key: 'formlyInput3',
+            type: VCD_FORMLY_INPUT_TYPES.select,
+            templateOptions: CommonUtil.getNewObj(SELECT_TEMPLATE_OPTIONS),
+        },
+    ];
+}
+
+const SELECT_TEMPLATE_OPTIONS = {
+    label: 'Select input',
+    required: true,
+    showAsterisk: true,
+    options: [
+        { value: '', display: '' },
+        { value: 1, display: 'One', isTranslatable: false },
+        { value: 2, display: 'required', isTranslatable: true },
+    ],
+};

--- a/projects/components/src/formly/vcd/inputs/select/formly-select.component.ts
+++ b/projects/components/src/formly/vcd/inputs/select/formly-select.component.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+import { Observable, of } from 'rxjs';
+import { SelectOption } from '../../../../common/interfaces';
+
+@Component({
+    selector: 'vcd-formly-select',
+    template: `
+        <vcd-form-select
+            [label]="to.label"
+            [description]="to.description"
+            [showAsterisk]="to.required"
+            [isReadOnly]="to.isReadOnly"
+            [errorLabels]="errorLabels"
+            [formControl]="formControl"
+            [options]="selectOptions | async"
+        >
+        </vcd-form-select>
+    `,
+})
+export class FormlySelectComponent extends FieldType {
+    get errorLabels(): string[] {
+        return this.to.errorLabels || [];
+    }
+
+    get selectOptions(): Observable<SelectOption[]> {
+        if (!(this.to.options instanceof Observable)) {
+            return of(this.to.options);
+        }
+        return this.to.options;
+    }
+}

--- a/projects/components/src/formly/vcd/vcd-formly.config.ts
+++ b/projects/components/src/formly/vcd/vcd-formly.config.ts
@@ -1,0 +1,85 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { ConfigOption, FormlyFieldConfig, FormlyTemplateOptions } from '@ngx-formly/core';
+import { Observable } from 'rxjs';
+import { SelectOption } from '../../common/interfaces';
+import { Unit } from '../../utils';
+import { FormlyInputComponent } from './inputs/input/formly-input.component';
+import { FormlyNumberWithUnitInputComponent } from './inputs/number-with-unit-input/formly-number-with-unit-input.component';
+import { FormlySelectComponent } from './inputs/select/formly-select.component';
+
+/**
+ * Options that are specific to Vcd form components. These are passed as inputs or outputs in the HTML templates.
+ */
+export interface VcdFormlyTemplateOptions extends FormlyTemplateOptions {
+    options?: SelectOption[] | Observable<SelectOption[]>;
+    inputValueUnit?: Unit;
+    unlimitedValue?: number;
+    showUnlimitedOption?: boolean;
+    unitOptions?: Unit[];
+    isReadOnly?: boolean;
+    hint?: string;
+    hintPosition?: string;
+    errorLabels?: string[];
+    onEnterClicked?: (field: FormlyFieldConfig) => any;
+    onEscapeClicked?: (field: FormlyFieldConfig) => any;
+}
+
+/**
+ * Configuration of {@link FormlyForm.fields} that is specific to Vcd.
+ */
+export interface VcdFormlyFieldConfig extends FormlyFieldConfig {
+    /**
+     * {@link VCD_FORMLY_INPUT_TYPES}
+     */
+    type?: VCD_FORMLY_INPUT_TYPES;
+    /**
+     * {@link VcdFormlyTemplateOptions}
+     */
+    templateOptions?: VcdFormlyTemplateOptions;
+    /**
+     * {@link FormlyForm.fields}
+     */
+    fieldGroup?: VcdFormlyFieldConfig[];
+}
+
+/**
+ * Different of Vcd form inputs that are configurable through Formly
+ */
+export enum VCD_FORMLY_INPUT_TYPES {
+    /**
+     * Used for identifying {@link FormlyInputComponent} type
+     */
+    input = 'input',
+    /**
+     * Used for identifying {@link FormlySelectComponent} type
+     */
+    select = 'select',
+    /**
+     * Used for identifying {@link FormlyNumberWithUnitInputComponent} type
+     */
+    number_with_unit_input = 'number_with_unit_input',
+}
+
+/**
+ * For configuring the FormlyModule with Vcd specific Formly components and wrappers
+ */
+export const VCD_FORMLY_CONFIG: ConfigOption = {
+    types: [
+        {
+            name: VCD_FORMLY_INPUT_TYPES.input,
+            component: FormlyInputComponent,
+        },
+        {
+            name: VCD_FORMLY_INPUT_TYPES.select,
+            component: FormlySelectComponent,
+        },
+        {
+            name: VCD_FORMLY_INPUT_TYPES.number_with_unit_input,
+            component: FormlyNumberWithUnitInputComponent,
+        },
+    ],
+};

--- a/projects/components/src/formly/vcd/vcd-formly.module.ts
+++ b/projects/components/src/formly/vcd/vcd-formly.module.ts
@@ -1,0 +1,36 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlySelectModule } from '@ngx-formly/core/select';
+import { I18nModule } from '@vcd/i18n';
+import { VcdFormModule } from '../../form';
+import { FormlyInputComponent } from './inputs/input/formly-input.component';
+import { FormlyNumberWithUnitInputComponent } from './inputs/number-with-unit-input/formly-number-with-unit-input.component';
+import { FormlySelectComponent } from './inputs/select/formly-select.component';
+import { VCD_FORMLY_CONFIG } from './vcd-formly.config';
+
+export const VCD_FORMLY_INPUT_COMPONENTS = [
+    FormlyInputComponent,
+    FormlySelectComponent,
+    FormlyNumberWithUnitInputComponent,
+];
+
+@NgModule({
+    declarations: [...VCD_FORMLY_INPUT_COMPONENTS],
+    imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        FormlyModule.forChild(VCD_FORMLY_CONFIG),
+        VcdFormModule,
+        FormlySelectModule,
+        I18nModule,
+    ],
+    exports: [],
+})
+export class VcdFormlyModule {}

--- a/projects/components/src/index.ts
+++ b/projects/components/src/index.ts
@@ -21,3 +21,4 @@ export * from './lib/directives/index';
 export * from './datagrid/index';
 export * from './utils/index';
 export * from './form/index';
+export * from './formly/vcd/index';

--- a/projects/components/src/utils/common-util.ts
+++ b/projects/components/src/utils/common-util.ts
@@ -15,4 +15,11 @@ export class CommonUtil {
         }
         return Number(Math.round(Number(value + 'e' + digits)) + 'e-' + digits);
     }
+    /**
+     * To get a new copy of an object. Typically used inside unit tests to avoid mutating mock data used by multiple
+     * tests
+     */
+    static getNewObj(obj: object): object {
+        return { ...obj };
+    }
 }

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -5,7 +5,7 @@
 
 import { registerLocaleData } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { NgModule } from '@angular/core';
+import { FactoryProvider, ModuleWithProviders, NgModule, Provider } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -19,6 +19,7 @@ import { AppRoutingModule } from './app-routing.module';
 
 import { AppComponent } from './app.component';
 
+import { FormlyModule } from '@ngx-formly/core';
 import { CompodocSchema, NgLiveDocsModule, StackBlitzInfo } from '@vmw/ng-live-docs';
 import componentsDocumentationJson from '../../gen/components-doc.json';
 import examplesDocumentationJson from '../../gen/examples-doc.json';
@@ -27,6 +28,7 @@ import { DataExporterExamplesModule } from '../components/data-exporter/data-exp
 import { DatagridExamplesModule } from '../components/datagrid/datagrid.examples.module';
 import { ErrorBannerExamplesModule } from '../components/error/error-banner.examples.module';
 import { FormInputComponentsExamplesModule } from '../components/form-input/form-input-components.examples.module';
+import { FormlyInputComponentsExamplesModule } from '../components/formly/input/formly-input.examples.module';
 import { LoadingIndicatorExamplesModule } from '../components/loading/loading-indicator.examples.module';
 import { SubscriptionTrackerExamplesModule } from '../components/subscription/subscription-tracker.examples.module';
 import { ShowClippedTextExamplesModule } from './components/show-clipped-text/show-clipped-text-examples.module';
@@ -73,6 +75,8 @@ export const sbInfo: StackBlitzInfo = {
         ErrorBannerExamplesModule,
         ActivityReporterExamplesModule,
         FormInputComponentsExamplesModule,
+        FormlyInputComponentsExamplesModule,
+        FormlyModule.forRoot(),
     ],
     entryComponents: [HomeComponent],
     providers: [

--- a/projects/examples/src/assets/our-translations.json
+++ b/projects/examples/src/assets/our-translations.json
@@ -1,7 +1,10 @@
 {
     "en": {
         "data-exporter.title": "Data Exporter!!",
-        "app.title": "VCD UI Common Components"
+        "app.title": "VCD UI Common Components",
+        "min": "Only numbers in the range of {1} to {2} are allowed",
+        "max": "Only numbers in the range of {1} to {2} are allowed",
+        "required": "Required"
     },
     "de": {
         "select.all": "Wählen Sie Alle",


### PR DESCRIPTION
Module containing the configuration required for creating forms using the Formly library package and the custom Vcd form components.

This PR only has input, select, and number with unit input components. The rest will come in later

PS: The 1st commit in this PR doesn't have examples for the components. They will be added in the next commit.