### PR TITLE
Change the contextual actions availability and display logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3463,9 +3463,9 @@
       }
     },
     "@vmw/ng-live-docs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@vmw/ng-live-docs/-/ng-live-docs-0.0.6.tgz",
-      "integrity": "sha512-tbYsTkCO3wWs0zeiDulqzSVjLtNzmGQKg9OPtG+YQs7L+yg9mCN3RmtfOonOvfgIDmMBMhCaD+HHEHainu+/dQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@vmw/ng-live-docs/-/ng-live-docs-0.0.7.tgz",
+      "integrity": "sha512-7/9mrzlpnRCzrpkUheeDYdA6sPDWEKiSn55kv50P1IgsW4CVJxEHQtGdV8z5fEaR7gtrgtj9d75na4Z9lSdScg==",
       "requires": {
         "@stackblitz/sdk": "1.3.0",
         "@vmw/plain-js-live-docs": "0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3463,9 +3463,9 @@
       }
     },
     "@vmw/ng-live-docs": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@vmw/ng-live-docs/-/ng-live-docs-0.0.7.tgz",
-      "integrity": "sha512-7/9mrzlpnRCzrpkUheeDYdA6sPDWEKiSn55kv50P1IgsW4CVJxEHQtGdV8z5fEaR7gtrgtj9d75na4Z9lSdScg==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@vmw/ng-live-docs/-/ng-live-docs-0.0.6.tgz",
+      "integrity": "sha512-tbYsTkCO3wWs0zeiDulqzSVjLtNzmGQKg9OPtG+YQs7L+yg9mCN3RmtfOonOvfgIDmMBMhCaD+HHEHainu+/dQ==",
       "requires": {
         "@stackblitz/sdk": "1.3.0",
         "@vmw/plain-js-live-docs": "0.0.2",

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.12",
+    "version": "1.0.0-dev.13",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },


### PR DESCRIPTION
Use calculateActionsAvailability switch before using the selectedEntities to determine availability and display of contextual actions