### PR TITLE
Add isRowExpanded input to vcd-datagrid

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "peerDependencies": {
         "@angular/common": ">6.0.0",
         "@angular/core": ">6.0.0",

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -94,7 +94,7 @@
         </clr-dg-cell>
 
         <ng-container ngProjectAs="clr-dg-row-detail" *ngIf="detailComponent !== undefined">
-            <clr-dg-row-detail *clrIfExpanded>
+            <clr-dg-row-detail *clrIfExpanded="isRowExpanded">
                 <ng-template
                     [vcdComponentRendererOutlet]="{
                         rendererSpec: getDetailRowRenderSpec(restItem, i, count)

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2019-2020 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -542,6 +542,29 @@ describe('DatagridComponent', () => {
             it('opens one detail pane when you click the button', function(this: HasFinderAndGrid): void {
                 this.clrGridWidget.clickDetailRowButton(0);
                 expect(this.clrGridWidget.getAllDetailRowContents().length).toEqual(1);
+            });
+        });
+
+        describe('@Input() isRowExpanded', () => {
+            beforeEach(function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.columns = [
+                    {
+                        displayName: 'Column',
+                        renderer: 'name',
+                    },
+                ];
+                this.finder.hostComponent.detailPane = undefined;
+                this.finder.detectChanges();
+            });
+
+            it('does NOT expand row when false', function(this: HasFinderAndGrid): void {
+                expect(this.clrGridWidget.getAllDetailRowContents().length).toEqual(0);
+            });
+
+            it('expands row when true', function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.isRowExpanded = true;
+                this.finder.detectChanges();
+                expect(this.clrGridWidget.getAllDetailRowContents().length).toEqual(2);
             });
         });
 
@@ -1144,6 +1167,7 @@ describe('DatagridComponent', () => {
                 [indicatorType]="indicatorType"
                 [trackBy]="trackBy"
                 [detailComponent]="details"
+                [isRowExpanded]="isRowExpanded"
                 [emptyGridPlaceholder]="placeholder"
                 [detailPane]="detailPane"
             >
@@ -1185,6 +1209,8 @@ export class HostWithDatagridComponent {
     };
 
     details = DatagridDetailsComponent;
+
+    isRowExpanded = false;
 
     detailPane = {
         header: 'Pane!',

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2019-2020 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -437,6 +437,11 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
      * @param R The type of record that this detail component will display.
      */
     @Input() detailComponent: ComponentRendererConstructor<DetailRowConfig<R>>;
+
+    /**
+     * Specifies if the row is expanded. The default is false.
+     */
+    @Input() isRowExpanded = false;
 
     /**
      * A detail pane that will be displayed when a user selects to expand a row.

--- a/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-row.example.component.ts
@@ -36,6 +36,15 @@ interface Data {
             [detailComponent]="noLazyDetails"
         >
         </vcd-datagrid>
+        <p>The user can specify <code>[isRowExpanded]</code> to expand the rows by default.</p>
+        <vcd-datagrid
+            [gridData]="gridData"
+            (gridRefresh)="refresh($event)"
+            [columns]="columns"
+            [detailComponent]="noLazyDetails"
+            [isRowExpanded]="true"
+        >
+        </vcd-datagrid>
     `,
 })
 export class DatagridDetailRowExampleComponent {


### PR DESCRIPTION
The user can now decide to have all rows expanded by setting isRowExpanded to true. The default is to have all rows collapsed.
Updated the datagrid example to show how the input works.

Testing Done:
Added two more tests for when the input is true and false.

Signed-off-by: Xuanvinh Vu <xvu@vmware.com>