### PR TITLE
Add class name to action items VcdDropdown

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.14",
+    "version": "1.0.0-dev.15",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.html
+++ b/projects/components/src/action-menu/action-menu.component.html
@@ -12,7 +12,7 @@
 
         <vcd-dropdown
             class="inline-action-dropdown"
-            *ngIf="contextualActions.length && shouldDisplayContextualActionsDropdown"
+            *ngIf="contextualActions.length"
             [items]="contextualActions"
             [trackByFunction]="actionsTrackBy"
             [dropdownPosition]="dropdownPosition"

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -22,13 +22,16 @@ import {
 import { ClrDatagrid, ClrDatagridPagination, ClrDatagridStateInterface } from '@clr/angular';
 import { LazyString, TranslationService } from '@vcd/i18n';
 import { Observable } from 'rxjs';
-import { ActionMenuComponent, DEFAULT_ACTION_DISPLAY_CONFIG } from '../action-menu/action-menu.component';
+import {
+    ActionMenuComponent,
+    DEFAULT_ACTION_DISPLAY_CONFIG,
+    getCopyOfActionDisplayConfig,
+} from '../action-menu/action-menu.component';
 import { ActivityReporter } from '../common/activity-reporter';
 import {
     ActionDisplayConfig,
     ActionHandlerType,
     ActionItem,
-    ActionStyling,
     ActionType,
 } from '../common/interfaces/action-item.interface';
 import { SubscriptionTracker } from '../common/subscription';
@@ -458,7 +461,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit, OnDestroy {
     /**
      * How to display the static and contextual actions.
      */
-    @Input() actionDisplayConfig: ActionDisplayConfig = DEFAULT_ACTION_DISPLAY_CONFIG;
+    @Input() actionDisplayConfig: ActionDisplayConfig = getCopyOfActionDisplayConfig(DEFAULT_ACTION_DISPLAY_CONFIG);
 
     /**
      * Whether to display contextual actions inside the row or on top of the grid

--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -35,7 +35,7 @@
 
                 <ng-container *ngIf="!action.children">
                     <button
-                        class="btn btn-link"
+                        [className]="[action.class, 'btn', 'btn-link']"
                         [ngClass]="{ 'btn-icon': shouldShowIcon }"
                         clrDropdownItem
                         (click)="onItemClickedCb(action)"

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -27,6 +27,10 @@ interface DropdownItem<T extends DropdownItem<T>> {
      * To mark if the {@link #ActionItem.textKey} has to be translated or not
      */
     isTranslatable?: boolean;
+    /**
+     * Css class of the dropdown item. Must be unique among all dropdown items within the dropdown items list
+     */
+    class: string;
 }
 
 /**

--- a/projects/examples/src/components/action-menu/action-menu.example.component.ts
+++ b/projects/examples/src/components/action-menu/action-menu.example.component.ts
@@ -13,7 +13,7 @@ import {
     ActionType,
     DEFAULT_ACTION_SEARCH_SECTION_HEADER_PREFIX,
     SpotlightSearchService,
-    TextIcon
+    TextIcon,
 } from '@vcd/ui-components';
 import Mousetrap from 'mousetrap';
 
@@ -72,16 +72,14 @@ interface HandlerData {
             [placeholder]="'Search contextual actions'"
         ></vcd-spotlight-search>
     `,
-    styleUrls: ['action-menu.example.component.scss']
+    styleUrls: ['action-menu.example.component.scss'],
 })
 export class ActionMenuExampleComponent<R extends Record, T extends HandlerData> implements OnInit, OnDestroy {
-
     constructor(
         private spotlightSearchService: SpotlightSearchService,
         private translationService: TranslationService,
         private ts: TranslationService
-    ) {
-    }
+    ) {}
 
     get staticActions(): ActionItem<R, T>[] {
         return this.actions.filter(
@@ -141,6 +139,7 @@ export class ActionMenuExampleComponent<R extends Record, T extends HandlerData>
                     availability: (rec: R[]) => rec.length === 1 && rec[0].paused,
                     actionType: ActionType.CONTEXTUAL_FEATURED,
                     isTranslatable: false,
+                    class: 'start',
                 },
                 {
                     textKey: 'Stop',
@@ -152,6 +151,7 @@ export class ActionMenuExampleComponent<R extends Record, T extends HandlerData>
                     availability: (rec: R[]) => rec.length === 1 && !rec[0].paused,
                     actionType: ActionType.CONTEXTUAL_FEATURED,
                     isTranslatable: false,
+                    class: 'stop',
                 },
             ],
         },


### PR DESCRIPTION
# Why?
The end 2 end tests in vcd ui are failing because of missing class names on action items inside action dropdowns. So, added those class names

# Testing:
Added class names to action item objects in ActionMenuExample component and made sure that those classes get added to the class list of action button html element