### PR TITLE
Change styles of action menu for using it inside the datagrid components

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.4",
+    "version": "1.0.0-dev.5",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.html
+++ b/projects/components/src/action-menu/action-menu.component.html
@@ -11,6 +11,7 @@
         </ng-container>
 
         <vcd-dropdown
+            class="inline-action-dropdown"
             [items]="contextualActions"
             [trackByFunction]="actionsTrackBy"
             [dropdownPosition]="dropdownPosition"

--- a/projects/components/src/action-menu/action-menu.component.scss
+++ b/projects/components/src/action-menu/action-menu.component.scss
@@ -1,23 +1,15 @@
 .inline-actions-container {
     display: flex;
     flex-direction: row;
-    margin-top: 10px;
 
     & > .static-actions-separator {
         flex: 1 1 auto;
     }
 
-    & > .static-actions {
-        margin-right: 0;
-    }
-
-    & ::ng-deep button.btn.inline-action-button {
-        margin-top: 0;
-
-        margin-right: 15px;
-
-        &:last-child {
-            margin-right: 0;
+    & .inline-action-dropdown {
+        & ::ng-deep .nested-dropdown > .first-dropdown-toggle {
+            // Without this, Clarity styles from .dropdown-toggle are making the margin-top as 0 px
+            margin-top: 0.3rem;
         }
     }
 }

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -34,6 +34,9 @@ export class ActionMenuComponent<R, T> {
      * List of actions containing both static and contextual that are given by the calling component
      */
     @Input() set actions(actions: ActionItem<R, T>[]) {
+        if (!actions) {
+            return;
+        }
         this._actions = actions.map(action => {
             if (!action.actionType) {
                 action.actionType = ActionType.CONTEXTUAL;
@@ -42,7 +45,7 @@ export class ActionMenuComponent<R, T> {
         });
     }
     get actions(): ActionItem<R, T>[] {
-        return this.getDeepCopy(this._actions);
+        return getDeepCopyOfActionItems(this._actions);
     }
 
     private _actionDisplayConfig: ActionDisplayConfig = DEFAULT_ACTION_DISPLAY_CONFIG;
@@ -169,24 +172,16 @@ export class ActionMenuComponent<R, T> {
      * 'vcd.cc.action.menu.all.actions'
      */
     get contextualDropdownActions(): ActionItem<R, T>[] | object {
+        const contextualFeaturedActions = this.contextualFeaturedActions;
+        if (!contextualFeaturedActions?.length) {
+            return this.contextualActions;
+        }
         return this.contextualFeaturedActions.concat([
             {
                 textKey: 'vcd.cc.action.menu.all.actions',
                 children: this.contextualActions,
             },
         ]);
-    }
-
-    /**
-     * Without the deep copy, the changes made to any of the action children in one of the methods are persisting in other methods
-     */
-    private getDeepCopy(actions: ActionItem<R, T>[]): ActionItem<R, T>[] {
-        return actions.map(action => {
-            if (action.children && action.children.length) {
-                action.children = this.getDeepCopy(action.children);
-            }
-            return { ...action };
-        });
     }
 
     /**
@@ -322,4 +317,16 @@ export class ActionMenuComponent<R, T> {
             this.shouldDisplayStaticFeaturedActions(this.actionStyling.INLINE)
         );
     }
+}
+
+/**
+ * Without the deep copy, the changes made to any of the action children in one of the methods will persist in other methods
+ */
+export function getDeepCopyOfActionItems<R, T>(actions: ActionItem<R, T>[]): ActionItem<R, T>[] {
+    return actions.map(action => {
+        if (action.children && action.children.length) {
+            action.children = getDeepCopyOfActionItems(action.children);
+        }
+        return { ...action };
+    });
 }

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -11,7 +11,7 @@
     (clrDgSingleSelectedChange)="selectionChanged.emit([$event])"
 >
     <clr-dg-placeholder>{{ emptyGridPlaceholder }}</clr-dg-placeholder>
-    <clr-dg-action-bar *ngIf="shouldShowActionBarOnTop">
+    <clr-dg-action-bar class="top-action-bar" *ngIf="shouldShowActionBarOnTop">
         <vcd-action-menu
             [actions]="actions"
             [selectedEntities]="datagridSelection"

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -27,8 +27,8 @@ $supported-buttons: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
     }
 }
 
-.feature-bar {
-    display: inline-block;
+clr-dg-action-bar.top-action-bar {
+    height: unset;
 }
 
 // The height properties need to be marked as important because of a bug in Clarity

--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -1,6 +1,6 @@
 <clr-dropdown class="nested-dropdown">
     <button
-        [ngClass]="{ 'btn btn-link': dropdownTriggerBtnTxt }"
+        [ngClass]="{ 'btn btn-link': dropdownTriggerBtnTxt, 'first-dropdown-toggle': !isNestedDropdown }"
         clrDropdownTrigger
         [vcdShowClippedText]="clipTextConfig"
         [disabled]="isDropdownDisabled"


### PR DESCRIPTION
**What was the change?**
Tweak the styles of action menu component so that it can be used in vcd_ui inside the datagrid components

**Why was this change made?**
Currently when the action menu is used inside datagrid components in vcd_ui, they don't show up properly

**Testing Done:**
Screenshots of the vcd_ui grids in which these changes are applied is attached in this MR: https://gitlab.eng.vmware.com/core-build/vcd_ui/merge_requests/2209

Note: Also, That MR will be pushed only after this PR is merged.