### PR TITLE
Make ExportColumn.displayName optional and convert object to JSON string when exporting.

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.27",
+    "version": "1.0.0-dev.28",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.html
+++ b/projects/components/src/action-menu/action-menu.component.html
@@ -25,9 +25,8 @@
         ></vcd-dropdown>
     </ng-container>
 
-    <div class="static-actions-separator" *ngIf="shouldDisplayStaticAndStaticFeaturedActionsInline"></div>
-
     <ng-container *ngIf="shouldDisplayStaticActions(actionStyling.INLINE)">
+        <div class="static-actions-separator"></div>
         <ng-container *ngFor="let action of staticActions; trackBy: actionsTrackBy">
             <ng-template *ngTemplateOutlet="actionButton; context: { $implicit: action }"></ng-template>
         </ng-container>

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -317,16 +317,6 @@ export class ActionMenuComponent<R, T> {
             this.shouldDisplayStaticFeaturedActions(this.actionStyling.DROPDOWN)
         );
     }
-
-    /**
-     * To show or hide {@link ActionType.STATIC_FEATURED} and {@link ActionType.STATIC} actions in a inline action bar
-     */
-    get shouldDisplayStaticAndStaticFeaturedActionsInline(): boolean {
-        return (
-            this.shouldDisplayStaticActions(this.actionStyling.INLINE) &&
-            this.shouldDisplayStaticFeaturedActions(this.actionStyling.INLINE)
-        );
-    }
 }
 
 /**

--- a/projects/components/src/data-exporter/csv-exporter.service.spec.ts
+++ b/projects/components/src/data-exporter/csv-exporter.service.spec.ts
@@ -65,6 +65,11 @@ describe('CsvExporterService', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
             expect(service.createCsv([['a+', 'a-', 'a@', 'a='], [null, undefined]], true)).toEqual('a+,a-,a@,a=\n,');
         });
+
+        it('encodes JavaScript object to JSON string', () => {
+            const service: CsvExporterService = TestBed.inject(CsvExporterService);
+            expect(service.createCsv([['a', 'b', 'c'], [{a: 1, b: 2}, [1, 2], 10]])).toEqual('a,b,c\n"{""a"":1,""b"":2}","[1,2]",10');
+        });
     });
 
     describe('downloadCsvFile - msSaveBlob', () => {

--- a/projects/components/src/data-exporter/csv-exporter.service.ts
+++ b/projects/components/src/data-exporter/csv-exporter.service.ts
@@ -83,6 +83,8 @@ function encodeValue(cellValue: unknown, shouldSanitize: boolean): string {
     let innerValue = cellValue == null ? '' : cellValue.toString();
     if (cellValue instanceof Date) {
         innerValue = cellValue.toLocaleString();
+    } else if (cellValue && typeof cellValue === 'object') {
+        innerValue = JSON.stringify(cellValue);
     }
     // Double quotes are doubled
     let result = innerValue.replace(/"/g, '""');

--- a/projects/components/src/data-exporter/data-exporter.component.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.ts
@@ -15,9 +15,9 @@ import { CsvExporterService } from './csv-exporter.service';
  */
 export interface ExportColumn {
     /**
-     * Displayed in the list of columns
+     * Displayed in the list of columns. If there is no displayName, the default value is fieldName
      */
-    displayName: string;
+    displayName?: string;
     /**
      * The name of the field in the JSON that is returned and converted to a viewable format
      */
@@ -349,7 +349,7 @@ export class DataExporterComponent implements OnInit, OnDestroy {
     private getDisplayNameForField(fieldName: string): string {
         for (const column of this.columns) {
             if (column.fieldName === fieldName) {
-                return column.displayName;
+                return column.displayName || column.fieldName;
             }
         }
         return fieldName;


### PR DESCRIPTION
Make `ExportColumn.displayName` optional. If there is no displayName, the default value to display column will be `fieldName`.
When exporting data, if the given value is a Javascript object, it will be converted to JSON string.
Enable `static-action-separator` when there is static action. Static actions will align right without static featured action.

Test done:
 - unit tests: add and pass test cases for `CsvExporterService` and `DataExporterComponent`.
 - manually: static actions can align right when there is no static featured action.

<img width="1421" alt="Screen Shot 2020-08-28 at 11 34 28 AM" src="https://user-images.githubusercontent.com/49406822/91585764-79368f00-e922-11ea-8139-980892b27ef5.png">

Signed-off-by: yumengwu <yumengwu95@gmail.com>