### PR TITLE
Fixes a bug in the datagrid where filtering, pagination, sorting might make it empty

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.0",
+    "version": "1.0.0-dev.1",
     "peerDependencies": {
         "@angular/common": ">6.0.0",
         "@angular/core": ">6.0.0",


### PR DESCRIPTION
# Description

Fixed a bug in the datagrid where if the grid was set to empty, then set to have items, it might appear as empty. This is because of a bug in Clarity https://github.com/vmware/clarity/issues/4692

# Testing

Loaded this build of components into VCD-UI and sorted, filtered, and paginated in the orgs list screen. All of these actions worked as intended. 

Signed-off-by: Ryan Bradford <rbradford@vmware.com>