### PR TITLE
Fixed the number with unit form default error translation

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.24",
+    "version": "1.0.0-dev.25",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -61,7 +61,7 @@ vcd.cc.cpu.speed.unit.ZHz={0} ZHz
 vcd.cc.cpu.speed.unit.YHz={0} YHz
 
 # Validation error strings
-vcd.cc.warning.numRange=Only numbers in the range of {min} to {max} are allowed
+vcd.cc.warning.numRange=Only numbers in the range of {1} to {2} are allowed
 
 vcd.cc.numeric.filter.from=From:
 vcd.cc.numeric.filter.to=To:


### PR DESCRIPTION
# Description

Fixes the default translation key for the number with unit form input. Right now the error message appears as "Only numbers in the range of undefined to undefined are allowed". 

# Testing

Ran the app locally and verified that the message appears as:

<img width="370" alt="Screen Shot 2020-08-24 at 11 42 24 AM" src="https://user-images.githubusercontent.com/7528512/91065779-e5518400-e5fe-11ea-8a3f-632585fca008.png">

Signed-off-by: Ryan Bradford <rbradford@vmware.com>