### PR TITLE
Disable Ivy for route-analyzer

### DIFF
--- a/projects/route-analyzer/package.json
+++ b/projects/route-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/route-analyzer",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "bin": "cli.js",
   "dependencies": {
     "@wessberg/ts-evaluator": "0.0.25",

--- a/projects/route-analyzer/tsconfig.lib.json
+++ b/projects/route-analyzer/tsconfig.lib.json
@@ -17,7 +17,8 @@
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
-    "enableResourceInlining": true
+    "enableResourceInlining": true,
+    "enableIvy": false
   },
   "exclude": [
     "src/test.ts",


### PR DESCRIPTION
Previous attempt to publush to npm repository failed with error:
> ERROR: Trying to publish a package that has been compiled by Ivy. This is not allowed.
> Please delete and rebuild the package, without compiling with Ivy, before attempting to publish.

Signed-off-by: Ivo Rahov <irahov@vmware.com>