### PR TITLE
Spotlight search improvements

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.20",
+    "version": "1.0.0-dev.21",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/spotlight-search/spotlight-search.component.html
+++ b/projects/components/src/spotlight-search/spotlight-search.component.html
@@ -17,10 +17,13 @@
             />
         </div>
         <div class="search-result-container">
-            <div *ngFor="let searchSection of searchSections" class="search-result-section">
-                <div *ngIf="showSectionTitle(searchSection)" class="search-result-section-title">
+            <section
+                *ngFor="let searchSection of searchSections; let i = index"
+                class="search-result-section section-index-{{ i }}"
+            >
+                <h5 *ngIf="showSectionTitle(searchSection)" class="search-result-section-title">
                     {{ searchSection.section }}
-                </div>
+                </h5>
                 <div *ngIf="searchSection.isLoading">
                     <div class="spinner spinner-inline"></div>
                     {{ 'vcd.cc.loading' | translate }}
@@ -28,6 +31,7 @@
                 <ul *ngIf="!searchSection.isLoading" class="list-unstyled compact">
                     <li
                         class="search-result-item"
+                        role="button"
                         *ngFor="let item of searchSection.results"
                         (click)="itemClicked(item)"
                         [ngClass]="item == selectedItem ? 'selected' : ''"
@@ -35,7 +39,7 @@
                         {{ item.displayText }}
                     </li>
                 </ul>
-            </div>
+            </section>
         </div>
     </div>
 </clr-modal>

--- a/projects/components/src/spotlight-search/spotlight-search.component.scss
+++ b/projects/components/src/spotlight-search/spotlight-search.component.scss
@@ -32,6 +32,7 @@
 
         .search-result-section-title {
             font-weight: bold;
+            margin-top: 0;
         }
 
         .search-result-item {
@@ -39,6 +40,9 @@
 
             &.selected {
                 background-color: var(--clr-global-selection-color);
+            }
+            &:hover {
+                background-color: var(--clr-global-hover-color);
             }
         }
     }

--- a/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
@@ -259,7 +259,7 @@ describe('SpotlightSearchComponent', () => {
     });
 
     describe('section', () => {
-        it('does not display section title if there is just one provider', function(this: Test): void {
+        it('displays section title even if there is just one provider', function(this: Test): void {
             // Open
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
@@ -267,7 +267,7 @@ describe('SpotlightSearchComponent', () => {
             this.spotlightSearch.searchInputValue = 'copy';
             //
             expect(this.spotlightSearch.searchResults.length).toBe(1);
-            expect(this.spotlightSearch.sectionTitles.length).toBe(0);
+            expect(this.spotlightSearch.sectionTitles).toEqual(['section']);
         });
 
         it('displays all section titles when there are results', function(this: Test): void {
@@ -283,6 +283,26 @@ describe('SpotlightSearchComponent', () => {
             this.spotlightSearch.searchInputValue = 'copy';
             //
             expect(this.spotlightSearch.sectionTitles).toEqual(['section', 'new section']);
+        });
+
+        it('does not display section title if it is not provided', function(this: Test): void {
+            // Register a provider with empty section title
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.simpleProvider,
+                ''
+            );
+            // Register a provider with undefined section title
+            this.spotlightSearchData.spotlightSearchService.registerProvider(
+                this.spotlightSearchData.simpleProvider,
+                undefined
+            );
+            // Open
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            // Set search
+            this.spotlightSearch.searchInputValue = 'copy';
+            //
+            expect(this.spotlightSearch.sectionTitles).toEqual(['section']);
         });
 
         it('can hide the section title when there is no result', function(this: Test): void {

--- a/projects/components/src/spotlight-search/spotlight-search.component.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.ts
@@ -5,6 +5,7 @@
 
 import { ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { TranslationService } from '@vcd/i18n';
+import { DomUtil } from '../utils/dom-util';
 import { SpotlightSearchResult, SpotlightSearchResultType } from './spotlight-search-result';
 import { RegisteredProviders, SpotlightSearchService } from './spotlight-search.service';
 
@@ -85,6 +86,7 @@ export class SpotlightSearchComponent {
     constructor(
         private searchService: SpotlightSearchService,
         private changeDetectorRef: ChangeDetectorRef,
+        private el: ElementRef,
         public translationService: TranslationService
     ) {}
 
@@ -225,6 +227,12 @@ export class SpotlightSearchComponent {
         // Call the change detector otherwise the selection on the screen may not refreshed quickly enough if the
         // user just presses and holds down the arrow key
         this.changeDetectorRef.detectChanges();
+
+        // Ensure the selected element is visible
+        DomUtil.scrollToElement(this.el, '.selected');
+        if (selectedItemIndex === 0) {
+            DomUtil.scrollToElement(this.el, '.section-index-0 .search-result-section-title');
+        }
     }
 
     /**
@@ -263,6 +271,6 @@ export class SpotlightSearchComponent {
     showSectionTitle(searchSection: SearchSection): boolean {
         // In order to show a section title there should be more than one sections
         // and the current section should either be loading data or have results
-        return this.searchSections.length > 1 && (searchSection.isLoading || searchSection.results.length > 0);
+        return searchSection.section && (searchSection.isLoading || searchSection.results.length > 0);
     }
 }

--- a/projects/components/src/utils/dom-util.spec.ts
+++ b/projects/components/src/utils/dom-util.spec.ts
@@ -1,0 +1,146 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ElementRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { WidgetFinder, WidgetObject } from '../utils/test/widget-object';
+import { DomUtil } from './dom-util';
+
+describe('DomUtil', () => {
+    describe('scrollToElement', () => {
+        // scrollToElement uses smooth scrolling, so we should give the browser some time to do it
+        const SMOOTH_SCROLLING_TIMEOUT = 100;
+
+        interface Test {
+            finder: WidgetFinder<TestHostComponent>;
+            widgetObject: TestHostWidgetObject;
+        }
+
+        beforeEach(async function(this: Test): Promise<void> {
+            await TestBed.configureTestingModule({
+                imports: [NoopAnimationsModule],
+                declarations: [TestHostComponent],
+            }).compileComponents();
+            this.finder = new WidgetFinder(TestHostComponent);
+            this.finder.detectChanges();
+            this.widgetObject = this.finder.find(TestHostWidgetObject);
+        });
+
+        it('does not throw if no inputs are provided', () => {
+            expect(DomUtil.scrollToElement.bind(DomUtil, null, null)).not.toThrow();
+        });
+
+        it('does not throw if the ElementRef is not valid', () => {
+            expect(DomUtil.scrollToElement.bind(DomUtil, new ElementRef(null), null)).not.toThrow();
+        });
+
+        it('scrolls view to element defined by selector', function(this: Test, done): void {
+            // Last element should be hidden
+            expect(this.widgetObject.containerBottom).toBeLessThan(this.widgetObject.lastElementTop);
+            DomUtil.scrollToElement(this.widgetObject.containerRef, TestHostComponent.LAST_ELEMENT_CSS);
+            setTimeout(() => {
+                // Last element should be visible now
+                expect(this.widgetObject.containerBottom).toBeGreaterThan(this.widgetObject.lastElementTop);
+                done();
+            }, SMOOTH_SCROLLING_TIMEOUT);
+        });
+
+        it('scrolls view to the element ref when no selector is provided', function(this: Test, done): void {
+            // Last element should be hidden
+            expect(this.widgetObject.containerBottom).toBeLessThan(this.widgetObject.lastElementTop);
+            DomUtil.scrollToElement(this.widgetObject.lastElementRef);
+            setTimeout(() => {
+                // Last element should be visible now
+                expect(this.widgetObject.containerBottom).toBeGreaterThan(this.widgetObject.lastElementTop);
+                done();
+            }, SMOOTH_SCROLLING_TIMEOUT);
+        });
+
+        it('does not scrolls the view if the element is already visible', function(this: Test, done): void {
+            const top = this.widgetObject.thirdElementTop;
+            // Third element should be visible
+            expect(this.widgetObject.containerBottom).toBeGreaterThan(top);
+            DomUtil.scrollToElement(this.widgetObject.containerRef, TestHostComponent.THIRD_ELEMENT_CSS);
+            setTimeout(() => {
+                // Third element should not have been scrolled at all
+                expect(this.widgetObject.thirdElementTop).toBe(top);
+                done();
+            }, SMOOTH_SCROLLING_TIMEOUT);
+        });
+
+        it('does not scrolls the view if element defined by selector does not exist', function(this: Test, done): void {
+            const top = this.widgetObject.thirdElementTop;
+            DomUtil.scrollToElement(this.widgetObject.containerRef, '.not-existing');
+            setTimeout(() => {
+                expect(this.widgetObject.thirdElementTop).toBe(top);
+                done();
+            }, SMOOTH_SCROLLING_TIMEOUT);
+        });
+    });
+});
+
+@Component({
+    template: `
+        <section>
+            <div class="container">
+                <div *ngFor="let el of elements; let i = index" class="element element-{{ i + 1 }}">{{ i + 1 }}</div>
+            </div>
+        </section>
+    `,
+    styles: [
+        `
+            .container {
+                height: 100px;
+                overflow: auto;
+            }
+            .element {
+                height: 20px;
+            }
+        `,
+    ],
+})
+export class TestHostComponent {
+    private static ELEMENTS_COUNT = 7;
+    public static THIRD_ELEMENT_CSS = `.element-3`;
+    public static LAST_ELEMENT_CSS = `.element-${TestHostComponent.ELEMENTS_COUNT}`;
+    public elements = Array(TestHostComponent.ELEMENTS_COUNT);
+}
+
+export class TestHostWidgetObject extends WidgetObject<TestHostComponent> {
+    static tagName = `section`;
+
+    private get container(): HTMLElement {
+        return this.findElement('.container').nativeElement;
+    }
+
+    private get lastElement(): HTMLElement {
+        return this.findElement(TestHostComponent.LAST_ELEMENT_CSS).nativeElement;
+    }
+
+    private get thirdElement(): HTMLElement {
+        return this.findElement(TestHostComponent.THIRD_ELEMENT_CSS).nativeElement;
+    }
+
+    public get containerRef(): ElementRef {
+        return new ElementRef(this.container);
+    }
+
+    public get containerBottom(): number {
+        return this.container.getBoundingClientRect().bottom;
+    }
+
+    public get lastElementRef(): ElementRef {
+        return new ElementRef(this.lastElement);
+    }
+
+    public get lastElementTop(): number {
+        return this.lastElement.getBoundingClientRect().top;
+    }
+
+    public get thirdElementTop(): number {
+        return this.thirdElement.getBoundingClientRect().top;
+    }
+}

--- a/projects/components/src/utils/dom-util.ts
+++ b/projects/components/src/utils/dom-util.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { ElementRef } from '@angular/core';
+
+export class DomUtil {
+    /**
+     * Scrolls view to a element so that the element becomes visible in the viewport.
+     * If a css style selector is provided then the element to scroll is the html element
+     * described by the css selector which parent is the provided element.
+     * Id a css style selector is not provided then the element to scroll is the provided
+     * element itself.
+     *
+     * @param elRef the view's element.
+     * @param classSelector the css-style selector for the element to scroll to.
+     */
+    public static scrollToElement(elRef: ElementRef, classSelector?: string): void {
+        if (!elRef || !elRef.nativeElement) {
+            return;
+        }
+        const el: HTMLElement = elRef.nativeElement as HTMLElement;
+        const elementToScroll = classSelector ? el.querySelector(classSelector) : el;
+
+        if (elementToScroll) {
+            elementToScroll.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        }
+    }
+}

--- a/projects/examples/src/components/spotlight-search/spotlight-search-no-title-example.component.html
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-no-title-example.component.html
@@ -1,0 +1,14 @@
+Press <kbd>Command</kbd>+<kbd>f</kbd> on MacOS / <kbd>Ctrl</kbd>+<kbd>f</kbd> on PC or click
+<a href="javascript: void(0);" (click)="spotlightOpen = true">here</a> to open the Spotlight Search.
+<p>
+    There is just one section with no title. That's why no section title is displayed at all.
+</p>
+<p>
+    Use the keyboard arrow keys to move through the search result. You can do this even while the results are still
+    loading.
+</p>
+<p>
+    Press 'Enter' to invoke the selected action. You can also use the mouse to click on an item
+</p>
+
+<vcd-spotlight-search [(open)]="spotlightOpen" [placeholder]="'Search ...'"></vcd-spotlight-search>

--- a/projects/examples/src/components/spotlight-search/spotlight-search-no-title-example.component.ts
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-no-title-example.component.ts
@@ -1,0 +1,66 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+    SpotlightSearchProvider,
+    SpotlightSearchResult,
+    SpotlightSearchResultType,
+    SpotlightSearchService,
+} from '@vcd/ui-components';
+import Mousetrap from 'mousetrap';
+
+@Component({
+    selector: 'vcd-spotlight-example',
+    templateUrl: './spotlight-search-no-title-example.component.html',
+})
+export class SpotlightSearchNoTitleExampleComponent implements OnInit, OnDestroy {
+    kbdShortcut = 'mod+f';
+    spotlightOpen: boolean;
+    private registrationId: string;
+    private readonly mousetrap: MousetrapInstance;
+
+    constructor(private spotlightSearchService: SpotlightSearchService) {
+        // Create an instance of mouse trap within the constructor so that any bount shortcut event handler
+        // would be executed within the angular zone
+        this.mousetrap = new Mousetrap();
+    }
+
+    ngOnInit(): void {
+        this.mousetrap.bind(this.kbdShortcut, () => {
+            this.spotlightOpen = true;
+            return false;
+        });
+
+        this.registrationId = this.spotlightSearchService.registerProvider(new ActionsSearchProvider(), '');
+    }
+
+    ngOnDestroy(): void {
+        this.mousetrap.reset();
+        this.spotlightSearchService.unregisterProvider(this.registrationId);
+    }
+}
+
+export class ActionsSearchProvider implements SpotlightSearchProvider {
+    private actions: SpotlightSearchResult[];
+
+    constructor() {
+        // Build actions
+        this.actions = [...Array(200).keys()].map(i => {
+            const action = `action - ${i + 1}`;
+            return {
+                displayText: action,
+                handler: () => {
+                    alert(`Action handler for '${action}' is called`);
+                },
+            };
+        });
+    }
+
+    search(criteria: string): SpotlightSearchResultType {
+        criteria = criteria ? criteria.toLowerCase() : '';
+        return this.actions.filter(action => action.displayText.toLowerCase().includes(criteria));
+    }
+}

--- a/projects/examples/src/components/spotlight-search/spotlight-search.example.module.ts
+++ b/projects/examples/src/components/spotlight-search/spotlight-search.example.module.ts
@@ -8,13 +8,14 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { SpotlightSearchModule, VcdFormModule } from '@vcd/ui-components';
 import { ActionsSearchProvider, SpotlightSearchExampleComponent } from './spotlight-search-example.component';
+import { SpotlightSearchNoTitleExampleComponent } from './spotlight-search-no-title-example.component';
 
 /**
  * A module that imports all activity reporter examples.
  */
 @NgModule({
     imports: [ClarityModule, SpotlightSearchModule, VcdFormModule, ReactiveFormsModule],
-    declarations: [SpotlightSearchExampleComponent],
+    declarations: [SpotlightSearchNoTitleExampleComponent, SpotlightSearchExampleComponent],
     exports: [SpotlightSearchExampleComponent],
     entryComponents: [SpotlightSearchExampleComponent],
     providers: [ActionsSearchProvider],

--- a/projects/examples/src/components/spotlight-search/spotlight-search.examples.module.ts
+++ b/projects/examples/src/components/spotlight-search/spotlight-search.examples.module.ts
@@ -7,6 +7,7 @@ import { NgModule } from '@angular/core';
 import { SpotlightSearchComponent } from '@vcd/ui-components';
 import { Documentation } from '@vmw/ng-live-docs';
 import { SpotlightSearchExampleComponent } from './spotlight-search-example.component';
+import { SpotlightSearchNoTitleExampleComponent } from './spotlight-search-no-title-example.component';
 import { SpotlightSearchExampleModule } from './spotlight-search.example.module';
 
 Documentation.registerDocumentationEntry({
@@ -17,8 +18,14 @@ Documentation.registerDocumentationEntry({
         {
             component: SpotlightSearchExampleComponent,
             forComponent: null,
-            title: 'Spotlight search',
-            urlSegment: 'spotlight-search',
+            title: 'Async and sync sections',
+            urlSegment: 'async-sync-sections',
+        },
+        {
+            component: SpotlightSearchNoTitleExampleComponent,
+            forComponent: null,
+            title: 'Single section with no title',
+            urlSegment: 'no-title-section',
         },
     ],
 });


### PR DESCRIPTION
 # Core component changes:
- use `section` instead of `div`
- use `h5` instead of `div`
- scroll to selected item to ensure it is always visible
- always display section title if such has been provided
      Up to now if there was just one search provider, i.e. one section
      its title was not shown. This leads to confusion when providers
      are added and removed on the fly. In that case one section may apear
      without a title and at the next moment when there is another provider
      this section will have a title.
- add `role="button"` for better ARIA support
- add DOM util class, currently with `scrollToElement` functionality

# Example changes
- new example for a simgle section with no title and many items
- create instance of mouse trap within the constructor to eliminate the
      usage of change detector
- refactor code to make it easier to follow