### PR TITLE
Create spotlight search component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12163,6 +12163,11 @@
         }
       }
     },
+    "mousetrap": {
+      "version": "1.6.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha1-inZtjCcrCDk9X1YHTgtewYNIW/k="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "karma-coverage": "2.0.2",
     "lit-html": "1.1.2",
     "messageformat": "1.0.2",
+    "mousetrap": "1.6.5",
     "prismjs": "1.17.1",
     "properties": "1.2.1",
     "rbradford-compodoc": "1.1.11",

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "peerDependencies": {
         "@angular/common": ">6.0.0",
         "@angular/core": ">6.0.0",

--- a/projects/components/src/components.module.ts
+++ b/projects/components/src/components.module.ts
@@ -11,6 +11,7 @@ import { VcdDataExporterModule } from './data-exporter/data-exporter.module';
 import { VcdDatagridModule } from './datagrid/datagrid.module';
 import { VcdFormModule } from './form/form.module';
 import { ShowClippedTextDirectiveModule } from './lib/directives/show-clipped-text.directive.module';
+import { SpotlightSearchModule } from './spotlight-search/spotlight-search.module';
 
 @NgModule({
     exports: [
@@ -21,6 +22,7 @@ import { ShowClippedTextDirectiveModule } from './lib/directives/show-clipped-te
         VcdLoadingIndicatorModule,
         VcdActivityReporterModule,
         VcdFormModule,
+        SpotlightSearchModule,
     ],
 })
 export class VcdComponentsModule {}

--- a/projects/components/src/index.ts
+++ b/projects/components/src/index.ts
@@ -19,6 +19,7 @@ export * from './common/activity-reporter/index';
 export * from './data-exporter/index';
 export * from './lib/directives/index';
 export * from './datagrid/index';
+export * from './spotlight-search/index';
 export * from './utils/index';
 export * from './form/index';
 export * from './action-menu/index';

--- a/projects/components/src/spotlight-search/index.ts
+++ b/projects/components/src/spotlight-search/index.ts
@@ -1,0 +1,9 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+export * from './spotlight-search.module';
+export * from './spotlight-search-result';
+export * from './spotlight-search.component';
+export * from './spotlight-search.service';
+export * from './spotlight-search.provider';

--- a/projects/components/src/spotlight-search/spotlight-search-result.ts
+++ b/projects/components/src/spotlight-search/spotlight-search-result.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/**
+ * The interface a spotlight search result item should implement
+ */
+export interface SpotlightSearchResult {
+    /**
+     * The text that will be displayed in the spotlight search component
+     */
+    displayText: string;
+
+    /**
+     * The keyboard shortcut that can be used to call the handler of this item
+     */
+    kbdShortcut?: string;
+
+    /**
+     * Function that is going to be called when this item is to be handled, i.e. when the
+     * user clicks on this item or  selects it and presses the Enter key.
+     */
+    handler: () => void;
+}
+
+/**
+ * The type of the spotlight search result which can be a promise
+ */
+export type SpotlightSearchResultType = SpotlightSearchResult[] | Promise<SpotlightSearchResult[]>;

--- a/projects/components/src/spotlight-search/spotlight-search.component.html
+++ b/projects/components/src/spotlight-search/spotlight-search.component.html
@@ -1,8 +1,8 @@
 <clr-modal
     [(clrModalOpen)]="open"
     [clrModalStaticBackdrop]="false"
-    (keydown.arrowup)="onArrowKey($event)"
-    (keydown.arrowdown)="onArrowKey($event)"
+    (keydown.arrowup)="onArrowUp($event)"
+    (keydown.arrowdown)="onArrowDown($event)"
     (keydown.enter)="onEnterKey($event)"
 >
     <div class="modal-body">

--- a/projects/components/src/spotlight-search/spotlight-search.component.html
+++ b/projects/components/src/spotlight-search/spotlight-search.component.html
@@ -1,0 +1,47 @@
+<clr-modal
+    [(clrModalOpen)]="open"
+    [clrModalStaticBackdrop]="false"
+    (keydown.arrowup)="onArrowKey($event)"
+    (keydown.arrowdown)="onArrowKey($event)"
+    (keydown.enter)="onEnterKey($event)"
+>
+    <div class="modal-body">
+        <div class="search-input-container">
+            <clr-icon shape="search" size="20"></clr-icon>
+            <input
+                #searchInput
+                type="text"
+                class="clr-input"
+                [placeholder]="placeholder || ''"
+                [(ngModel)]="searchCriteria"
+            />
+        </div>
+        <div class="search-result-container">
+            <div *ngFor="let searchSection of searchSections" class="search-result-section">
+                <div
+                    *ngIf="
+                        searchSections.length > 1 &&
+                        (searchSection.isLoading || searchSection.results.length > 0 || showEmptySection)
+                    "
+                    class="search-result-section-title"
+                >
+                    {{ searchSection.section }}
+                </div>
+                <div *ngIf="searchSection.isLoading">
+                    <div class="spinner spinner-inline"></div>
+                    {{ 'vcd.cc.loading' | translate }}
+                </div>
+                <ul *ngIf="!searchSection.isLoading" class="list-unstyled compact">
+                    <li
+                        class="search-result-item"
+                        *ngFor="let item of searchSection.results"
+                        (click)="itemClicked(item)"
+                        [ngClass]="item == selectedItem ? 'selected' : ''"
+                    >
+                        {{ item.displayText }}
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</clr-modal>

--- a/projects/components/src/spotlight-search/spotlight-search.component.html
+++ b/projects/components/src/spotlight-search/spotlight-search.component.html
@@ -18,13 +18,7 @@
         </div>
         <div class="search-result-container">
             <div *ngFor="let searchSection of searchSections" class="search-result-section">
-                <div
-                    *ngIf="
-                        searchSections.length > 1 &&
-                        (searchSection.isLoading || searchSection.results.length > 0 || showEmptySection)
-                    "
-                    class="search-result-section-title"
-                >
+                <div *ngIf="showSectionTitle(searchSection)" class="search-result-section-title">
                     {{ searchSection.section }}
                 </div>
                 <div *ngIf="searchSection.isLoading">

--- a/projects/components/src/spotlight-search/spotlight-search.component.scss
+++ b/projects/components/src/spotlight-search/spotlight-search.component.scss
@@ -1,0 +1,46 @@
+::ng-deep {
+    .modal-header {
+        display: none;
+    }
+
+    .modal-backdrop {
+        background: transparent;
+    }
+}
+
+.modal-body {
+    display: flex;
+    flex-direction: column;
+    height: 500px;
+
+    .search-input-container {
+        display: flex;
+
+        clr-icon {
+            margin-top: 2px;
+            margin-right: 4px;
+        }
+
+        .clr-input {
+            flex-grow: 1;
+        }
+    }
+
+    .search-result-container {
+        margin-top: 8px;
+        flex: 1;
+        overflow: auto;
+
+        .search-result-section-title {
+            font-weight: bold;
+        }
+
+        .search-result-item {
+            padding-left: 8px;
+
+            &.selected {
+                background-color: var(--clr-global-selection-color);
+            }
+        }
+    }
+}

--- a/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
@@ -272,8 +272,6 @@ describe('SpotlightSearchComponent', () => {
         });
 
         it('can hide the section title when there is no result', function(this: Test): void {
-            // Configure
-            this.finder.hostComponent.showEmptySection = false;
             // Register one more provider
             this.spotlightSearchData.spotlightSearchService.registerProvider(
                 this.spotlightSearchData.simpleProvider,
@@ -287,24 +285,6 @@ describe('SpotlightSearchComponent', () => {
             //
             expect(this.spotlightSearch.searchResults.length).toBe(0);
             expect(this.spotlightSearch.sectionTitles.length).toEqual(0);
-        });
-
-        it('can show section title even if there is no result', function(this: Test): void {
-            // Configure
-            this.finder.hostComponent.showEmptySection = true;
-            // Register one more provider
-            this.spotlightSearchData.spotlightSearchService.registerProvider(
-                this.spotlightSearchData.simpleProvider,
-                'new section'
-            );
-            // Open
-            this.finder.hostComponent.spotlightOpen = true;
-            this.finder.detectChanges();
-            // Set search
-            this.spotlightSearch.searchInputValue = 'no match';
-            //
-            expect(this.spotlightSearch.searchResults.length).toBe(0);
-            expect(this.spotlightSearch.sectionTitles).toEqual(['section', 'new section']);
         });
     });
 
@@ -523,15 +503,10 @@ describe('SpotlightSearchComponent', () => {
 
 @Component({
     template: `
-        <vcd-spotlight-search
-            [(open)]="spotlightOpen"
-            [placeholder]="placeholder"
-            [showEmptySection]="showEmptySection"
-        ></vcd-spotlight-search>
+        <vcd-spotlight-search [(open)]="spotlightOpen" [placeholder]="placeholder"></vcd-spotlight-search>
     `,
 })
 export class HostSpotlightSearchComponent {
-    public showEmptySection: boolean;
     public placeholder: string;
     public spotlightOpen = false;
 }
@@ -552,9 +527,7 @@ export class SpotlightSearchWidgetObject extends WidgetObject<SpotlightSearchCom
     }
 
     public set searchInputValue(val: string) {
-        this.searchInputElement.value = val;
-        this.searchInputElement.dispatchEvent(new Event('input'));
-        this.detectChanges();
+        this.setInputValue(val, '.search-input-container input');
     }
 
     public get seacrhPlaceholder(): string {

--- a/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
@@ -1,0 +1,556 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MockTranslationService, TranslationService } from '@vcd/i18n';
+import { WidgetFinder, WidgetObject } from '../utils/test/widget-object';
+import { SpotlightSearchResult, SpotlightSearchResultType } from './spotlight-search-result';
+import { SpotlightSearchComponent } from './spotlight-search.component';
+import { SpotlightSearchModule } from './spotlight-search.module';
+import { SpotlightSearchProvider } from './spotlight-search.provider';
+import { SpotlightSearchService } from './spotlight-search.service';
+
+interface Test {
+    finder: WidgetFinder<HostSpotlightSearchComponent>;
+    spotlightSearch: SpotlightSearchWidgetObject;
+    spotlightSearchData: {
+        itemHandler: jasmine.Spy;
+        searchHandler: jasmine.Spy;
+        simpleProvider: SpotlightSearchProvider;
+        asyncProvider: SpotlightSearchProvider;
+        spotlightSearchService: SpotlightSearchService;
+    };
+}
+
+describe('SpotlightSearchComponent', () => {
+    beforeEach(async function(this: Test): Promise<void> {
+        await TestBed.configureTestingModule({
+            imports: [SpotlightSearchModule, NoopAnimationsModule],
+            providers: [
+                {
+                    provide: TranslationService,
+                    useValue: new MockTranslationService(),
+                },
+            ],
+            declarations: [HostSpotlightSearchComponent],
+        }).compileComponents();
+
+        this.finder = new WidgetFinder(HostSpotlightSearchComponent);
+        this.finder.detectChanges();
+        this.spotlightSearch = this.finder.find(SpotlightSearchWidgetObject);
+
+        this.spotlightSearchData = (() => {
+            // Item handler spy
+            const itemHandler = jasmine.createSpy('itemHandler', value => console.log(value)).and.callThrough();
+
+            // Provider search spy
+            const searchHandler = jasmine
+                .createSpy(
+                    'searchHandler',
+                    (criteria: string): SpotlightSearchResultType => {
+                        return ['copy', 'create']
+                            .filter(item => item.includes(criteria))
+                            .map(item => ({
+                                displayText: item,
+                                handler: () => itemHandler(item),
+                            }));
+                    }
+                )
+                .and.callThrough();
+
+            // Provider that returns an array
+            class SimpleSearchProvider implements SpotlightSearchProvider {
+                search(criteria: string): SpotlightSearchResult[] {
+                    return searchHandler(criteria);
+                }
+            }
+
+            // Provider that returns a promise
+            class AsyncSearchProvider implements SpotlightSearchProvider {
+                search(criteria: string): Promise<SpotlightSearchResult[]> {
+                    return new Promise(resolve => {
+                        setTimeout(() => {
+                            resolve(searchHandler(criteria));
+                        }, 1000);
+                    });
+                }
+            }
+
+            // Create the 2 types of providers
+            const simpleProvider = new SimpleSearchProvider();
+            const asyncProvider = new AsyncSearchProvider();
+
+            // Get a reference to the spotlight search service and register the simple provider
+            const spotlightSearchService = TestBed.inject(SpotlightSearchService) as SpotlightSearchService;
+            spotlightSearchService.registerProvider(simpleProvider, 'section');
+
+            // spotlightSearchData that the test will use
+            return {
+                itemHandler,
+                searchHandler,
+                simpleProvider,
+                asyncProvider,
+                spotlightSearchService,
+            };
+        })();
+    });
+
+    describe('visibility', () => {
+        beforeEach(function(this: Test): void {
+            expect(this.spotlightSearch.isOpened()).toBeFalsy('Spotlight Search should be closed');
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            expect(this.spotlightSearch.isOpened()).toBeTruthy('Spotlight Search should be opened');
+        });
+
+        it('can be opened', function(this: Test): void {
+            expect(this.spotlightSearch.isOpened()).toBeTruthy('Spotlight Search should be opened');
+        });
+
+        it('can be closed', function(this: Test): void {
+            this.finder.hostComponent.spotlightOpen = false;
+            this.finder.detectChanges();
+            expect(this.spotlightSearch.isOpened()).toBeFalsy('Spotlight Search should be closed');
+        });
+
+        it('is closed when esc is pressed', function(this: Test): void {
+            this.spotlightSearch.pressEscape();
+            expect(this.spotlightSearch.isOpened()).toBeFalsy('Spotlight Search should be closed');
+        });
+
+        it('is closed when clicking outside', function(this: Test): void {
+            this.spotlightSearch.clickOutside();
+            expect(this.spotlightSearch.isOpened()).toBeFalsy('Spotlight Search should be closed');
+        });
+
+        it('is closed when item is handled', function(this: Test): void {
+            this.spotlightSearch.searchInputValue = 'c';
+            this.spotlightSearch.pressEnter();
+            expect(this.spotlightSearch.isOpened()).toBeFalsy('Spotlight Search should be closed');
+        });
+    });
+
+    describe('search', () => {
+        it('does not call the search providers if there is no search criteria', function(this: Test): void {
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            expect(this.spotlightSearchData.searchHandler).not.toHaveBeenCalled();
+        });
+
+        it('displays the result immediately when it is an array', function(this: Test): void {
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            this.spotlightSearch.searchInputValue = 'c';
+            expect(this.spotlightSearchData.searchHandler).toHaveBeenCalledWith('c');
+            expect(this.spotlightSearch.searchResults).toEqual(['copy', 'create']);
+        });
+
+        it('displays a loading indicator when the result is a promise', function(this: Test): void {
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.asyncProvider,
+                'async section'
+            );
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            this.spotlightSearch.searchInputValue = 'c';
+            expect(this.spotlightSearch.isLoading).toBeTruthy(
+                'There should be a loading indicator in the second section'
+            );
+        });
+
+        it('displays the result when the promise is resolved', fakeAsync(function(this: Test): void {
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.asyncProvider,
+                'async section'
+            );
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            this.spotlightSearch.searchInputValue = 'copy';
+            tick(1000);
+            this.finder.detectChanges();
+            expect(this.spotlightSearch.isLoading).toBeFalsy();
+            expect(this.spotlightSearch.searchResults).toEqual(['copy', 'copy']);
+        }));
+
+        it('preserves the search criteria upon reopening', function(this: Test): void {
+            // Open
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Set search
+            this.spotlightSearch.searchInputValue = 'copy';
+            // Close
+            this.finder.hostComponent.spotlightOpen = false;
+            this.finder.detectChanges();
+            // Open again
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            expect(this.spotlightSearch.searchInputValue).toEqual('copy');
+            expect(this.spotlightSearch.searchResults).toEqual(['copy']);
+        });
+
+        it('uses a newly added search handler', function(this: Test): void {
+            // Open
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Set search
+            this.spotlightSearch.searchInputValue = 'copy';
+            // Test that the search handler is called
+            expect(this.spotlightSearchData.searchHandler).toHaveBeenCalledTimes(1);
+            expect(this.spotlightSearchData.searchHandler).toHaveBeenCalledWith('copy');
+            // Close
+            this.finder.hostComponent.spotlightOpen = false;
+            this.finder.detectChanges();
+            // Register new provider
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.simpleProvider,
+                'new section'
+            );
+            // Open again
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Test thst the search handler is called 2 more times, 1 more for the old handler and 1 more for the new handler
+            expect(this.spotlightSearchData.searchHandler).toHaveBeenCalledTimes(3);
+            expect(this.spotlightSearchData.searchHandler).toHaveBeenCalledWith('copy');
+        });
+    });
+
+    describe('section', () => {
+        it('does not display section title if there is just one provider', function(this: Test): void {
+            // Open
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Set search
+            this.spotlightSearch.searchInputValue = 'copy';
+            //
+            expect(this.spotlightSearch.searchResults.length).toBe(1);
+            expect(this.spotlightSearch.sectionTitles.length).toBe(0);
+        });
+
+        it('displays all section titles when there are results', function(this: Test): void {
+            // Register one more provider
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.simpleProvider,
+                'new section'
+            );
+            // Open
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Set search
+            this.spotlightSearch.searchInputValue = 'copy';
+            //
+            expect(this.spotlightSearch.sectionTitles).toEqual(['section', 'new section']);
+        });
+
+        it('can hide the section title when there is no result', function(this: Test): void {
+            // Configure
+            this.finder.hostComponent.showEmptySection = false;
+            // Register one more provider
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.simpleProvider,
+                'new section'
+            );
+            // Open
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Set search
+            this.spotlightSearch.searchInputValue = 'no match';
+            //
+            expect(this.spotlightSearch.searchResults.length).toBe(0);
+            expect(this.spotlightSearch.sectionTitles.length).toEqual(0);
+        });
+
+        it('can show section title even if there is no result', function(this: Test): void {
+            // Configure
+            this.finder.hostComponent.showEmptySection = true;
+            // Register one more provider
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.simpleProvider,
+                'new section'
+            );
+            // Open
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Set search
+            this.spotlightSearch.searchInputValue = 'no match';
+            //
+            expect(this.spotlightSearch.searchResults.length).toBe(0);
+            expect(this.spotlightSearch.sectionTitles).toEqual(['section', 'new section']);
+        });
+    });
+
+    describe('selection', () => {
+        describe('auto selection', () => {
+            it('selects the first item if the first section is loaded', function(this: Test): void {
+                // Append async provider
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.asyncProvider,
+                    'async section'
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
+            });
+
+            it('does not select any item if the first section returns async result', function(this: Test): void {
+                // Prepend async provider so that the first section will be loading
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.asyncProvider,
+                    'async section',
+                    0
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                expect(this.spotlightSearch.getSelectedItem()).toEqual('');
+            });
+
+            it('selects the first item after the promise is resolved', fakeAsync(function(this: Test): void {
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.asyncProvider,
+                    'async section',
+                    0
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                tick(1000);
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
+            }));
+        });
+
+        describe('arrow keys', () => {
+            it('selects first item when there is no selection and arrow up is pressed', function(this: Test): void {
+                // Prepend async provider so that there is no auto selection
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.asyncProvider,
+                    'async section',
+                    0
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                this.spotlightSearch.pressArrowUp();
+                expect(this.spotlightSearch.getSelectedItem(2)).toEqual('copy');
+            });
+
+            it('selects first item when there is no selection and arrow down is pressed', function(this: Test): void {
+                // Prepend async provider so that there is no auto selection
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.asyncProvider,
+                    'async section',
+                    0
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                this.spotlightSearch.pressArrowDown();
+                expect(this.spotlightSearch.getSelectedItem(2)).toEqual('copy');
+            });
+
+            it('selects next item when arrow down is pressed', function(this: Test): void {
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
+                this.spotlightSearch.pressArrowDown();
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('create');
+            });
+
+            it('selects from the next section when being at the bottom of a section and arrow down is pressed', function(this: Test): void {
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.simpleProvider,
+                    'new section'
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                this.spotlightSearch.pressArrowDown();
+                // Test the selection is from the first section
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('create');
+                this.spotlightSearch.pressArrowDown();
+                // Test the selection now is from the second section
+                expect(this.spotlightSearch.getSelectedItem(2)).toEqual('copy');
+            });
+
+            it('selects the first item when being at the bottom of the list and down is pressed', function(this: Test): void {
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.simpleProvider,
+                    'new section'
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                expect(this.spotlightSearch.searchResults.length).toBe(4);
+                // Go to the bottom of the list
+                this.spotlightSearch.pressArrowDown();
+                this.spotlightSearch.pressArrowDown();
+                this.spotlightSearch.pressArrowDown();
+                // Test the selection is the bottom of the second section
+                expect(this.spotlightSearch.getSelectedItem(2)).toEqual('create');
+                // Go beyond the length of the list
+                this.spotlightSearch.pressArrowDown();
+                // Test the selection is the first item of the first selection
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
+            });
+
+            it('selects the last item when being at the top of the list and up is pressed', function(this: Test): void {
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.simpleProvider,
+                    'new section'
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                // Test
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
+                // Press arrow up key
+                this.spotlightSearch.pressArrowUp();
+                // Test
+                expect(this.spotlightSearch.getSelectedItem(2)).toEqual('create');
+            });
+        });
+    });
+
+    describe('item handler', () => {
+        it('is called when pressing enter and there is a selection', function(this: Test): void {
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            this.spotlightSearch.searchInputValue = 'c';
+            this.spotlightSearch.pressEnter();
+            expect(this.spotlightSearchData.itemHandler).toHaveBeenCalledWith('copy');
+        });
+
+        it('is not called when pressing enter and there is no selection', function(this: Test): void {
+            // Prepend async provider so that there is no auto selection
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.asyncProvider,
+                'async section',
+                0
+            );
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            this.spotlightSearch.searchInputValue = 'c';
+            this.spotlightSearch.pressEnter();
+            expect(this.spotlightSearchData.itemHandler).not.toHaveBeenCalled();
+        });
+
+        it('is called when item is clicked', function(this: Test): void {
+            // Prepend async provider so that there is no auto selection
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.asyncProvider,
+                'async section',
+                0
+            );
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            this.spotlightSearch.searchInputValue = 'c';
+            this.spotlightSearch.clickItem(2, 2);
+            expect(this.spotlightSearchData.itemHandler).toHaveBeenCalledWith('create');
+        });
+    });
+
+    describe('search input placeholder', () => {
+        it('default to empty', function(this: Test): void {
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            expect(this.spotlightSearch.seacrhPlaceholder).toBe('');
+        });
+
+        it('can be set', function(this: Test): void {
+            this.finder.hostComponent.placeholder = 'Search...';
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            expect(this.spotlightSearch.seacrhPlaceholder).toBe('Search...');
+        });
+    });
+});
+
+@Component({
+    template: `
+        <vcd-spotlight-search
+            [(open)]="spotlightOpen"
+            [placeholder]="placeholder"
+            [showEmptySection]="showEmptySection"
+        ></vcd-spotlight-search>
+    `,
+})
+export class HostSpotlightSearchComponent {
+    public showEmptySection: boolean;
+    public placeholder: string;
+    public spotlightOpen = false;
+}
+
+export class SpotlightSearchWidgetObject extends WidgetObject<SpotlightSearchComponent> {
+    static tagName = `vcd-spotlight-search`;
+
+    public isOpened(): boolean {
+        return !!this.findElement('.search-input-container input');
+    }
+
+    private get searchInputElement(): HTMLInputElement {
+        return this.findElement('.search-input-container input').nativeElement;
+    }
+
+    public get searchInputValue(): string {
+        return this.searchInputElement.value;
+    }
+
+    public set searchInputValue(val: string) {
+        this.searchInputElement.value = val;
+        this.searchInputElement.dispatchEvent(new Event('input'));
+        this.detectChanges();
+    }
+
+    public get seacrhPlaceholder(): string {
+        return this.searchInputElement.placeholder;
+    }
+
+    public clickOutside(): void {
+        this.click('.modal-backdrop');
+    }
+
+    public pressEscape(): void {
+        this.sendKeyboardEvent('escape', '.search-input-container input');
+    }
+
+    public pressEnter(): void {
+        this.sendKeyboardEvent('enter', '.search-input-container input');
+    }
+
+    public pressArrowUp(): void {
+        this.sendKeyboardEvent('ArrowUp', '.search-input-container input');
+    }
+
+    public pressArrowDown(): void {
+        this.sendKeyboardEvent('ArrowDown', '.search-input-container input');
+    }
+
+    public get searchResults(): string[] {
+        return this.getTexts('.search-result-item');
+    }
+
+    public get sectionTitles(): string[] {
+        return this.getTexts('.search-result-section-title');
+    }
+
+    public getSelectedItem(section?: number): string {
+        let cssSelector = '.search-result-item.selected';
+        if (section) {
+            cssSelector = `.search-result-section:nth-child(${section}) ${cssSelector}`;
+        }
+        return this.getText(cssSelector);
+    }
+
+    public clickItem(itemIndex, sectionIndex): void {
+        this.click(`.search-result-section:nth-child(${sectionIndex}) .search-result-item:nth-child(${itemIndex})`);
+    }
+
+    public get isLoading(): boolean {
+        return !!this.findElement('.spinner');
+    }
+}

--- a/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
@@ -176,6 +176,32 @@ describe('SpotlightSearchComponent', () => {
             expect(this.spotlightSearch.searchResults).toEqual(['copy', 'copy']);
         }));
 
+        it('displays result from the last search', fakeAsync(function(this: Test): void {
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.asyncProvider,
+                'async section'
+            );
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Start the first search
+            this.spotlightSearch.searchInputValue = 'copy';
+            tick(500);
+            this.finder.detectChanges();
+            // Start a second search
+            this.spotlightSearch.searchInputValue = 'create';
+            // Advance the clock so that the first search has finished
+            tick(500);
+            this.finder.detectChanges();
+            // There should be just one result form the first provider
+            expect(this.spotlightSearch.searchResults).toEqual(['create']);
+            // There should still be loading indicator from the second search
+            expect(this.spotlightSearch.isLoading).toBeTruthy();
+            // Advance the clock so that the second search has finished also
+            tick(500);
+            this.finder.detectChanges();
+            expect(this.spotlightSearch.searchResults).toEqual(['create', 'create']);
+        }));
+
         it('preserves the search criteria upon reopening', function(this: Test): void {
             // Open
             this.finder.hostComponent.spotlightOpen = true;
@@ -296,6 +322,20 @@ describe('SpotlightSearchComponent', () => {
                 expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
             });
 
+            it('can update the selected item', function(this: Test): void {
+                // Append async provider
+                this.spotlightSearchData.spotlightSearchService.registerProvider(
+                    this.spotlightSearchData.asyncProvider,
+                    'async section'
+                );
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
+                this.spotlightSearch.searchInputValue = 'cr';
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('create');
+            });
+
             it('does not select any item if the first section returns async result', function(this: Test): void {
                 // Prepend async provider so that the first section will be loading
                 this.spotlightSearchData.spotlightSearchService.registerProvider(
@@ -377,7 +417,7 @@ describe('SpotlightSearchComponent', () => {
                 expect(this.spotlightSearch.getSelectedItem(2)).toEqual('copy');
             });
 
-            it('selects the first item when being at the bottom of the list and down is pressed', function(this: Test): void {
+            it('selects the first item when being at the bottom of the list and arrow down is pressed', function(this: Test): void {
                 this.spotlightSearchData.spotlightSearchService.registerProvider(
                     this.spotlightSearchData.simpleProvider,
                     'new section'
@@ -395,6 +435,17 @@ describe('SpotlightSearchComponent', () => {
                 // Go beyond the length of the list
                 this.spotlightSearch.pressArrowDown();
                 // Test the selection is the first item of the first selection
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
+            });
+
+            it('selects previous item when arrow up is pressed', function(this: Test): void {
+                this.finder.hostComponent.spotlightOpen = true;
+                this.finder.detectChanges();
+                this.spotlightSearch.searchInputValue = 'c';
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
+                this.spotlightSearch.pressArrowDown();
+                expect(this.spotlightSearch.getSelectedItem(1)).toEqual('create');
+                this.spotlightSearch.pressArrowUp();
                 expect(this.spotlightSearch.getSelectedItem(1)).toEqual('copy');
             });
 

--- a/projects/components/src/spotlight-search/spotlight-search.component.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.ts
@@ -65,14 +65,6 @@ export class SpotlightSearchComponent {
     @Input() public placeholder: string;
 
     /**
-     * Show the section even if the corresponding search has not found any results.
-     * If `true` the section will shown even if it is empty otherwise it will be hidden.
-     * Applicable only if the spotlight search is configured with more than one section.
-     * If there is just one section then no section title is available at all.
-     */
-    @Input() public showEmptySection = false;
-
-    /**
      * This property alongside with `openChange` provide two-way binding [(open)] for controlling the visibility state
      * of the spotlight component
      */
@@ -259,7 +251,7 @@ export class SpotlightSearchComponent {
             setTimeout(() => {
                 this.searchInput.nativeElement.focus();
                 this.searchInput.nativeElement.select();
-            }, 10);
+            }, 0);
         }
 
         this._open = open;
@@ -270,5 +262,11 @@ export class SpotlightSearchComponent {
     private handleItem(item: SpotlightSearchResult): void {
         item.handler();
         this.open = false;
+    }
+
+    showSectionTitle(searchSection: SearchSection): boolean {
+        // In order to show a section title there should be more than one sections
+        // and the current section should either be loading data or have results
+        return this.searchSections.length > 1 && (searchSection.isLoading || searchSection.results.length > 0);
     }
 }

--- a/projects/components/src/spotlight-search/spotlight-search.component.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.ts
@@ -1,0 +1,273 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { TranslationService } from '@vcd/i18n';
+import { SpotlightSearchResult, SpotlightSearchResultType } from './spotlight-search-result';
+import { RegisteredProviders, SpotlightSearchService } from './spotlight-search.service';
+
+interface SearchSection extends RegisteredProviders {
+    results: SpotlightSearchResult[];
+    isLoading: boolean;
+}
+
+/**
+ * The Spotlight Search component is inspired by the Spotlight Search functionality in Mac OSX (cmd+space)
+ * and the Search Everywhere in IntelliJ (shift+shift)
+ *
+ * This VCD Spotlight Search does not provide any search by itself. It is not also a single component
+ * but rather a group of objects that work together in order to allow the developer to build a might search experience
+ * for the end user.
+ *
+ * Basically the VCD Spotlight Search consists of:
+ * <ul>
+ *     <li>SpotlightSearchComponent - the visual component that you should include in your template</li>
+ *     <li>{@link SpotlightSearchService}<a href="/compodoc/injectables/SpotlightSearchService.html">SpotlightSearchService</a>
+ *     - the service that you should register your own providers with</li>
+ *     <li>{@link SpotlightSearchProvider}<a href="/compodoc/interfaces/SpotlightSearchProvider.html">SpotlightSearchProvider</a>
+ *     - the interface your search provider should implement.
+ *     It can return either an array of {@link SpotlightSearchResult} or a promise for lazy loading of results</li>
+ * </ul>
+ *
+ * SpotlightSearchComponent:
+ *
+ *    <vcd-spotlight-search
+ *        [(open)]="spotlightOpen"
+ *        [placeholder]="'Search ...'"
+ *    ></vcd-spotlight-search>
+ *
+ *
+ * {@link SpotlightSearchService}:
+ *
+ * This service works along with the component in order to provide search results displayed. Those results are gropued
+ * in sections based on the registered provider {@link SpotlightSearchProvider}.
+ *
+ * You can provide order of the search providers, hence the order of the displayed sections
+ *
+ * If there is just one search provider no section title is displayed.
+ *
+ * In case of multiple search providers the Spotlight Search can be configured to hide the entire section if it contains no data.
+ *
+ *
+ * For a complete end-to-end running example please take a look at the `Examples` tab of the live-docs
+ */
+@Component({
+    selector: 'vcd-spotlight-search',
+    templateUrl: './spotlight-search.component.html',
+    styleUrls: ['./spotlight-search.component.scss'],
+})
+export class SpotlightSearchComponent {
+    /**
+     * Placeholder for the search input. Default is empty string;
+     */
+    @Input() public placeholder: string;
+
+    /**
+     * Show the section even if the corresponding search has not found any results.
+     * If `true` the section will shown even if it is empty otherwise it will be hidden.
+     * Applicable only if the spotlight search is configured with more than one section.
+     * If there is just one section then no section title is available at all.
+     */
+    @Input() public showEmptySection = false;
+
+    /**
+     * This property alongside with `openChange` provide two-way binding [(open)] for controlling the visibility state
+     * of the spotlight component
+     */
+    @Input()
+    public set open(open: boolean) {
+        this.handleOpen(open);
+    }
+    public get open(): boolean {
+        return this._open;
+    }
+
+    /**
+     * This method along with `open` property provide two-way binding [(open)] for controlling the visibility state
+     * of the spotlight component
+     */
+    @Output() openChange: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+
+    constructor(
+        private searchService: SpotlightSearchService,
+        private changeDetectorRef: ChangeDetectorRef,
+        public translationService: TranslationService
+    ) {}
+
+    get searchCriteria(): string {
+        return this._searchCriteria;
+    }
+
+    set searchCriteria(value: string) {
+        this._searchCriteria = value;
+        this.doSearch();
+    }
+    private _searchCriteria: string;
+
+    private _open = false;
+
+    @ViewChild('searchInput', { static: false, read: ElementRef }) searchInput: ElementRef;
+
+    private searchId = 0;
+
+    /**
+     * The search sections are provided by the {@link SpotlightSearchService} upon opening the Spotlight Search.
+     * This insures that new sections based on the current context of the application may appear.
+     */
+    searchSections: SearchSection[] = [];
+
+    selectedItem: SpotlightSearchResult;
+
+    itemClicked(item: SpotlightSearchResult): void {
+        this.handleItem(item);
+    }
+
+    onArrowKey(event: KeyboardEvent): void {
+        event.preventDefault();
+        if (event.key === 'ArrowDown') {
+            this.selectNext(true);
+        } else if (event.key === 'ArrowUp') {
+            this.selectNext(false);
+        }
+    }
+
+    onEnterKey(event): void {
+        event.preventDefault();
+        if (!this.selectedItem) {
+            return;
+        }
+        this.handleItem(this.selectedItem);
+    }
+
+    private doSearch(): void {
+        // Remember which is the current search. This will help us not to show results from an old search
+        const searchId = ++this.searchId;
+        // Upon new search we clear the currently selected item
+        this.selectedItem = null;
+
+        // Go through the available search sections, i.e. the registered search providers and request for results
+        this.searchSections.forEach(async searchSection => {
+            let results: SpotlightSearchResultType = [];
+            // Only request for data if the search is not empty
+            if (!!this.searchCriteria) {
+                results = searchSection.provider.search(this.searchCriteria);
+
+                // Some of the results may be provided later, so mark the section as loading
+                if (results instanceof Promise) {
+                    searchSection.isLoading = true;
+                    results = await results;
+                }
+                // Use the closure to verify that the displayed data is going to be really from the latest search
+                if (searchId !== this.searchId) {
+                    return;
+                }
+            }
+            searchSection.results = results;
+            searchSection.isLoading = false;
+            this.selectFirst(true);
+        });
+    }
+
+    /**
+     * Try to select the first item in the compound search result.
+     * @param ensureFirstSectionIsLoaded if true and if the topmost section is still loading then do not select an item
+     */
+    private selectFirst(ensureFirstSectionIsLoaded: boolean): void {
+        // Do nothing if there is already a selection
+        if (this.selectedItem) {
+            return;
+        }
+
+        for (const section of this.searchSections) {
+            // The section is still loading. If it was requested to ensure the loading has completed than abort
+            // the attempt to select an item or just skip it and examine the next section.
+            if (section.isLoading) {
+                if (ensureFirstSectionIsLoaded) {
+                    return;
+                }
+                continue;
+            }
+            this.selectedItem = section.results[0];
+            if (this.selectedItem) {
+                break;
+            }
+        }
+        this.changeDetectorRef.detectChanges();
+    }
+
+    private selectNext(down: boolean): void {
+        // If there is no selection then just select the first available item
+        if (!this.selectedItem) {
+            this.selectFirst(false);
+            return;
+        }
+
+        // Get all the items form all the sections in a single flat array
+        const allResults = this.searchSections.reduce((acc, v) => [...acc, ...(v.results || [])], []);
+
+        let selectedItemIndex = allResults.indexOf(this.selectedItem);
+
+        // There is a selected item but it is not one of the available ones, so just select the first from the list
+        if (selectedItemIndex < 0) {
+            this.selectedItem = null;
+            this.selectFirst(false);
+            return;
+        }
+
+        // Determine the index of the next selection
+        if (down) {
+            if (selectedItemIndex === allResults.length - 1) {
+                selectedItemIndex = 0;
+            } else {
+                selectedItemIndex++;
+            }
+        } else {
+            if (selectedItemIndex === 0) {
+                selectedItemIndex = allResults.length - 1;
+            } else {
+                selectedItemIndex--;
+            }
+        }
+
+        this.selectedItem = allResults[selectedItemIndex];
+
+        // Call the change detector otherwise the selection on the screen may not refreshed quickly enough if the
+        // user just presses and holds down the arrow key
+        this.changeDetectorRef.detectChanges();
+    }
+
+    /**
+     * Handle showing / hiding of the Spotlight Search.
+     * @param open true when opening, false when closing
+     */
+    private handleOpen(open: boolean): void {
+        // Don't do anything if the state has not been changed or if the developer has not explicitly specified the state.
+        // This may happen if the template is used with uninitialized variable.
+        if (open === this._open || typeof open !== 'boolean') {
+            return;
+        }
+
+        if (open) {
+            this.searchSections = this.searchService
+                .getRegisteredProviders()
+                .map(data => ({ ...data, results: [], isLoading: true }));
+            this.doSearch();
+
+            setTimeout(() => {
+                this.searchInput.nativeElement.focus();
+                this.searchInput.nativeElement.select();
+            }, 10);
+        }
+
+        this._open = open;
+        this.openChange.emit(this._open);
+        this.changeDetectorRef.detectChanges();
+    }
+
+    private handleItem(item: SpotlightSearchResult): void {
+        item.handler();
+        this.open = false;
+    }
+}

--- a/projects/components/src/spotlight-search/spotlight-search.component.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.ts
@@ -124,13 +124,14 @@ export class SpotlightSearchComponent {
         this.handleItem(item);
     }
 
-    onArrowKey(event: KeyboardEvent): void {
+    onArrowDown(event: KeyboardEvent): void {
         event.preventDefault();
-        if (event.key === 'ArrowDown') {
-            this.selectNext(true);
-        } else if (event.key === 'ArrowUp') {
-            this.selectNext(false);
-        }
+        this.selectNext(true);
+    }
+
+    onArrowUp(event: KeyboardEvent): void {
+        event.preventDefault();
+        this.selectNext(false);
     }
 
     onEnterKey(event): void {

--- a/projects/components/src/spotlight-search/spotlight-search.module.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.module.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { I18nModule } from '@vcd/i18n';
+import { SpotlightSearchComponent } from './spotlight-search.component';
+import { SpotlightSearchService } from './spotlight-search.service';
+
+@NgModule({
+    imports: [CommonModule, ClarityModule, FormsModule, ReactiveFormsModule, I18nModule],
+    declarations: [SpotlightSearchComponent],
+    exports: [SpotlightSearchComponent],
+    providers: [SpotlightSearchService],
+})
+export class SpotlightSearchModule {}

--- a/projects/components/src/spotlight-search/spotlight-search.provider.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.provider.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { SpotlightSearchResultType } from './spotlight-search-result';
+
+/**
+ * The interface a search providers should implement in order to register itself with the {@link SpotlightSearchService}
+ */
+export interface SpotlightSearchProvider {
+    /**
+     * Returns an array or a promise of array of items that comply with the search criteria.
+     * @param criteria The search string provided by the user when typing in the Spotlight Search Component
+     */
+    search(criteria: string): SpotlightSearchResultType;
+}

--- a/projects/components/src/spotlight-search/spotlight-search.service.spec.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.service.spec.ts
@@ -23,13 +23,37 @@ describe('SpotlightSearchService', () => {
         expect(registeredProvider.section).toBe('section1');
     });
 
-    it('can register providers in specified order', () => {
+    it('registers a provider at the back if no order is provided', () => {
         const service = new SpotlightSearchService();
         service.registerProvider(new SimpleSearchProvider(), 'section1');
-        service.registerProvider(new SimpleSearchProvider(), 'section2', 0);
+        service.registerProvider(new SimpleSearchProvider(), 'section2');
         const providers = service.getRegisteredProviders();
-        expect(providers[0].section).toBe('section2');
+        expect(providers[0].section).toBe('section1');
+        expect(providers[1].section).toBe('section2');
+    });
+
+    it('registers the providers in the beginning of the list when order 0 i sprovided', () => {
+        const service = new SpotlightSearchService();
+        service.registerProvider(new SimpleSearchProvider(), 'section1');
+        service.registerProvider(new SimpleSearchProvider(), 'section2');
+        service.registerProvider(new SimpleSearchProvider(), 'section_first', 0);
+        const providers = service.getRegisteredProviders();
+        expect(providers[0].section).toBe('section_first');
         expect(providers[1].section).toBe('section1');
+        expect(providers[2].section).toBe('section2');
+    });
+
+    it('registers providers in specific order', () => {
+        const service = new SpotlightSearchService();
+        service.registerProvider(new SimpleSearchProvider(), 'section_last');
+        service.registerProvider(new SimpleSearchProvider(), 'section3', 3);
+        service.registerProvider(new SimpleSearchProvider(), 'section1', 1);
+        service.registerProvider(new SimpleSearchProvider(), 'section2', 2);
+        const providers = service.getRegisteredProviders();
+        expect(providers[0].section).toBe('section1');
+        expect(providers[1].section).toBe('section2');
+        expect(providers[2].section).toBe('section3');
+        expect(providers[3].section).toBe('section_last');
     });
 
     it('can unregister a provider', () => {
@@ -38,5 +62,23 @@ describe('SpotlightSearchService', () => {
         service.unregisterProvider(id);
         const providers = service.getRegisteredProviders();
         expect(providers.length).toBe(0);
+    });
+
+    it('returns true when a provider is unregistered', () => {
+        const service = new SpotlightSearchService();
+        const id = service.registerProvider(new SimpleSearchProvider(), 'section1');
+        service.registerProvider(new SimpleSearchProvider(), 'section2');
+        expect(service.unregisterProvider(id)).toBeTruthy();
+        const providers = service.getRegisteredProviders();
+        expect(providers.length).toBe(1);
+    });
+
+    it('returns false when a provider is not unregistered', () => {
+        const service = new SpotlightSearchService();
+        const id = service.registerProvider(new SimpleSearchProvider(), 'section1');
+        service.registerProvider(new SimpleSearchProvider(), 'section2');
+        expect(service.unregisterProvider(id + '_no_match')).toBeFalsy();
+        const providers = service.getRegisteredProviders();
+        expect(providers.length).toBe(2);
     });
 });

--- a/projects/components/src/spotlight-search/spotlight-search.service.spec.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.service.spec.ts
@@ -1,0 +1,42 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { SpotlightSearchResultType } from './spotlight-search-result';
+import { SpotlightSearchProvider } from './spotlight-search.provider';
+import { SpotlightSearchService } from './spotlight-search.service';
+
+class SimpleSearchProvider implements SpotlightSearchProvider {
+    search(criteria: string): SpotlightSearchResultType {
+        return [];
+    }
+}
+
+describe('SpotlightSearchService', () => {
+    it('can register a provider', () => {
+        const service = new SpotlightSearchService();
+        const provider1 = new SimpleSearchProvider();
+        service.registerProvider(provider1, 'section1');
+        const registeredProvider = service.getRegisteredProviders()[0];
+        expect(registeredProvider.provider).toBe(provider1);
+        expect(registeredProvider.section).toBe('section1');
+    });
+
+    it('can register providers in specified order', () => {
+        const service = new SpotlightSearchService();
+        service.registerProvider(new SimpleSearchProvider(), 'section1');
+        service.registerProvider(new SimpleSearchProvider(), 'section2', 0);
+        const providers = service.getRegisteredProviders();
+        expect(providers[0].section).toBe('section2');
+        expect(providers[1].section).toBe('section1');
+    });
+
+    it('can unregister a provider', () => {
+        const service = new SpotlightSearchService();
+        const id = service.registerProvider(new SimpleSearchProvider(), 'section1');
+        service.unregisterProvider(id);
+        const providers = service.getRegisteredProviders();
+        expect(providers.length).toBe(0);
+    });
+});

--- a/projects/components/src/spotlight-search/spotlight-search.service.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.service.ts
@@ -1,0 +1,97 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Injectable } from '@angular/core';
+import { SpotlightSearchProvider } from './spotlight-search.provider';
+
+/**
+ * Interface describing what providers are registered within the system
+ */
+export interface RegisteredProviders {
+    /**
+     * The very search provider
+     */
+    provider: SpotlightSearchProvider;
+
+    /**
+     * The section name (the title or the group name) that this provider will provides results for.
+     */
+    section: string;
+}
+
+/**
+ * This interface is used internally by the service
+ */
+interface InternalRegistrationData extends RegisteredProviders {
+    order?: number;
+    id: string;
+}
+
+/**
+ * Create unique id
+ */
+const createId = ((): (() => string) => {
+    let id = 1;
+    return () => `${new Date().getTime()}-${id++}`;
+})();
+
+@Injectable()
+export class SpotlightSearchService {
+    registrations: InternalRegistrationData[] = [];
+
+    /**
+     * Register a search provider
+     * @param provider The search provider {@link SpotlightSearchProvider}
+     * @param section The section name (the title or the group name) that this provider will provides results for.
+     * @param order The order of the section in the spotlight search results
+     */
+    public registerProvider(provider: SpotlightSearchProvider, section: string, order: number = -1): string {
+        const registrationData = { provider, section, order, id: createId() };
+
+        // Determine the position of the new registration
+        let insertIndex = -1;
+        if (order > -1) {
+            insertIndex = this.registrations.findIndex(data => {
+                if (data.order === undefined) {
+                    return true;
+                }
+                if (data.order > order) {
+                    return true;
+                }
+                if (data.order < 0) {
+                    return true;
+                }
+            });
+        }
+
+        if (insertIndex > -1) {
+            this.registrations.splice(insertIndex, 0, registrationData);
+        } else {
+            this.registrations.push(registrationData);
+        }
+
+        return registrationData.id;
+    }
+
+    /**
+     * Unregister a search provider by providing the registration id.
+     * Returns true if unregistration was done.
+     * @param registrationId the id returned when registering the provider
+     */
+    public unregisterProvider(registrationId: string): boolean {
+        const index = this.registrations.findIndex(data => data.id === registrationId);
+        if (index > -1) {
+            this.registrations.splice(index, 1);
+        }
+        return index > -1;
+    }
+
+    /**
+     * Get a list of all the registered search providers.
+     */
+    public getRegisteredProviders(): RegisteredProviders[] {
+        return this.registrations.map(data => ({ provider: data.provider, section: data.section }));
+    }
+}

--- a/projects/components/src/spotlight-search/spotlight-search.service.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.service.ts
@@ -45,22 +45,24 @@ export class SpotlightSearchService {
      * Register a search provider
      * @param provider The search provider {@link SpotlightSearchProvider}
      * @param section The section name (the title or the group name) that this provider will provides results for.
-     * @param order The order of the section in the spotlight search results
+     * @param order The order of the section in the spotlight search results. Less the order, closer to the beginning
+     *        of the list. So 0 means put provider in the beginning of the list, -1 appends the provider at the back.
      */
     public registerProvider(provider: SpotlightSearchProvider, section: string, order: number = -1): string {
         const registrationData = { provider, section, order, id: createId() };
 
-        // Determine the position of the new registration
         let insertIndex = -1;
+        // Determine the position of the new registration
         if (order > -1) {
             insertIndex = this.registrations.findIndex(data => {
-                if (data.order === undefined) {
-                    return true;
-                }
-                if (data.order > order) {
-                    return true;
-                }
+                // If an item has a negative index, this means no order had been provided for that item
+                // which means we have found the insert index
                 if (data.order < 0) {
+                    return true;
+                }
+
+                // If an item has a bigger order than the new one means we have found the insert index
+                if (order < data.order) {
                     return true;
                 }
             });

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -92,6 +92,20 @@ export abstract class WidgetObject<T> {
     }
 
     /**
+     * Sets the value of an input element or textarea element
+     * @param value the value that the element should display
+     * @param cssSelector Pass this in if you want trigger the event on a specific element.
+     *        If not passed in, the event will be triggered on the entire node
+     * @param parent the parent element for which to search for the {@param cssSelector} within. Defaults to root if not provided.
+     */
+    protected setInputValue(value: string | number, cssSelector?: string, parent: DebugElement = this.root): void {
+        const nativeElement: HTMLInputElement | HTMLTextAreaElement = parent.query(By.css(cssSelector)).nativeElement;
+        nativeElement.value = String(value);
+        nativeElement.dispatchEvent(new Event('input'));
+        this.detectChanges();
+    }
+
+    /**
      * Returns text content of this widget
      * If the element cannot be found, gives empty string.
      * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -77,6 +77,21 @@ export abstract class WidgetObject<T> {
     }
 
     /**
+     * Sends a keyboard event defined by the key to an element and detects changes so the DOM is immediately updated.
+     * The keyboard event consists of keydow
+     * @param key the key, for example Enter, Escape, ArrowUp etc.
+     * @param cssSelector Pass this in if you want trigger the event on a specific element.
+     *        If not passed in, the event will be triggered on the entire node
+     * @param parent the parent element for which to search for the {@param cssSelector} within. Defaults to root if not provided.
+     */
+    protected sendKeyboardEvent(key: string, cssSelector?: string, parent: DebugElement = this.root): void {
+        const nativeElement: HTMLBaseElement = parent.query(By.css(cssSelector)).nativeElement;
+        nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+        nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key, bubbles: true }));
+        this.detectChanges();
+    }
+
+    /**
      * Returns text content of this widget
      * If the element cannot be found, gives empty string.
      * @param cssSelector Pass this in if you want to retrieve text for a specific element within this widget.

--- a/projects/examples/src/app/app.module.ts
+++ b/projects/examples/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { DatagridExamplesModule } from '../components/datagrid/datagrid.examples
 import { ErrorBannerExamplesModule } from '../components/error/error-banner.examples.module';
 import { FormInputComponentsExamplesModule } from '../components/form-input/form-input-components.examples.module';
 import { LoadingIndicatorExamplesModule } from '../components/loading/loading-indicator.examples.module';
+import { SpotlightSearchExamplesModule } from '../components/spotlight-search/spotlight-search.examples.module';
 import { SubscriptionTrackerExamplesModule } from '../components/subscription/subscription-tracker.examples.module';
 import { ShowClippedTextExamplesModule } from './components/show-clipped-text/show-clipped-text-examples.module';
 import { HomeComponent } from './home/home.component';
@@ -73,6 +74,7 @@ export const sbInfo: StackBlitzInfo = {
         ErrorBannerExamplesModule,
         ActivityReporterExamplesModule,
         FormInputComponentsExamplesModule,
+        SpotlightSearchExamplesModule,
     ],
     entryComponents: [HomeComponent],
     providers: [

--- a/projects/examples/src/components/spotlight-search/spotlight-search-example.component.html
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-example.component.html
@@ -22,18 +22,6 @@ Press <code>`{{ kbdShortcut }}`</code> or click
         description="The text to be shown in the spotlight search input field when it is empty"
     >
     </vcd-form-input>
-
-    <vcd-form-checkbox
-        label="Show empty sections"
-        styling="toggle-switch"
-        [formControlName]="'showEmptySection'"
-        [description]="'Show the section even if the corresponding search has not found any results'"
-    >
-    </vcd-form-checkbox>
 </form>
 
-<vcd-spotlight-search
-    [(open)]="spotlightOpen"
-    [placeholder]="formGroup.value.placeholder"
-    [showEmptySection]="formGroup.value.showEmptySection"
-></vcd-spotlight-search>
+<vcd-spotlight-search [(open)]="spotlightOpen" [placeholder]="formGroup.value.placeholder"></vcd-spotlight-search>

--- a/projects/examples/src/components/spotlight-search/spotlight-search-example.component.html
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-example.component.html
@@ -1,0 +1,39 @@
+Press <code>`{{ kbdShortcut }}`</code> or click
+<a href="javascript: void(0);" (click)="spotlightOpen = true">here</a> to open the Spotlight Search.
+<p>
+    There are two sections. Both return the same result after the search but one is doing it asynchronously.
+</p>
+<p>
+    Use the keyboard arrow keys to move through the search result. You can do this even while the results are still
+    loading.
+</p>
+<p>
+    Press 'Enter' to invoke the selected action. You can also use the mouse to click on an item
+</p>
+<p>
+    Use the form below to configure the Spotlight Search
+</p>
+
+<form [formGroup]="formGroup" class="clr-form-horizontal">
+    <vcd-form-input
+        label="Placeholder"
+        [type]="'text'"
+        [formControlName]="'placeholder'"
+        description="The text to be shown in the spotlight search input field when it is empty"
+    >
+    </vcd-form-input>
+
+    <vcd-form-checkbox
+        label="Show empty sections"
+        styling="toggle-switch"
+        [formControlName]="'showEmptySection'"
+        [description]="'Show the section even if the corresponding search has not found any results'"
+    >
+    </vcd-form-checkbox>
+</form>
+
+<vcd-spotlight-search
+    [(open)]="spotlightOpen"
+    [placeholder]="formGroup.value.placeholder"
+    [showEmptySection]="formGroup.value.showEmptySection"
+></vcd-spotlight-search>

--- a/projects/examples/src/components/spotlight-search/spotlight-search-example.component.ts
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-example.component.ts
@@ -33,7 +33,6 @@ export class SpotlightSearchExampleComponent implements OnInit, OnDestroy {
     ) {
         this.formGroup = this.fb.group({
             ['placeholder']: [''],
-            ['showEmptySection']: [false],
         });
 
         // Register LazyLoadedActionsSearchProvider and ensure they go first in the list
@@ -49,6 +48,8 @@ export class SpotlightSearchExampleComponent implements OnInit, OnDestroy {
     ngOnInit(): void {
         mousetrap.bind(this.kbdShortcut, () => {
             this.spotlightOpen = true;
+            // Since this happens outside angular zone we need to notify angular manually
+            // otherwise the user should wait for any operation that will trigger angular change detection (angular zone event)
             this.changeDetectorRef.detectChanges();
             return false;
         });

--- a/projects/examples/src/components/spotlight-search/spotlight-search-example.component.ts
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-example.component.ts
@@ -1,0 +1,121 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { ChangeDetectorRef, Component, Injectable, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import {
+    SpotlightSearchProvider,
+    SpotlightSearchResult,
+    SpotlightSearchResultType,
+    SpotlightSearchService,
+} from '@vcd/ui-components';
+import mousetrap from 'mousetrap';
+
+const mousetrapModifierKeys: string[] = ['shift', 'ctrl', 'alt', 'meta', 'mod', 'option', 'command'];
+
+@Component({
+    selector: 'vcd-spotlight-example',
+    templateUrl: './spotlight-search-example.component.html',
+})
+export class SpotlightSearchExampleComponent implements OnInit, OnDestroy {
+    formGroup: FormGroup;
+    kbdShortcut = 'mod+f';
+    spotlightOpen: boolean;
+    private registrationId: string;
+
+    constructor(
+        private fb: FormBuilder,
+        private actionsSearchProvider: ActionsSearchProvider,
+        private spotlightSearchService: SpotlightSearchService,
+        private changeDetectorRef: ChangeDetectorRef
+    ) {
+        this.formGroup = this.fb.group({
+            ['placeholder']: [''],
+            ['showEmptySection']: [false],
+        });
+
+        // Register LazyLoadedActionsSearchProvider and ensure they go first in the list
+        this.registrationId = this.spotlightSearchService.registerProvider(
+            new LazyLoadedActionsSearchProvider(),
+            'Lazy Loaded Actions',
+            0
+        );
+    }
+
+    private resetMousetrap: () => void = () => {};
+
+    ngOnInit(): void {
+        mousetrap.bind(this.kbdShortcut, () => {
+            this.spotlightOpen = true;
+            this.changeDetectorRef.detectChanges();
+            return false;
+        });
+
+        const originalStopCallback = mousetrap.prototype.stopCallback;
+        this.resetMousetrap = () => {
+            mousetrap.unbind(this.kbdShortcut);
+            mousetrap.prototype.stopCallback = originalStopCallback;
+        };
+
+        if (mousetrapModifierKeys.some(key => this.kbdShortcut.includes(key))) {
+            mousetrap.prototype.stopCallback = () => {
+                return false;
+            };
+        }
+    }
+
+    ngOnDestroy(): void {
+        this.resetMousetrap();
+        this.spotlightSearchService.unregisterProvider(this.registrationId);
+    }
+}
+
+const actions: string[] = ['copy', 'paste', 'move', 'dummy'];
+
+function buildFilter(criteria: string): (item: SpotlightSearchResult) => boolean {
+    criteria = criteria ? criteria.toLowerCase() : '';
+    return (item: SpotlightSearchResult) => criteria && item.displayText.toLowerCase().includes(criteria);
+}
+
+@Injectable()
+export class ActionsSearchProvider implements SpotlightSearchProvider {
+    private actions: SpotlightSearchResult[];
+
+    constructor(private spotlightSearchService: SpotlightSearchService) {
+        // Auto register upon creation
+        this.spotlightSearchService.registerProvider(this, 'Actions');
+
+        // Build actions
+        this.actions = actions.map(action => {
+            return {
+                displayText: action,
+                handler: () => {
+                    alert(`Action handler for '${action}' is called`);
+                },
+            };
+        });
+    }
+
+    search(criteria: string): SpotlightSearchResult[] {
+        return this.actions.filter(buildFilter(criteria));
+    }
+}
+
+export class LazyLoadedActionsSearchProvider implements SpotlightSearchProvider {
+    private actions: SpotlightSearchResult[] = actions.map(action => {
+        return {
+            displayText: `Lazy loaded ${action}`,
+            handler: () => {
+                alert(`Action handler for lazy loaded '${action}' is called`);
+            },
+        };
+    });
+
+    search(criteria: string): SpotlightSearchResultType {
+        return new Promise(resolve => {
+            setTimeout(() => resolve(this.actions.filter(buildFilter(criteria))), 2000);
+        });
+    }
+}

--- a/projects/examples/src/components/spotlight-search/spotlight-search.example.module.ts
+++ b/projects/examples/src/components/spotlight-search/spotlight-search.example.module.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { SpotlightSearchModule, VcdFormModule } from '@vcd/ui-components';
+import { ActionsSearchProvider, SpotlightSearchExampleComponent } from './spotlight-search-example.component';
+
+/**
+ * A module that imports all activity reporter examples.
+ */
+@NgModule({
+    imports: [ClarityModule, SpotlightSearchModule, VcdFormModule, ReactiveFormsModule],
+    declarations: [SpotlightSearchExampleComponent],
+    exports: [SpotlightSearchExampleComponent],
+    entryComponents: [SpotlightSearchExampleComponent],
+    providers: [ActionsSearchProvider],
+})
+export class SpotlightSearchExampleModule {}

--- a/projects/examples/src/components/spotlight-search/spotlight-search.examples.module.ts
+++ b/projects/examples/src/components/spotlight-search/spotlight-search.examples.module.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { SpotlightSearchComponent } from '@vcd/ui-components';
+import { Documentation } from '@vmw/ng-live-docs';
+import { SpotlightSearchExampleComponent } from './spotlight-search-example.component';
+import { SpotlightSearchExampleModule } from './spotlight-search.example.module';
+
+Documentation.registerDocumentationEntry({
+    component: SpotlightSearchComponent,
+    displayName: 'Spotlight Search',
+    urlSegment: 'spotlightSearch',
+    examples: [
+        {
+            component: SpotlightSearchExampleComponent,
+            forComponent: null,
+            title: 'Spotlight search',
+        },
+    ],
+});
+
+/**
+ * A module that imports all activity reporter examples.
+ */
+@NgModule({
+    imports: [SpotlightSearchExampleModule],
+})
+export class SpotlightSearchExamplesModule {}


### PR DESCRIPTION
The Spotlight Search component is inspired by the Spotlight Search functionality in Mac OSX (cmd+space) and the Search Everywhere in IntelliJ (shift+shift)

This is the basic implementation consisting of:
- angular component
- search service
- search provider interface
- search results interface

The commit also includes
- documentation
- full feature live doc example
- unit tests

Signed-off-by: Ivo Rahov <irahov@vmware.com>