### PR TITLE
Calculate actions availability switch

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.9",
+    "version": "1.0.0-dev.10",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -67,6 +67,8 @@ export class ActionMenuComponent<R, T> {
         return this._actionDisplayConfig;
     }
 
+    @Input() calculateActionsAvailability: boolean = true;
+
     /**
      * Text Content of the action menu dropdown trigger button. Used when {@link #actionDisplayConfig} styling is
      * {@link ActionStyling.DROPDOWN}
@@ -140,7 +142,12 @@ export class ActionMenuComponent<R, T> {
      * disabled mode
      */
     private isActionAvailable(action: ActionItem<R, T>): boolean {
-        return !action.availability || action.availability(this.selectedEntities) || this.isActionDisabled(action);
+        return (
+            !this.calculateActionsAvailability ||
+            !action.availability ||
+            action.availability(this.selectedEntities) ||
+            this.isActionDisabled(action)
+        );
     }
 
     /**


### PR DESCRIPTION
Add a switch to turn off calculation of actions availability if they are already calculated outside