### PR TITLE
Fixed i18n issues

### DIFF
--- a/projects/i18n/package.json
+++ b/projects/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/i18n",
-  "version": "0.0.9",
+  "version": "1.0.0-dev.0",
   "peerDependencies": {
     "@angular/common": ">6.0.0",
     "@angular/core": ">6.0.0"

--- a/projects/i18n/src/lib/loader/translation-loader.ts
+++ b/projects/i18n/src/lib/loader/translation-loader.ts
@@ -4,7 +4,8 @@
  */
 
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { Translations, TranslationSet } from '../service/translation-service';
 
 /**
@@ -23,17 +24,25 @@ export class TranslationLoader {
      * Returns the translations for the given language that are located at the {@link assetUrl}.
      */
     public getTranslation(language: string): Observable<Translations> {
-        return (this.http.get(
-            `${this.assetUrl}${TranslationLoader.PREFIX}${language}${TranslationLoader.SUFFIX}`
-        ) as any) as Observable<Translations>;
+        const url = `${this.assetUrl}${TranslationLoader.PREFIX}${language}${TranslationLoader.SUFFIX}`;
+        return ((this.http.get(url) as any) as Observable<Translations>).pipe(
+            catchError((error, caught) => {
+                console.log('Could not find translation file located at ' + url);
+                return of({});
+            })
+        );
     }
 
     /**
      * Returns the translations for all languages that are located at the {@link assetUrl}.
      */
     public getCombinedTranslation(): Observable<TranslationSet> {
-        return (this.http.get(`${this.assetUrl}/../i18n${TranslationLoader.SUFFIX}`) as any) as Observable<
-            TranslationSet
-        >;
+        const url = `${this.assetUrl}/../i18n${TranslationLoader.SUFFIX}`;
+        return ((this.http.get(url) as any) as Observable<TranslationSet>).pipe(
+            catchError((error, caught) => {
+                console.log('Could not find translation file located at ' + url);
+                return of({});
+            })
+        );
     }
 }

--- a/projects/i18n/src/lib/loader/translation-loader.ts
+++ b/projects/i18n/src/lib/loader/translation-loader.ts
@@ -5,6 +5,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { Translations, TranslationSet } from '../service/translation-service';
 
 /**
  * A HTTP loader that can load translations from some assetUrl.
@@ -21,14 +22,18 @@ export class TranslationLoader {
     /**
      * Returns the translations for the given language that are located at the {@link assetUrl}.
      */
-    public getTranslation(language: string): Observable<object> {
-        return this.http.get(`${this.assetUrl}${TranslationLoader.PREFIX}${language}${TranslationLoader.SUFFIX}`);
+    public getTranslation(language: string): Observable<Translations> {
+        return (this.http.get(
+            `${this.assetUrl}${TranslationLoader.PREFIX}${language}${TranslationLoader.SUFFIX}`
+        ) as any) as Observable<Translations>;
     }
 
     /**
      * Returns the translations for all languages that are located at the {@link assetUrl}.
      */
-    public getCombinedTranslation(): Observable<object> {
-        return this.http.get(`${this.assetUrl}/../i18n${TranslationLoader.SUFFIX}`);
+    public getCombinedTranslation(): Observable<TranslationSet> {
+        return (this.http.get(`${this.assetUrl}/../i18n${TranslationLoader.SUFFIX}`) as any) as Observable<
+            TranslationSet
+        >;
     }
 }

--- a/projects/i18n/src/lib/pipe/translation-pipe.spec.ts
+++ b/projects/i18n/src/lib/pipe/translation-pipe.spec.ts
@@ -4,16 +4,19 @@
  */
 
 import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BehaviorSubject } from 'rxjs';
+import { delay } from 'rxjs/operators';
 import { MockTranslationService } from '../service/mock-translation-service';
 import { TranslationService } from '../service/translation-service';
 import { TranslationPipe } from './translation-pipe';
 
 describe('TranslationPipe', () => {
-    it('should forward to translation service', () => {
+    it('should forward to translation service', fakeAsync(() => {
         const translationService = new MockTranslationService();
+        const observable = new BehaviorSubject('Hi doctor nick!').pipe(delay(100));
+        spyOn(translationService, 'translateAsync').and.returnValue(observable);
         TestBed.configureTestingModule({
             declarations: [TranslationPipeTestComponent, TranslationPipe],
             providers: [
@@ -25,15 +28,11 @@ describe('TranslationPipe', () => {
         }).compileComponents();
         const fixture = TestBed.createComponent(TranslationPipeTestComponent);
         fixture.detectChanges();
-        const observable = new BehaviorSubject('?test.translation');
-        spyOn(translationService, 'translateAsync').and.returnValue(observable);
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('h1')).nativeElement.textContent).toBe('?test.translation');
-        observable.next('Hi doctor nick!');
+        tick(200);
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('h1')).nativeElement.textContent).toBe('Hi doctor nick!');
         expect(translationService.translateAsync).toHaveBeenCalledWith('test.translation', []);
-    });
+    }));
 });
 
 @Component({

--- a/projects/i18n/src/lib/pipe/translation-pipe.ts
+++ b/projects/i18n/src/lib/pipe/translation-pipe.ts
@@ -4,6 +4,7 @@
  */
 
 import { ChangeDetectorRef, Injectable, Pipe, PipeTransform } from '@angular/core';
+import { take } from 'rxjs/operators';
 import { TranslationService } from '../service/translation-service';
 
 /**
@@ -35,7 +36,7 @@ export class TranslationPipe implements PipeTransform {
             return key;
         }
 
-        if (key === this.lastKey && params === this.lastArgs) {
+        if (key === this.lastKey && JSON.stringify(params) === JSON.stringify(this.lastArgs)) {
             return this.value;
         }
 
@@ -46,9 +47,12 @@ export class TranslationPipe implements PipeTransform {
     }
 
     private updateValue(key: string, ...args: any[]): void {
-        this.translate.translateAsync(key, args).subscribe(result => {
-            this.value = result;
-            this.changeDetector.markForCheck();
-        });
+        this.translate
+            .translateAsync(key, args)
+            .pipe(take(1))
+            .subscribe(result => {
+                this.value = result;
+                this.changeDetector.markForCheck();
+            });
     }
 }

--- a/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
+++ b/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
@@ -7,7 +7,7 @@
  * Copyright 2017 VMware, Inc. All rights reserved. VMware Confidential
  */
 import { BehaviorSubject } from 'rxjs';
-import { delay } from 'rxjs/operators';
+import { delay, take } from 'rxjs/operators';
 import { TranslationLoader } from '../loader/translation-loader';
 import { MessageFormatTranslationService } from './message-format-translation-service';
 
@@ -82,7 +82,7 @@ describe('MessageFormatTranslationService', () => {
         expect(translationService.translate('multiple.params', [{ count: 2, name: 'World' }])).toBe(`many Worlds`);
     });
 
-    it('translates the string via the translation loader via combined translation', done => {
+    it('translates the string via the translation loader via combined translation', async () => {
         const loader = new TranslationLoader(null, '');
         spyOn(loader, 'getCombinedTranslation').and.returnValue(
             new BehaviorSubject({
@@ -93,14 +93,17 @@ describe('MessageFormatTranslationService', () => {
         );
         const translationService = new MessageFormatTranslationService('en', 'en', loader, true);
         translationService.registerTranslations();
-        translationService.translateAsync('hi').subscribe(result => {
-            expect(result).toEqual('hello');
-            expect(translationService.translate('hi')).toEqual('hello');
-            done();
-        });
+        await translationService
+            .translateAsync('hi')
+            .pipe(take(1))
+            .toPromise()
+            .then(result => {
+                expect(result).toEqual('hello');
+                expect(translationService.translate('hi')).toEqual('hello');
+            });
     });
 
-    it('translates the string via the translation loader via single language translation', done => {
+    it('translates the string via the translation loader via single language translation', async () => {
         const loader = new TranslationLoader(null, '');
         spyOn(loader, 'getTranslation').and.returnValue(
             new BehaviorSubject({
@@ -109,14 +112,17 @@ describe('MessageFormatTranslationService', () => {
         );
         const translationService = new MessageFormatTranslationService('en', 'en', loader);
         translationService.registerTranslations();
-        translationService.translateAsync('hi').subscribe(result => {
-            expect(result).toEqual('hello');
-            expect(translationService.translate('hi')).toEqual('hello');
-            done();
-        });
+        await translationService
+            .translateAsync('hi')
+            .pipe(take(1))
+            .toPromise()
+            .then(result => {
+                expect(result).toEqual('hello');
+                expect(translationService.translate('hi')).toEqual('hello');
+            });
     });
 
-    it('translates via the fallback locale using async translations if the main language is not loaded', done => {
+    it('translates via the fallback locale using async translations if the main language is not loaded', async () => {
         const loader = new TranslationLoader(null, '');
         spyOn(loader, 'getTranslation').and.callFake(arg => {
             if (arg === 'de') {
@@ -130,11 +136,14 @@ describe('MessageFormatTranslationService', () => {
 
         const translationService = new MessageFormatTranslationService('en', 'de', loader);
         translationService.registerTranslations();
-        translationService.translateAsync('hi').subscribe(result => {
-            expect(result).toEqual('guten tag');
-            expect(translationService.translate('hi')).toEqual('guten tag');
-            done();
-        });
+        await translationService
+            .translateAsync('hi')
+            .pipe(take(1))
+            .toPromise()
+            .then(result => {
+                expect(result).toEqual('guten tag');
+                expect(translationService.translate('hi')).toEqual('guten tag');
+            });
     });
 
     it('translates the string using the provided multiple object keys', () => {

--- a/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
+++ b/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
@@ -93,14 +93,12 @@ describe('MessageFormatTranslationService', () => {
         );
         const translationService = new MessageFormatTranslationService('en', 'en', loader, true);
         translationService.registerTranslations();
-        await translationService
+        const result = await translationService
             .translateAsync('hi')
             .pipe(take(1))
-            .toPromise()
-            .then(result => {
-                expect(result).toEqual('hello');
-                expect(translationService.translate('hi')).toEqual('hello');
-            });
+            .toPromise();
+        expect(result).toEqual('hello');
+        expect(translationService.translate('hi')).toEqual('hello');
     });
 
     it('translates the string via the translation loader via single language translation', async () => {
@@ -112,14 +110,12 @@ describe('MessageFormatTranslationService', () => {
         );
         const translationService = new MessageFormatTranslationService('en', 'en', loader);
         translationService.registerTranslations();
-        await translationService
+        const result = await translationService
             .translateAsync('hi')
             .pipe(take(1))
-            .toPromise()
-            .then(result => {
-                expect(result).toEqual('hello');
-                expect(translationService.translate('hi')).toEqual('hello');
-            });
+            .toPromise();
+        expect(result).toEqual('hello');
+        expect(translationService.translate('hi')).toEqual('hello');
     });
 
     it('translates via the fallback locale using async translations if the main language is not loaded', async () => {
@@ -136,14 +132,12 @@ describe('MessageFormatTranslationService', () => {
 
         const translationService = new MessageFormatTranslationService('en', 'de', loader);
         translationService.registerTranslations();
-        await translationService
+        const result = await translationService
             .translateAsync('hi')
             .pipe(take(1))
-            .toPromise()
-            .then(result => {
-                expect(result).toEqual('guten tag');
-                expect(translationService.translate('hi')).toEqual('guten tag');
-            });
+            .toPromise();
+        expect(result).toEqual('guten tag');
+        expect(translationService.translate('hi')).toEqual('guten tag');
     });
 
     it('translates the string using the provided multiple object keys', () => {

--- a/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
+++ b/projects/i18n/src/lib/service/message-format-translation-service.spec.ts
@@ -7,6 +7,7 @@
  * Copyright 2017 VMware, Inc. All rights reserved. VMware Confidential
  */
 import { BehaviorSubject } from 'rxjs';
+import { delay } from 'rxjs/operators';
 import { TranslationLoader } from '../loader/translation-loader';
 import { MessageFormatTranslationService } from './message-format-translation-service';
 
@@ -81,33 +82,58 @@ describe('MessageFormatTranslationService', () => {
         expect(translationService.translate('multiple.params', [{ count: 2, name: 'World' }])).toBe(`many Worlds`);
     });
 
-    it('translates the string via the translation loader via combined translation', () => {
+    it('translates the string via the translation loader via combined translation', done => {
         const loader = new TranslationLoader(null, '');
         spyOn(loader, 'getCombinedTranslation').and.returnValue(
             new BehaviorSubject({
                 en: {
                     hi: 'hello',
                 },
-            })
+            }).pipe(delay(100))
         );
         const translationService = new MessageFormatTranslationService('en', 'en', loader, true);
         translationService.registerTranslations();
         translationService.translateAsync('hi').subscribe(result => {
             expect(result).toEqual('hello');
+            expect(translationService.translate('hi')).toEqual('hello');
+            done();
         });
     });
 
-    it('translates the string via the translation loader via single language translation', () => {
+    it('translates the string via the translation loader via single language translation', done => {
         const loader = new TranslationLoader(null, '');
         spyOn(loader, 'getTranslation').and.returnValue(
             new BehaviorSubject({
                 hi: 'hello',
-            })
+            }).pipe(delay(100))
         );
         const translationService = new MessageFormatTranslationService('en', 'en', loader);
         translationService.registerTranslations();
         translationService.translateAsync('hi').subscribe(result => {
             expect(result).toEqual('hello');
+            expect(translationService.translate('hi')).toEqual('hello');
+            done();
+        });
+    });
+
+    it('translates via the fallback locale using async translations if the main language is not loaded', done => {
+        const loader = new TranslationLoader(null, '');
+        spyOn(loader, 'getTranslation').and.callFake(arg => {
+            if (arg === 'de') {
+                return new BehaviorSubject({
+                    hi: 'guten tag',
+                }).pipe(delay(100));
+            } else {
+                return new BehaviorSubject({}).pipe(delay(100));
+            }
+        });
+
+        const translationService = new MessageFormatTranslationService('en', 'de', loader);
+        translationService.registerTranslations();
+        translationService.translateAsync('hi').subscribe(result => {
+            expect(result).toEqual('guten tag');
+            expect(translationService.translate('hi')).toEqual('guten tag');
+            done();
         });
     });
 


### PR DESCRIPTION
# Description

Fixes three issues with the i18n library:

1. The translateAsync method would emit an untranslated string prior to emitting a translated string while the translations are loading.
2. The fallbackLocale was not used with async translations.
3. The translationPipe was causing memory issues by creating too many subscriptions. 

# Testing

1. Added unit tests to test the first two issues. 
2. Fixed old unit tests that weren't running. 
3. Loaded into VCD UI and tested the app both in english and German
4. Ran the examples app and made sure translations worked in English.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>

