### PR TITLE
Restrict the css only to the spotlight search component

### DIFF
--- a/projects/components/src/spotlight-search/spotlight-search.component.scss
+++ b/projects/components/src/spotlight-search/spotlight-search.component.scss
@@ -1,45 +1,47 @@
-::ng-deep {
-    .modal-header {
-        display: none;
+:host {
+    ::ng-deep {
+        .modal-header {
+            display: none;
+        }
+
+        .modal-backdrop {
+            background: transparent;
+        }
     }
 
-    .modal-backdrop {
-        background: transparent;
-    }
-}
-
-.modal-body {
-    display: flex;
-    flex-direction: column;
-    height: 500px;
-
-    .search-input-container {
+    .modal-body {
         display: flex;
+        flex-direction: column;
+        height: 500px;
 
-        clr-icon {
-            margin-top: 2px;
-            margin-right: 4px;
+        .search-input-container {
+            display: flex;
+
+            clr-icon {
+                margin-top: 2px;
+                margin-right: 4px;
+            }
+
+            .clr-input {
+                flex-grow: 1;
+            }
         }
 
-        .clr-input {
-            flex-grow: 1;
-        }
-    }
+        .search-result-container {
+            margin-top: 8px;
+            flex: 1;
+            overflow: auto;
 
-    .search-result-container {
-        margin-top: 8px;
-        flex: 1;
-        overflow: auto;
+            .search-result-section-title {
+                font-weight: bold;
+            }
 
-        .search-result-section-title {
-            font-weight: bold;
-        }
+            .search-result-item {
+                padding-left: 8px;
 
-        .search-result-item {
-            padding-left: 8px;
-
-            &.selected {
-                background-color: var(--clr-global-selection-color);
+                &.selected {
+                    background-color: var(--clr-global-selection-color);
+                }
             }
         }
     }


### PR DESCRIPTION
This is to address:
spotlight search styles hides modal-backdrop and modal-headers #130
https://github.com/vmware/vmware-cloud-director-ui-components/issues/130

Signed-off-by: Ivo Rahov <irahov@vmware.com>