### PR TITLE
Fixed datagrid trackBy

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.26",
+    "version": "1.0.0-dev.27",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -12,13 +12,10 @@
 >
     <clr-dg-placeholder>{{ emptyGridPlaceholder }}</clr-dg-placeholder>
     <clr-dg-action-bar class="top-action-bar" *ngIf="shouldShowActionBarOnTop">
-        <vcd-action-menu
-            [actions]="actions"
-            [selectedEntities]="datagridSelection"
-            [actionDisplayConfig]="actionDisplayConfig"
-            [dropdownTriggerBtnText]="'vcd.cc.action.menu.actions'"
-        >
-        </vcd-action-menu>
+        <!--- We need to instantiate the action bar as its own component to separate its provider chain
+        such that the clr-dg-row doesn't get its trackBy. 
+        This is due to a bug in Clarity: https://github.com/vmware/clarity/issues/3936 -->
+        <ng-container *ngTemplateOutlet="actionBar"> </ng-container>
     </clr-dg-action-bar>
 
     <clr-dg-column *ngIf="shouldDisplayContextualActionsInRow" [ngClass]="'buttons-' + maxFeaturedActionsOnRow">
@@ -125,3 +122,13 @@
         </clr-dg-pagination>
     </clr-dg-footer>
 </clr-datagrid>
+
+<ng-template #actionBar>
+    <vcd-action-menu
+        [actions]="actions"
+        [selectedEntities]="datagridSelection"
+        [actionDisplayConfig]="actionDisplayConfig"
+        [dropdownTriggerBtnText]="'vcd.cc.action.menu.actions'"
+    >
+    </vcd-action-menu>
+</ng-template>

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, HostBinding, ViewChild } from '@angular/core';
+import { Component, HostBinding, TrackByFunction, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LoadingListener } from '@clr/angular';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
+import { Mock } from 'protractor/built/driverProviders';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { ActivityPromiseResolver } from '../common/activity-reporter/activity-promise-resolver';
@@ -767,6 +768,28 @@ describe('DatagridComponent', () => {
                     expect(monitorGetSpy).toHaveBeenCalled();
                 }
             );
+
+            it('does not change what trackBy is used', function(this: HasFinderAndGrid): void {
+                this.finder.hostComponent.gridData = {
+                    items: mockData,
+                    totalItems: 2,
+                };
+                this.finder.detectChanges();
+
+                this.finder.hostComponent.actions = [
+                    {
+                        textKey: 'static.action',
+                        handler: () => null,
+                        availability: () => true,
+                        actionType: ActionType.STATIC,
+                    },
+                ];
+                this.finder.detectChanges();
+
+                console.log(this.finder.hostComponent.getGridTrackBy().toString());
+
+                expect(this.finder.hostComponent.getGridTrackBy()(0, mockData[0])).toEqual(mockData[0].name);
+            });
         });
 
         describe('shouldShowActionBarOnTop', () => {
@@ -1111,6 +1134,10 @@ export class HostWithDatagridComponent {
 
     getSelection(): MockRecord[] {
         return this.grid.datagridSelection;
+    }
+
+    getGridTrackBy(): TrackByFunction<MockRecord> {
+        return this.grid.datagrid.items.trackBy;
     }
 }
 


### PR DESCRIPTION
# Description

Fixes the problem where the trackBy function was not working on the vcd-datagrid and selection was lost on every refresh. This is specifically due to a bug in Clarity (https://github.com/vmware/clarity/issues/3936) where the trackBy on the row might come from somewhere else in the grid. We initially only thought this would happen if the trackBy was unset on the row, but it seems like it can even override it in certain cases. To fix this, I separated out the action menu into it's own template to separate the provider chain. With this fix, the trackBy in the action menu stays where it should be.

Closes https://github.com/vmware/vmware-cloud-director-ui-components/issues/156

# Testing
1. Added a unit test and verified that this unit test fails before my change.
2. Build library and put into VCD_UI, navigated to the orgs list page, create and disabled an org using the action menu.
3. Build library and put into VCD_UI, navigated to the VDC-VDC VPN connection page, and made sure the "New" button appeared and worked.
4. Made sure all the selection and trackBy examples in our library continue to work.

# Question
1. Is it possible to put this template separation within the action menu instead of in the datagrid to solve the problem at its root?


Signed-off-by: Ryan Bradford <rbradford@vmware.com>