### PR TITLE
Restrict the css only to the spotlight search component

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ the extremely long folder name.
 
 Publishing happens through the CI/CD pipeline. See [package.json](.github/workflows/ci-cd.yml)
 
+## Versioning
+
+For all official releases, versioning should be semantic as per [NPM's documentation](https://docs.npmjs.com/about-semantic-versioning).
+
+For all development, nightly builds, the version should be created using `npm version prerelease --preid=dev`.
+
 ### Steps for publishing an @next release:
 
 -   Update version number in projects/<lib-name>/package.json

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.1",
+    "version": "1.0.0-dev.2",
     "peerDependencies": {
         "@angular/common": ">6.0.0",
         "@angular/core": ">6.0.0",

--- a/projects/components/src/spotlight-search/spotlight-search.component.scss
+++ b/projects/components/src/spotlight-search/spotlight-search.component.scss
@@ -1,8 +1,7 @@
-::ng-deep {
+:host ::ng-deep {
     .modal-header {
         display: none;
     }
-
     .modal-backdrop {
         background: transparent;
     }


### PR DESCRIPTION
# Description

Fixes an issue in VCD-UI where all modals were appearing without a header. 

Fixes #130 

# Testing

Linked to VCD-UI and made sure the modals display correctly.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>