### PR TITLE
Replace pagination translation call back with a string input

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "peerDependencies": {
         "@angular/common": ">6.0.0",
         "@angular/core": ">6.0.0",

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -126,7 +126,7 @@
             [clrDgPageSize]="this.pageSize"
             [clrDgPageInputDisabled]="!this.pagination.shouldShowPageNumberInput"
         >
-            <div>{{ paginationCallbackWrapper(paginationData) | lazyString }}</div>
+            <div>{{ getPaginationTranslation(paginationData) | lazyString }}</div>
             <clr-dg-page-size
                 [clrPageSizeOptions]="this.pageSizeOptions"
                 *ngIf="this.pagination.shouldShowPageSizeSelector"

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -4,17 +4,24 @@
  */
 
 import { Component, HostBinding, ViewChild } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LoadingListener } from '@clr/angular';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
+import { Observable } from 'rxjs';
+import { first, last } from 'rxjs/operators';
 import { ActivityPromiseResolver } from '../common/activity-reporter/activity-promise-resolver';
 import { TextIcon } from '../common/interfaces/action-item.interface';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { ClrDatagridWidgetObject } from '../utils/test/datagrid/datagrid.wo';
 import { VcdDatagridWidgetObject } from '../utils/test/datagrid/vcd-datagrid.wo';
 import { WidgetFinder } from '../utils/test/widget-object';
-import { ActivityIndicatorType, GridSelectionType, PaginationConfiguration } from './datagrid.component';
+import {
+    ActivityIndicatorType,
+    DEFAULT_PAGINATION_TRANSLATION_KEY,
+    GridSelectionType,
+    PaginationConfiguration,
+} from './datagrid.component';
 import { DatagridComponent, GridDataFetchResult, GridState } from './datagrid.component';
 import { VcdDatagridModule } from './datagrid.module';
 import { DatagridStringFilter, WildCardPosition } from './filters/datagrid-string-filter.component';
@@ -61,6 +68,7 @@ describe('DatagridComponent', () => {
         this.finder = new WidgetFinder(HostWithDatagridComponent);
         this.vcdDatagrid = this.finder.find(GridWithBoldRenderer);
         this.clrGridWidget = this.vcdDatagrid.clrDatagrid;
+        this.component = this.finder.find(VcdDatagridWidgetObject).component as DatagridComponent<MockRecord>;
     });
 
     describe('Grid', () => {
@@ -254,10 +262,18 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() pagination', () => {
+                let translationService: TranslationService;
+                beforeEach(() => {
+                    translationService = TestBed.inject(TranslationService);
+                });
                 describe('pageSize', () => {
                     it('can set the page size before AfterViewInit', function(this: HasFinderAndGrid): void {
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 5 of 150 items');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                            translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                                { firstItem: 1, lastItem: 5, totalItems: 150 },
+                            ])
+                        );
                     });
 
                     it('finds the most rows that can fit in the set height with magic pagination', function(this: HasFinderAndGrid): void {
@@ -268,7 +284,11 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 52 of 150 items');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                            translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                                { firstItem: 1, lastItem: 52, totalItems: 150 },
+                            ])
+                        );
                     });
 
                     it('shows a minimum of 15 rows', function(this: HasFinderAndGrid): void {
@@ -279,7 +299,11 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 15 of 150 items');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                            translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                                { firstItem: 1, lastItem: 15, totalItems: 150 },
+                            ])
+                        );
                     });
 
                     it('allows the user to set a custom row height with magic pagination ', function(this: HasFinderAndGrid): void {
@@ -291,7 +315,11 @@ describe('DatagridComponent', () => {
                             rowHeight: 100,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 19 of 150 items');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                            translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                                { firstItem: 1, lastItem: 19, totalItems: 150 },
+                            ])
+                        );
                     });
 
                     it('uses grid height when height is set to calculate page size ', function(this: HasFinderAndGrid): void {
@@ -302,7 +330,11 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 25 of 150 items');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                            translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                                { firstItem: 1, lastItem: 25, totalItems: 150 },
+                            ])
+                        );
                     });
 
                     it('lets the user set rows per page', function(this: HasFinderAndGrid): void {
@@ -311,7 +343,11 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 100 of 150 items');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                            translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                                { firstItem: 1, lastItem: 100, totalItems: 150 },
+                            ])
+                        );
                     });
 
                     it('creates a smaller page when buttons are present', function(this: HasFinderAndGrid): void {
@@ -338,7 +374,11 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 51 of 150 items');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                            translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                                { firstItem: 1, lastItem: 51, totalItems: 150 },
+                            ])
+                        );
                     });
 
                     it('creates a smaller page size when a header is present', function(this: HasFinderAndGrid): void {
@@ -350,7 +390,11 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 51 of 150 items');
+                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                            translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                                { firstItem: 1, lastItem: 51, totalItems: 150 },
+                            ])
+                        );
                     });
                 });
 
@@ -384,12 +428,6 @@ describe('DatagridComponent', () => {
                         this.finder.detectChanges();
                         expect(this.clrGridWidget.getPaginationSizeSelectorText()).toEqual('Total Items52050100');
                     });
-                });
-            });
-
-            describe('@Input() paginationCallback', () => {
-                it('displays pagination callback information on page one', function(this: HasFinderAndGrid): void {
-                    expect(this.clrGridWidget.getPaginationDescription()).toEqual('1 - 5 of 150 items');
                 });
             });
 
@@ -1102,6 +1140,24 @@ describe('DatagridComponent', () => {
                 }
             );
         });
+
+        describe('getPaginationTranslation', () => {
+            it('returns translated string', async function(this: HasFinderAndGrid): Promise<void> {
+                const translatedString = await (this.component.getPaginationTranslation({
+                    firstItem: 1,
+                    lastItem: 10,
+                    totalItems: 100,
+                } as any) as Observable<string>)
+                    .pipe(first())
+                    .toPromise();
+
+                expect(translatedString).toBe(
+                    TestBed.inject(TranslationService).translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
+                        { firstItem: 2, lastItem: 11, totalItems: 100 },
+                    ])
+                );
+            });
+        });
     });
 
     describe('Column Renderers', () => {
@@ -1158,7 +1214,6 @@ describe('DatagridComponent', () => {
                 [clrDatarowCssClassGetter]="clrDatarowCssClassGetter"
                 [selectionType]="selectionType"
                 (selectionChanged)="selectionChanged($event)"
-                [paginationCallback]="paginationCallback"
                 [paginationDropdownText]="paginationText"
                 [pagination]="pagination"
                 [buttonConfig]="buttonConfig"
@@ -1229,10 +1284,6 @@ export class HostWithDatagridComponent {
     trackBy = (index, record: MockRecord) => record.name;
 
     selectionChanged(selection: MockRecord[]): void {}
-
-    paginationCallback(first: number, last: number, total: number): string {
-        return `${first} - ${last} of ${total} items`;
-    }
 
     clrDatarowCssClassGetter(a: MockRecord, index: number): string {
         return '';

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -57,6 +57,11 @@ const MAX_HEADER_HEIGHT = 40;
 const ROW_HEIGHT = 37;
 
 /**
+ * Key used for translation of pagination when a translation key is not given as input from the caller
+ */
+export const DEFAULT_PAGINATION_TRANSLATION_KEY = 'vcd.cc.grid.default.pagination';
+
+/**
  * Different types of row selection on the grid
  */
 export enum GridSelectionType {
@@ -554,21 +559,9 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
     private viewInitted = false;
 
     /**
-     * Gives the correct string to display for the pagination.
-     *
-     * @param firstItem the index of the first item displayed.
-     * @param lastItem the index of the last item displayed.
-     * @param totalItems the total number of items that could be displayed.
+     * Used for translating pagination information displayed in the grid
      */
-    @Input() paginationCallback: PaginationCallback = (firstItem: number, lastItem: number, totalItems: number) => {
-        return this.translationService.translateAsync('vcd.cc.grid.default.pagination', [
-            {
-                firstItem,
-                lastItem,
-                totalItems,
-            },
-        ]);
-    };
+    @Input() paginationTranslationKey: string = DEFAULT_PAGINATION_TRANSLATION_KEY;
 
     /**
      * To add or replace a column of this datagrid columns. Exposed for columns modifiers(eg: directives) that listen to
@@ -846,10 +839,16 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit {
     }
 
     /**
-     * Updates the pagination data and makes the callback.
+     * Gives the correct string to display for the pagination.
      */
-    paginationCallbackWrapper(paginationData: ClrDatagridPagination): LazyString {
-        return this.paginationCallback(paginationData.firstItem + 1, paginationData.lastItem + 1, this.totalItems);
+    getPaginationTranslation(paginationData: ClrDatagridPagination): LazyString {
+        return this.translationService.translateAsync(this.paginationTranslationKey, [
+            {
+                firstItem: paginationData.firstItem + 1,
+                lastItem: paginationData.lastItem + 1,
+                totalItems: paginationData.totalItems,
+            },
+        ]);
     }
 
     /**


### PR DESCRIPTION
This commit has the following changes:
- Make the DG take a string as input for pagination translation instead of a callback

These changes affect VCD UI and they are made in the following MR:
https://gitlab.eng.vmware.com/core-build/vcd_ui/merge_requests/2097