### PR TITLE
Fixes a problem due to a breaking TS change

### DIFF
--- a/projects/i18n/package.json
+++ b/projects/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/i18n",
-  "version": "1.0.0-dev.0",
+  "version": "1.0.0-dev.1",
   "peerDependencies": {
     "@angular/common": ">6.0.0",
     "@angular/core": ">6.0.0"

--- a/projects/i18n/src/lib/service/mock-translation-service.spec.ts
+++ b/projects/i18n/src/lib/service/mock-translation-service.spec.ts
@@ -10,7 +10,7 @@ describe('MockTranslationService', () => {
 
     it('uses the perferred local set', () => {
         service.preferredLocale = 'en';
-        expect(service.activeLocale).toEqual('en');
+        expect(service.getActiveLocale()).toEqual('en');
     });
 
     it('formats dates using the default formatter', () => {

--- a/projects/i18n/src/lib/service/mock-translation-service.ts
+++ b/projects/i18n/src/lib/service/mock-translation-service.ts
@@ -17,7 +17,7 @@ class MockTranslationService extends TranslationService {
 
     registerTranslations(set: TranslationSet): void {}
 
-    get activeLocale(): string {
+    getActiveLocale(): string {
         return this.preferredLocale;
     }
 


### PR DESCRIPTION
# Description

Fixes a problem where a getter was not being compiled to a readonly in the .d.ts files. This causes the error that `error TS1086: An accessor cannot be declared in an ambient context.`. This is because of a TS breaking change https://github.com/microsoft/TypeScript/issues/33939.

# Testing

Inspected the TS output and made sure it did not contain any getters.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>