### PR TITLE
Provide resultActivated emitter

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.25",
+    "version": "1.0.0-dev.26",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/spotlight-search/spotlight-search-result.ts
+++ b/projects/components/src/spotlight-search/spotlight-search-result.ts
@@ -13,11 +13,6 @@ export interface SpotlightSearchResult {
     displayText: string;
 
     /**
-     * The keyboard shortcut that can be used to call the handler of this item
-     */
-    kbdShortcut?: string;
-
-    /**
      * Function that is going to be called when this item is to be handled, i.e. when the
      * user clicks on this item or  selects it and presses the Enter key.
      */


### PR DESCRIPTION
# Description
It is useful to know when the spotlight search component is calling
the item handler. One specific use case is for doing analytics.


This code change ensures ResultActivatedEvent is emitted when the
item handler is called.

Signed-off-by: Ivo Rahov <irahov@vmware.com>