### PR TITLE
Increase the max width of nested dropdown triggers

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.23",
+    "version": "1.0.0-dev.24",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/dropdown/dropdown.component.scss
+++ b/projects/components/src/dropdown/dropdown.component.scss
@@ -1,5 +1,5 @@
 .nested-dropdown-menu ::ng-deep .nested-dropdown {
     display: block;
     white-space: nowrap;
-    max-width: 13rem;
+    max-width: 15rem;
 }


### PR DESCRIPTION
### Why?
This is to fix the extra gap that is being created between the right end of a dropdown trigger and right end of the dropdown menu

### Testing done:
Made sure that in the vm actions list which has the longest action item name "Upgrade virtual hardware version", there is no extra gap created.
<img width="739" alt="Screen Shot 2020-08-21 at 5 08 11 PM" src="https://user-images.githubusercontent.com/10735165/90935295-ed2be100-e3d0-11ea-820d-06ee4adc289c.png">
