### PR TITLE
Detail pane header is now dynamic

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -111,7 +111,7 @@
 
     <ng-container ngProjectAs="clr-dg-detail" *ngIf="detailPane">
         <clr-dg-detail *clrIfDetail="let restItem">
-            <clr-dg-detail-header>{{ detailPane.header }}</clr-dg-detail-header>
+            <clr-dg-detail-header>{{ detailPane.header(restItem) }}</clr-dg-detail-header>
             <clr-dg-detail-body>
                 <ng-template
                     [vcdComponentRendererOutlet]="{

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -663,6 +663,7 @@ describe('DatagridComponent', () => {
                 this.clrGridWidget.clickDetailPaneButton(0);
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getAllDetailPaneContents().length).toEqual(1);
+                expect(this.clrGridWidget.getDetailPaneHeader()).toEqual('Person 1');
             });
         });
 
@@ -1318,7 +1319,7 @@ export class HostWithDatagridComponent {
     isRowExpanded = false;
 
     detailPane = {
-        header: 'Pane!',
+        header: (record: MockRecord) => record.name,
         component: DatagridDetailsPaneComponent,
     };
 

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -205,7 +205,7 @@ export interface DetailPane<R> {
     /**
      * The header that goes on top of this detail pane.
      */
-    header: string;
+    header: (record: R) => string;
     /**
      * The contents that go within this detail pane.
      */

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -152,6 +152,13 @@ export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
     }
 
     /**
+     * Returns the header of the detail pane.
+     */
+    getDetailPaneHeader(): string {
+        return this.getText('.datagrid-detail-header-title');
+    }
+
+    /**
      * Clicks the given detail row button.
      */
     clickDetailRowButton(row: number): void {

--- a/projects/examples/src/components/datagrid/datagrid-detail-pane.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-detail-pane.example.component.ts
@@ -30,7 +30,7 @@ export class DatagridDetailPaneExampleComponent {
     };
 
     pane = {
-        header: 'Pane!',
+        header: (record: Data) => record.value,
         component: DatagridDetailPaneSubComponent,
     };
 


### PR DESCRIPTION
# Description

Makes it so the header of the detail pane is a callback that takes in a record and returns a string, instead of just a string.

# Testing

Updated the unit tests and examples to pass the header as a callback.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>