### PR TITLE
Make changes to not mutate action display config objects

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.15",
+    "version": "1.0.0-dev.16",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.spec.ts
+++ b/projects/components/src/action-menu/action-menu.component.spec.ts
@@ -6,9 +6,9 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
-import { ActionStyling, ActionType, TextIcon } from '../common/interfaces/index';
+import { ActionDisplayConfig, ActionStyling, ActionType, TextIcon } from '../common/interfaces/index';
 import { WidgetFinder, WidgetObject } from '../utils/test/index';
-import { ActionMenuComponent } from './action-menu.component';
+import { ActionMenuComponent, getDefaultActionDisplayConfig } from './action-menu.component';
 import { VcdActionMenuModule } from './action-menu.module';
 
 interface HasFinderAndActionMenu {
@@ -79,6 +79,49 @@ describe('ActionMenuComponent', () => {
                 expect(this.actionMenu.shouldShowIcon).toBeTruthy();
                 expect(this.actionMenu.shouldShowText).toBeFalsy();
                 expect(this.actionMenu.shouldShowTooltip).toBeTruthy();
+            }
+        );
+        it(
+            'does not change the default value of nested actionDisplayConfig.contextual object when the input config is changed to just ' +
+                'have the staticActionStyling',
+            function(this: HasFinderAndActionMenu): void {
+                const configInputOne = {
+                    contextual: {
+                        featuredCount: 5,
+                        styling: ActionStyling.DROPDOWN,
+                        buttonContents: TextIcon.TEXT,
+                    },
+                };
+                const configInputTwo = {
+                    staticActionStyling: ActionStyling.DROPDOWN,
+                };
+
+                this.actionMenu.actionDisplayConfig = configInputOne;
+                expect(this.actionMenu.actionDisplayConfig.contextual).toEqual(configInputOne.contextual);
+
+                this.actionMenu.actionDisplayConfig = configInputTwo;
+                expect(this.actionMenu.actionDisplayConfig.contextual).toEqual(
+                    getDefaultActionDisplayConfig().contextual
+                );
+            }
+        );
+        it(
+            'does not change the input config objects staticActionStyling value to default ' +
+                'getDefaultActionDisplayConfig.staticActionStyling when it is not passed in',
+            function(this: HasFinderAndActionMenu): void {
+                const configInputOne: ActionDisplayConfig = {
+                    contextual: {
+                        featuredCount: 5,
+                        styling: ActionStyling.DROPDOWN,
+                        buttonContents: TextIcon.TEXT,
+                    },
+                };
+
+                this.actionMenu.actionDisplayConfig = configInputOne;
+                expect(configInputOne.staticActionStyling).toBeUndefined();
+                expect(this.actionMenu.actionDisplayConfig.staticActionStyling).toEqual(
+                    getDefaultActionDisplayConfig().staticActionStyling
+                );
             }
         );
     });

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -10,14 +10,16 @@ import { CommonUtil } from '../utils';
 /**
  * Value used for the display configuration of action buttons if no input is provided by the caller
  */
-export const DEFAULT_ACTION_DISPLAY_CONFIG: ActionDisplayConfig = {
-    contextual: {
-        featuredCount: 0,
-        styling: ActionStyling.INLINE,
-        buttonContents: TextIcon.TEXT,
-    },
-    staticActionStyling: ActionStyling.INLINE,
-};
+export function getDefaultActionDisplayConfig(): ActionDisplayConfig {
+    return {
+        contextual: {
+            featuredCount: 0,
+            styling: ActionStyling.INLINE,
+            buttonContents: TextIcon.TEXT,
+        },
+        staticActionStyling: ActionStyling.INLINE,
+    };
+}
 
 /**
  * Renders actions in screens containing grids, cards and details container screens
@@ -66,17 +68,19 @@ export class ActionMenuComponent<R, T> {
      */
     shouldDisplayContextualActionsDropdown = false;
 
-    private _actionDisplayConfig: ActionDisplayConfig = getCopyOfActionDisplayConfig(DEFAULT_ACTION_DISPLAY_CONFIG);
+    private _actionDisplayConfig: ActionDisplayConfig = getDefaultActionDisplayConfig();
     /**
      * Display configuration of both static and contextual actions
      * If null or undefined is passed, default config {@link _actionDisplayConfig} is used
      */
     @Input() set actionDisplayConfig(config: ActionDisplayConfig) {
-        const copyOfConfig = getCopyOfActionDisplayConfig(config || {});
-        const copyOfDefaultConfig = getCopyOfActionDisplayConfig(DEFAULT_ACTION_DISPLAY_CONFIG);
-        Object.keys(copyOfConfig).forEach(
-            key => (this._actionDisplayConfig[key] = copyOfConfig[key] ? copyOfConfig[key] : copyOfDefaultConfig[key])
-        );
+        this._actionDisplayConfig = getDefaultActionDisplayConfig();
+        if (config.contextual) {
+            this._actionDisplayConfig.contextual = { ...config.contextual };
+        }
+        if (config.staticActionStyling) {
+            this._actionDisplayConfig.staticActionStyling = config.staticActionStyling;
+        }
         const buttonContents = this.actionDisplayConfig.contextual.buttonContents;
         this.shouldShowIcon = (TextIcon.ICON & buttonContents) === TextIcon.ICON;
         this.shouldShowText = (TextIcon.TEXT & buttonContents) === TextIcon.TEXT;
@@ -355,15 +359,4 @@ export function getDeepCopyOfActionItems<R, T>(actions: ActionItem<R, T>[]): Act
         }
         return { ...action };
     });
-}
-
-/**
- * Without the deep copy, the changes made to action display config object are mutating the original config object and the default config
- * object
- */
-export function getCopyOfActionDisplayConfig(displayConfig: ActionDisplayConfig): ActionDisplayConfig {
-    return {
-        contextual: { ...displayConfig.contextual },
-        staticActionStyling: displayConfig.staticActionStyling
-    };
 }

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -24,8 +24,7 @@ import { LazyString, TranslationService } from '@vcd/i18n';
 import { Observable } from 'rxjs';
 import {
     ActionMenuComponent,
-    DEFAULT_ACTION_DISPLAY_CONFIG,
-    getCopyOfActionDisplayConfig,
+    getDefaultActionDisplayConfig,
 } from '../action-menu/action-menu.component';
 import { ActivityReporter } from '../common/activity-reporter';
 import {
@@ -461,7 +460,7 @@ export class DatagridComponent<R> implements OnInit, AfterViewInit, OnDestroy {
     /**
      * How to display the static and contextual actions.
      */
-    @Input() actionDisplayConfig: ActionDisplayConfig = getCopyOfActionDisplayConfig(DEFAULT_ACTION_DISPLAY_CONFIG);
+    @Input() actionDisplayConfig: ActionDisplayConfig = getDefaultActionDisplayConfig();
 
     /**
      * Whether to display contextual actions inside the row or on top of the grid


### PR DESCRIPTION
# Why?
- To avoid mutating _actionDisplayConfig being used internally by the ActionMenuComponent to control the view
- To avoid mutating the config object being passed as input from the calling component using ActionMenuComponent

# Testing done:
Added unit tests to test the above 2 scenarios