### PR TITLE
Created new WidgetObject pattern for Cypress and Angular tests

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.17",
+    "version": "1.0.0-dev.18",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/utils/test/angular-widget-driver.spec.ts
+++ b/projects/components/src/utils/test/angular-widget-driver.spec.ts
@@ -1,0 +1,189 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, Input, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AngularWidgetDriver } from './angular-widget-driver';
+import { AngularWidgetFinder, HasAngularFinder } from './angular-widget-finder';
+import { BaseWidgetObject } from './base-widget-object';
+
+/**
+ * This is the reusable component being tested, typically goes in its own file
+ */
+@Component({
+    selector: 'vcd-click-tracker',
+    template: `
+        <div>
+            <h1>{{ header }}</h1>
+            <p (click)="clickCount = clickCount + 1">
+                Clicks: <span class="click-count">{{ clickCount }}</span>
+            </p>
+        </div>
+    `,
+})
+class ClickTrackerComponent {
+    @Input() header = 'Click Tracker';
+    clickCount = 0;
+}
+
+/**
+ * Each component being tested should have a matching widget object.
+ *
+ * This class could be tested mostly through the component instance but we are using the HTML to show the base class's
+ * functionality
+ */
+class ClickTrackerWidgetObject extends BaseWidgetObject {
+    static tagName = 'vcd-click-tracker';
+
+    get clickCount(): Promise<string> {
+        // If we wanted to use the instance, but we want to show base functionality
+        // return this.component.clickCount;
+        return this.getText('.click-count');
+    }
+
+    get headerText(): Promise<string> {
+        // If we wanted to use the instance
+        // return this.component.header;
+        return this.getText('h1');
+    }
+
+    clickTrackedElement(): Promise<void> {
+        // Clicking requires the DOM
+        return this.click('p');
+    }
+}
+
+/**
+ * These are the host components that are typically created within the test
+ */
+@Component({
+    template: `
+        <vcd-click-tracker header="First" class="first"></vcd-click-tracker>
+        <vcd-click-tracker header="Second" class="second"></vcd-click-tracker>
+    `,
+})
+class HostWithTwoComponent {}
+
+/**
+ * This is the host component that is typically created within the test
+ */
+@Component({
+    template: `
+        <vcd-click-tracker header="First"></vcd-click-tracker>
+    `,
+})
+class HostWithOneComponent {}
+
+function setup(fixtureRoot: Type<unknown>): void {
+    beforeEach(async function(this: HasAngularFinder): Promise<void> {
+        await TestBed.configureTestingModule({
+            declarations: [ClickTrackerComponent, fixtureRoot],
+        }).compileComponents();
+        this.finder = new AngularWidgetFinder(fixtureRoot);
+        this.finder.detectChanges();
+    });
+}
+
+describe('AngularWidgetFinder', () => {
+    describe('when there are multiple instances within host', () => {
+        setup(HostWithTwoComponent);
+
+        describe('find', () => {
+            it('finds object by simple CSS classNames', async function(this: HasAngularFinder): Promise<void> {
+                const widget = this.finder.find({
+                    woConstructor: ClickTrackerWidgetObject,
+                    className: 'second',
+                });
+                expect(await widget.headerText).toBe('Second');
+            });
+
+            it('throws an error if widget is not found', function(this: HasAngularFinder): void {
+                expect(() => {
+                    this.finder.find({
+                        woConstructor: ClickTrackerWidgetObject,
+                        className: 'does-not-exist',
+                    });
+                }).toThrow();
+            });
+
+            it('throws an error if multiple widgets are found', function(this: HasAngularFinder): void {
+                expect(() => {
+                    this.finder.find(ClickTrackerWidgetObject);
+                }).toThrow();
+            });
+        });
+
+        describe('findWidgets', () => {
+            it('does not throw an error if no widgets are found', function(this: HasAngularFinder): void {
+                expect(() => {
+                    this.finder.findWidgets({
+                        woConstructor: ClickTrackerWidgetObject,
+                        className: 'does-not-exist',
+                    });
+                }).not.toThrow();
+            });
+        });
+    });
+
+    describe('when there is a single instance within host', () => {
+        setup(HostWithOneComponent);
+
+        describe('find', () => {
+            it('returns the first one within the fixture if no classname is specified', function(this: HasAngularFinder): void {
+                const widget = this.finder.find(ClickTrackerWidgetObject);
+                widget.headerText.then(item => item === 'First');
+            });
+        });
+    });
+});
+
+/**
+ * Test object for the tests below
+ */
+interface HasClickTracker {
+    clickTracker: ClickTrackerWidgetObject;
+    fixture: ComponentFixture<ClickTrackerComponent>;
+}
+
+/**
+ * For all these tests of base class functionality, you must look at the implementation of the methods being called
+ * in the concrete {@link ClickTrackerWidgetObject}
+ */
+describe('WidgetObject (through ClickTracerWidgetObject)', () => {
+    beforeEach(async function(this: HasClickTracker): Promise<void> {
+        await TestBed.configureTestingModule({
+            declarations: [ClickTrackerComponent],
+        }).compileComponents();
+
+        this.fixture = TestBed.createComponent(ClickTrackerComponent);
+        this.fixture.detectChanges();
+        this.clickTracker = new ClickTrackerWidgetObject(new AngularWidgetDriver(this.fixture));
+    });
+
+    afterEach(function(this: HasClickTracker): void {
+        if (this.fixture) {
+            this.fixture.destroy();
+        }
+    });
+
+    describe('constructor', () => {
+        it('can be called when you create the instance directly', function(this: HasClickTracker): void {
+            expect(this.clickTracker).toBeTruthy();
+        });
+    });
+
+    describe('getText', () => {
+        it('can find elements within itself passing a css query', async function(this: HasClickTracker): Promise<void> {
+            expect(await this.clickTracker.clickCount).toEqual('0');
+        });
+    });
+
+    describe('click', () => {
+        it('calls detectChanges after clicking', async function(this: HasClickTracker): Promise<void> {
+            await this.clickTracker.clickTrackedElement();
+            expect(await this.clickTracker.clickCount).toEqual('1');
+        });
+    });
+});

--- a/projects/components/src/utils/test/angular-widget-driver.ts
+++ b/projects/components/src/utils/test/angular-widget-driver.ts
@@ -1,0 +1,119 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { DebugElement } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { AngularWidgetFinder } from './angular-widget-finder';
+import { WidgetDriver } from './base-widget-object';
+import { FindableWidget, FindParams } from './widget-object';
+
+/**
+ * A WidgetDriver that knows how to interface with the Angular framework.
+ */
+export class AngularWidgetDriver<T> implements WidgetDriver {
+    constructor(
+        protected fixture: ComponentFixture<any>,
+        protected root: DebugElement = fixture.debugElement,
+        protected component: T = fixture.componentInstance
+    ) {}
+
+    find<W extends WidgetDriver>(params: FindParams<FindableWidget<W>> | FindableWidget<W>): W {
+        return new AngularWidgetFinder(this.fixture).find<W, FindableWidget<W>>(params, this.root);
+    }
+
+    async click(cssSelector?: string): Promise<void> {
+        this.getDebugElement(cssSelector).nativeElement.click();
+        this.fixture.detectChanges();
+    }
+
+    async classes(cssSelector?: string): Promise<string[]> {
+        return Object.keys(this.getDebugElement(cssSelector).nativeElement.classes);
+    }
+
+    async check(cssSelector?: string): Promise<void> {
+        const checkboxElement = this.getDebugElement(cssSelector).nativeElement;
+        checkboxElement.checked = !checkboxElement.checked;
+        checkboxElement.dispatchEvent(new Event('change'));
+        this.fixture.detectChanges();
+    }
+
+    async getChecked(cssSelector?: string): Promise<boolean> {
+        return this.getDebugElement(cssSelector).nativeElement.checked;
+    }
+
+    async select(option: string, cssSelector?: string): Promise<void> {
+        const selectElement = this.getDebugElement(cssSelector).nativeElement;
+        selectElement.value = option;
+        selectElement.dispatchEvent(new Event('change'));
+        this.fixture.detectChanges();
+    }
+
+    async sendKeyboardKey(key: string, cssSelector?: string): Promise<void> {
+        const nativeElement: HTMLBaseElement = this.getDebugElement(cssSelector).nativeElement;
+        nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+        nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key, bubbles: true }));
+        this.fixture.detectChanges();
+    }
+
+    async setInputValue(value: string, shouldAppend?: boolean, cssSelector?: string): Promise<void> {
+        if (!shouldAppend) {
+            this.clearInputValue(cssSelector);
+        }
+        return this.internalSetInputValue(this.getDebugElement(cssSelector), value);
+    }
+
+    async clearInputValue(cssSelector?: string): Promise<void> {
+        return this.internalSetInputValue(this.getDebugElement(cssSelector), '');
+    }
+
+    private internalSetInputValue(element: DebugElement, value: string): void {
+        element.nativeElement.value = String(value);
+        element.nativeElement.dispatchEvent(new Event('input'));
+        this.fixture.detectChanges();
+    }
+
+    async getText(cssSelector?: string): Promise<string> {
+        return this.getDebugElement(cssSelector).nativeElement.textContent.trim();
+    }
+
+    async getTexts(parentCssSelector?: string, cssSelector?: string): Promise<string[]> {
+        return this.getDebugElements(parentCssSelector, cssSelector).map(elem => elem.nativeElement.textContent.trim());
+    }
+
+    async getInputValue(cssSelector?: string): Promise<string | number | string[]> {
+        return this.getDebugElement(cssSelector).nativeElement.value;
+    }
+
+    async getInputValues(parentCssSelector?: string, cssSelector?: string): Promise<(string | number | string[])[]> {
+        return this.getDebugElements(parentCssSelector, cssSelector).map(elem => elem.nativeElement.value);
+    }
+
+    async exists(cssSelector?: string): Promise<boolean> {
+        return !!this.getDebugElement(cssSelector);
+    }
+
+    async disabled(cssSelector?: string): Promise<boolean> {
+        return this.getDebugElement(cssSelector).nativeElement.disabled;
+    }
+
+    async visible(cssSelector?: string): Promise<boolean> {
+        return this.exists(cssSelector);
+    }
+
+    async hidden(cssSelector?: string): Promise<boolean> {
+        return !(await this.exists(cssSelector));
+    }
+
+    private getDebugElement(cssSelector?: string): DebugElement {
+        return cssSelector ? this.root.query(By.css(cssSelector)) : this.root;
+    }
+
+    private getDebugElements(parentCssSelector?: string, cssSelector?: string): DebugElement[] {
+        const parent = parentCssSelector ? this.root.query(By.css(parentCssSelector)) : this.root;
+        const query = cssSelector ? By.css(cssSelector) : By.all();
+        return parent.queryAll(query);
+    }
+}

--- a/projects/components/src/utils/test/angular-widget-finder.ts
+++ b/projects/components/src/utils/test/angular-widget-finder.ts
@@ -1,0 +1,87 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { DebugElement, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { AngularWidgetDriver } from './angular-widget-driver';
+import { FindableWidget, FindParams, isFindParamsObject } from './widget-object';
+
+/**
+ * Finds instances that implement {@link FindableWidget}
+ * H is the host component's type
+ */
+export class AngularWidgetFinder<H = unknown> {
+    /**
+     * We don't care or could possibly know the type of fixture
+     */
+    private fixture: ComponentFixture<H>;
+
+    /**
+     * If you need direct access to manipulate the host
+     */
+    public hostComponent: H;
+
+    /**
+     * @param componentConstructor The host component to be created as the root of the tests's fixture
+     */
+    constructor(arg: Type<H> | ComponentFixture<H>) {
+        this.fixture = (arg as ComponentFixture<H>).componentRef
+            ? (arg as ComponentFixture<H>)
+            : TestBed.createComponent(arg as Type<H>);
+        this.hostComponent = this.fixture.componentInstance;
+    }
+
+    /**
+     * Finds widgets within a fixture
+     * @return A Potentially empty list of widgets matching the given specs
+     */
+    public findWidgets<C, T extends FindableWidget<C>>(
+        params: FindParams<T> | T,
+        parent?: DebugElement
+    ): InstanceType<T>[] {
+        const defaults = { ancestor: this.fixture.debugElement, className: '' };
+        const { woConstructor, ancestor, className } = isFindParamsObject(params)
+            ? { ...defaults, ...params }
+            : { ...defaults, woConstructor: params };
+        let query = woConstructor.tagName;
+        if (className) {
+            query += `.${className}`;
+        }
+        const componentRoots = (parent ? parent : ancestor).queryAll(By.css(query));
+        const widgets = componentRoots.map(
+            // Typescript is not able to infer it correctly as the subclass but we know for sure
+            root => new woConstructor(new AngularWidgetDriver(this.fixture, root, root.componentInstance))
+        );
+        return widgets as InstanceType<T>[];
+    }
+
+    /**
+     * Finds a single widget object
+     * @throws An error if the widget is not found or if there are multiple instances
+     */
+    public find<C, T extends FindableWidget<C>>(params: FindParams<T> | T, parent?: DebugElement): InstanceType<T> {
+        const widgets = this.findWidgets(params, parent);
+        const tagName = isFindParamsObject(params) ? params.woConstructor.tagName : params.tagName;
+        if (widgets.length === 0) {
+            throw Error(`Did not find a <${tagName}>`);
+        }
+        if (widgets.length > 1) {
+            throw Error(`Expected to find a single <${tagName}> but found ${widgets.length}`);
+        }
+        return widgets[0] as InstanceType<T>;
+    }
+
+    public detectChanges(): void {
+        this.fixture.detectChanges();
+    }
+}
+
+/**
+ * Can be used in tests that use `this` to share a finder with before/AfterEach instead of leaky closures
+ */
+export interface HasAngularFinder {
+    finder: AngularWidgetFinder;
+}

--- a/projects/components/src/utils/test/base-widget-object.ts
+++ b/projects/components/src/utils/test/base-widget-object.ts
@@ -1,0 +1,205 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { FindableWidget, FindParams } from './widget-object';
+
+/**
+ * Represents an object that knows how to drive testing for a specific testing type.
+ */
+export interface WidgetDriver {
+    /**
+     * Finds a widget using the given params within this widget driver.
+     */
+    find<W extends WidgetDriver>(params: FindParams<FindableWidget<W>> | FindableWidget<W>): W;
+
+    /**
+     * Says if any child elements exists that use this css selector.
+     */
+    exists(cssSelector?: string): Promise<boolean>;
+
+    /**
+     * Says if the element is disabled.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    disabled(cssSelector?: string): Promise<boolean>;
+
+    /**
+     * Says if the element is hidden.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    hidden(cssSeletor?: string): Promise<boolean>;
+
+    /**
+     * Says if the element is visible.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    visible(cssSelector?: string): Promise<boolean>;
+
+    /**
+     * Gives the CSS classes applied to the element
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    classes(cssSelector?: string): Promise<string[]>;
+
+    /**
+     * Clicks the element.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    click(cssSelector?: string): Promise<void>;
+
+    /**
+     * Checks the checkbox contained in the element.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    check(cssSelector?: string): Promise<void>;
+
+    /**
+     * Says if the checkbox is checked within the element.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    getChecked(cssSelector?: string): Promise<boolean>;
+
+    /**
+     * Selects the given option within the element.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    select(option: string, cssSelector?: string): Promise<void>;
+
+    /**
+     * Sends a single key event to the element.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    sendKeyboardKey(key: string, cssSelector?: string): Promise<void>;
+
+    /**
+     * Sets the input value of the element to the given value.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     * @param shouldAppend if the value should be appended to the current input value or if the input should be cleared.
+     *                     defaults to clearing the input (false).
+     */
+    setInputValue(value: string, shouldAppend?: boolean, cssSelector?: string): Promise<void>;
+
+    /**
+     * Gives the value of the input.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    getInputValue(cssSelector?: string): Promise<string | number | string[]>;
+
+    /**
+     * Gives the value of all inputs that match the given css selector.
+     *
+     * @param parentCssSelector the CSS selector of the immediate parent of the children.
+     * @param cssSelector the CSS selector to filter the children by.
+     */
+    getInputValues(parentCssSelector?: string, cssSelector?: string): Promise<(string | number | string[])[]>;
+
+    /**
+     * Clears the input value of the element.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    clearInputValue(cssSelector?: string): Promise<void>;
+
+    /**
+     * Gives the text within the element.
+     *
+     * @param cssSelector the selector to use to find the element, if null uses the current WidgetDriver.
+     */
+    getText(cssSelector?: string): Promise<string>;
+
+    /**
+     * Gives the text of all elements that match the given CSS selectors.
+     *
+     * @param parentCssSelector the CSS selector of the immediate parent of the children.
+     * @param cssSelector the CSS selector to filter the children by.
+     */
+    getTexts(parentCssSelector?: string, cssSelector?: string): Promise<string[]>;
+}
+
+/**
+ * An object that all other WidgetObjects should extend.
+ */
+export class BaseWidgetObject implements WidgetDriver {
+    constructor(private driver: WidgetDriver) {}
+
+    find<W extends WidgetDriver>(params: FindParams<FindableWidget<W>> | FindableWidget<W>): W {
+        return this.driver.find(params);
+    }
+
+    exists(cssSelector?: string): Promise<boolean> {
+        return this.driver.exists(cssSelector);
+    }
+
+    disabled(cssSelector?: string): Promise<boolean> {
+        return this.driver.disabled(cssSelector);
+    }
+
+    visible(cssSelector?: string): Promise<boolean> {
+        return this.driver.visible(cssSelector);
+    }
+
+    hidden(cssSelector?: string): Promise<boolean> {
+        return this.driver.hidden(cssSelector);
+    }
+
+    click(cssSelector?: string): Promise<void> {
+        return this.driver.click(cssSelector);
+    }
+
+    classes(cssSelector?: string): Promise<string[]> {
+        return this.driver.classes(cssSelector);
+    }
+
+    check(cssSelector?: string): Promise<void> {
+        return this.driver.check(cssSelector);
+    }
+
+    getChecked(cssSelector?: string): Promise<boolean> {
+        return this.driver.getChecked(cssSelector);
+    }
+
+    select(option: string, cssSelector?: string): Promise<void> {
+        return this.driver.select(option, cssSelector);
+    }
+
+    sendKeyboardKey(key: string, cssSelector?: string): Promise<void> {
+        return this.driver.sendKeyboardKey(key, cssSelector);
+    }
+
+    setInputValue(value: string, shouldAppend?: boolean, cssSelector?: string): Promise<void> {
+        return this.driver.setInputValue(value, shouldAppend, cssSelector);
+    }
+
+    clearInputValue(cssSelector?: string): Promise<void> {
+        return this.driver.clearInputValue(cssSelector);
+    }
+
+    getText(cssSelector?: string): Promise<string> {
+        return this.driver.getText(cssSelector);
+    }
+
+    getTexts(parentCssSelector?: string, cssSelector?: string): Promise<string[]> {
+        return this.driver.getTexts(parentCssSelector, cssSelector);
+    }
+
+    getInputValue(cssSelector?: string): Promise<string | number | string[]> {
+        return this.driver.getInputValue(cssSelector);
+    }
+
+    getInputValues(parentCssSelector?: string, cssSelector?: string): Promise<(string | number | string[])[]> {
+        return this.driver.getInputValues(parentCssSelector, cssSelector);
+    }
+}

--- a/projects/components/src/utils/test/cypress-widget-driver.ts
+++ b/projects/components/src/utils/test/cypress-widget-driver.ts
@@ -1,0 +1,131 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { WidgetDriver } from './base-widget-object';
+import { CypressWidgetFinder } from './cypress-widget-finder';
+import { FindableWidget, FindParams } from './widget-object';
+
+declare const Cypress;
+
+/**
+ * Given some Cypress Chainable, returns a promise that will resolve when that Chainable completes
+ * and rejects when it fails.
+ */
+export function promisify<T>(chain): Promise<T> {
+    return new Cypress.Promise((resolve, reject) => {
+        // We must subscribe to failures and bail. Without this, the Cypress runner would never stop
+
+        // // unsubscribe from test failure on both success and failure. This cleanup is essential
+        function resolvePromise(value): any {
+            resolve(value);
+            Cypress.off('fail', rejectPromise);
+        }
+        function rejectPromise(error): any {
+            reject(error);
+            Cypress.off('fail', rejectPromise);
+        }
+        Cypress.on('fail', rejectPromise);
+
+        chain.then(resolvePromise);
+    });
+}
+
+// If we load the 'cypress' module into this file, it also loads Chai which clashes with Jasmine - our testing framework of choice.
+// As such, this class isn't very type safe
+
+/**
+ * A WidgetDriver that knows how to interface with the Cypress framework.
+ */
+export class CypressWidgetDriver implements WidgetDriver {
+    constructor(private element) {}
+
+    find<W extends WidgetDriver>(params: FindParams<FindableWidget<W>> | FindableWidget<W>): W {
+        return new CypressWidgetFinder().find<W, FindableWidget<W>>(params, this.element);
+    }
+
+    exists(cssSelector?: string): Promise<boolean> {
+        return promisify(this.getElement(cssSelector));
+    }
+
+    visible(cssSelector?: string): Promise<boolean> {
+        return this.assert('be.visible', cssSelector);
+    }
+
+    hidden(cssSelector?: string): Promise<boolean> {
+        return this.assert('not.be.visible', cssSelector);
+    }
+
+    disabled(cssSelector?: string): Promise<boolean> {
+        return this.assert('be.disabled', cssSelector);
+    }
+
+    classes(cssSelector?: string): Promise<string[]> {
+        return promisify(this.getElement(cssSelector).invoke('classes'));
+    }
+
+    click(cssSelector?: string): Promise<void> {
+        return promisify(this.getElement(cssSelector).click());
+    }
+
+    check(cssSelector?: string): Promise<void> {
+        return promisify(this.getElement(cssSelector).check());
+    }
+
+    getChecked(cssSelector?: string): Promise<boolean> {
+        return this.assert('be.checked', cssSelector);
+    }
+
+    select(option: string, cssSelector?: string): Promise<void> {
+        return promisify(this.getElement(cssSelector).select(option));
+    }
+
+    sendKeyboardKey(key: string, cssSelector?: string): Promise<void> {
+        const element = this.getElement(cssSelector);
+        return promisify(element.invoke('keydown', key).then(() => element.invoke('keyup', key)));
+    }
+
+    async setInputValue(value: string, shouldAppend?: boolean, cssSelector?: string): Promise<void> {
+        if (!shouldAppend) {
+            await this.clearInputValue(cssSelector);
+        }
+        await promisify(this.getElement(cssSelector).type(value));
+    }
+
+    clearInputValue(cssSelector?: string): Promise<void> {
+        return promisify(this.getElement(cssSelector).clear());
+    }
+
+    getText(cssSelector?: string): Promise<string> {
+        return promisify(this.getElement(cssSelector).invoke('text')).then((text: string) => text.trim());
+    }
+
+    getTexts(parentCssSelector?: string, cssSelector?: string): Promise<string[]> {
+        return promisify(this.getElements(parentCssSelector, cssSelector).invoke('text')).then((texts: string[]) =>
+            texts.map(text => text.trim())
+        );
+    }
+
+    getInputValue(cssSelector?: string): Promise<string | number | string[]> {
+        return promisify(this.getElement(cssSelector).invoke('val'));
+    }
+
+    getInputValues(parentCssSelector?: string, cssSelector?: string): Promise<(string | number | string[])[]> {
+        return promisify(this.getElements(parentCssSelector, cssSelector).val());
+    }
+
+    // tslint:disable-next-line: typedef
+    private getElement(cssSelector?: string) {
+        return cssSelector ? this.element.get(cssSelector) : this.element;
+    }
+
+    // tslint:disable-next-line: typedef
+    private getElements(parentCssSelector?: string, cssSelector?: string) {
+        return this.getElement(parentCssSelector).children(cssSelector);
+    }
+
+    private assert(expectation: string, cssSelector?: string): Promise<boolean> {
+        return promisify(this.getElement(cssSelector).should(expectation));
+    }
+}

--- a/projects/components/src/utils/test/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/cypress-widget-finder.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CypressWidgetDriver } from './cypress-widget-driver';
+import { FindableWidget, FindParams, isFindParamsObject } from './widget-object';
+
+declare const cy;
+
+/**
+ * Finds instances that implement {@link FindableWidget}
+ * H is the host component's type
+ */
+export class CypressWidgetFinder {
+    /**
+     * Finds a single widget object
+     * @throws An error if the widget is not found or if there are multiple instances
+     */
+    public find<C, T extends FindableWidget<C>>(params: FindParams<T> | T, parent?: any): InstanceType<T> {
+        const defaults = { className: '' };
+        const { woConstructor, className } = isFindParamsObject(params)
+            ? { ...defaults, ...params }
+            : { ...defaults, woConstructor: params };
+        let query = woConstructor.tagName;
+        if (className) {
+            query += `.${className}`;
+        }
+
+        const ancestor = parent || cy;
+        const widget = new woConstructor(new CypressWidgetDriver(ancestor.get(query)));
+        if (!widget) {
+            throw Error(`Did not find a <${query}>`);
+        }
+        return widget as InstanceType<T>;
+    }
+}

--- a/projects/components/src/utils/test/index.ts
+++ b/projects/components/src/utils/test/index.ts
@@ -8,3 +8,9 @@ export * from './datagrid/vcd-datagrid.wo';
 export * from './activity-reporter/banner-activity-reporter.wo';
 export * from './activity-reporter/spinner-activity-reporter.wo';
 export * from './widget-object';
+
+export * from './cypress-widget-driver';
+export * from './cypress-widget-finder';
+export * from './angular-widget-driver';
+export * from './angular-widget-finder';
+export * from './base-widget-object';

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -139,14 +139,14 @@ export abstract class WidgetObject<T> {
  * This is done by creating a static property `tagName`on your subclass, not a regular instance, since this
  * interface represents a constructor for a {@link WidgetObject}, not an instance.
  */
-export interface FindableWidget<T> extends Type<WidgetObject<T>> {
+export interface FindableWidget<T> extends Type<T> {
     tagName: string;
 }
 
 /**
  * Arguments for {@link WidgetFinder#findWidgets} and {@link WidgetFinder#find}
  */
-interface FindParams<T> {
+export interface FindParams<T> {
     /**
      * The constructor of the widget to be found
      */
@@ -231,7 +231,7 @@ export class WidgetFinder<H = unknown> {
     }
 }
 
-function isFindParamsObject<T>(params: FindParams<T> | T): params is FindParams<T> {
+export function isFindParamsObject<T>(params: FindParams<T> | T): params is FindParams<T> {
     return !!(params as FindParams<T>).woConstructor;
 }
 /**


### PR DESCRIPTION
# Description

Creates a new WidgetObject pattern so that widget objects can be used in both Cypress and Angular tests. All new WidgetObjects should now extend the BaseWidgetObject which will give all the necessary methods to test features.

# Design

1. WidgetDriver interface
- this is the interface for an object that knows how to interact with the dom. Currently we have three CypressWidgetDriver (cypress), AngularWidgetDriver (angular), BaseWidgetDriver (delegation to another).
2. BaseWidgetDriver
- All new WidgetObjects should extend this to gain the ability to interact with the dom for any arbitrary testing framework.
3. WidgetFinders(s)
- Given a FindParams, locates the specific WidgetDriver and instantiates the WidgetObject. Two Widget Finders, one for Cypress, one for Angular

# Testing
1. Added the Angular Widget Driver spec
2. Implemented the rights bundle widget using the BaseWidgetDriver in VCD-UI

# Notes
1. The `find` method is not useful for testing if a non-existent element has properties. For example, we can't use find to test things about the Spinner because when the spinner is off, it's removed from the dom. Will discuss in standup tomorrow.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>