### PR TITLE
Use the same typescript version for @wessberg/ts-evaluator as the route-analyzer

### DIFF
--- a/projects/route-analyzer/package.json
+++ b/projects/route-analyzer/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@vcd/route-analyzer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "bin": "cli.js",
   "dependencies": {
     "@wessberg/ts-evaluator": "0.0.25",
-    "yargs": "15.3.1",
-    "typescript": "3.5.3"
+    "yargs": "15.3.1"
+  },
+  "peerDependencies": {
+    "typescript": "^3.x"
   },
   "devDependencies": {
     "ts-node": "^8.10.1",

--- a/projects/route-analyzer/src/lib/utils.ts
+++ b/projects/route-analyzer/src/lib/utils.ts
@@ -85,7 +85,9 @@ export function evaluateNode(
     typeChecker: ts.TypeChecker,
     throwOnFailure: boolean = true
 ): any {
-    const val: EvaluateResult = evaluate({ node, typeChecker });
+    // The evaluation should use the same typescript version as the analyzer
+    // otherwise the evaluation may not succeed.
+    const val: EvaluateResult = evaluate({ node, typeChecker, typescript: ts });
     if (val.success) {
         return val.value as object;
     }


### PR DESCRIPTION
If typescripts are different versions then evaluation may not succeed.
Also the typescript library is now a peer dependency since route-analyzer
is not only a standalone tool but also an angular package library,
providing AppRoute interface.
All of this implies that typescript should not be bundled with route-analyzer.

Signed-off-by: Ivo Rahov <irahov@vmware.com>