### PR TITLE
Enable projecting content when there is no search

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.30",
+    "version": "1.0.0-dev.31",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/spotlight-search/spotlight-search.component.html
+++ b/projects/components/src/spotlight-search/spotlight-search.component.html
@@ -17,6 +17,7 @@
             />
         </div>
         <div class="search-result-container">
+            <ng-content *ngIf="!searchCriteria" select=".no-search"></ng-content>
             <section
                 *ngFor="let searchSection of searchSections; let i = index"
                 class="search-result-section section-index-{{ i }}"

--- a/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
+++ b/projects/components/src/spotlight-search/spotlight-search.component.spec.ts
@@ -594,6 +594,30 @@ describe('SpotlightSearchComponent', () => {
             expect(this.spotlightSearch.seacrhPlaceholder).toBe('Search...');
         });
     });
+
+    describe('projecting ".no-search" content', () => {
+        it('shows projected content after opening', function(this: Test): void {
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            expect(this.spotlightSearch.searchResultContainerText).toEqual('No search content');
+        });
+
+        it('does not show projected content when searching', function(this: Test): void {
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            this.spotlightSearch.searchInputValue = ' ';
+            expect(this.spotlightSearch.searchResultContainerText).not.toContain('No search content');
+        });
+
+        it('shows projected content when the search is cleared', function(this: Test): void {
+            this.finder.hostComponent.spotlightOpen = true;
+            this.finder.detectChanges();
+            this.spotlightSearch.searchInputValue = 'c';
+            expect(this.spotlightSearch.searchResultContainerText).not.toContain('No search content');
+            this.spotlightSearch.searchInputValue = '';
+            expect(this.spotlightSearch.searchResultContainerText).toEqual('No search content');
+        });
+    });
 });
 
 @Component({
@@ -603,6 +627,9 @@ describe('SpotlightSearchComponent', () => {
             (resultActivated)="resultActivated($event)"
             [placeholder]="placeholder"
         >
+            <div class="no-search">No search content</div>
+            <div>Unavailable</div>
+            content
         </vcd-spotlight-search>
     `,
 })
@@ -653,6 +680,10 @@ export class SpotlightSearchWidgetObject extends WidgetObject<SpotlightSearchCom
 
     public pressArrowDown(): void {
         this.sendKeyboardEvent('ArrowDown', '.search-input-container input');
+    }
+
+    public get searchResultContainerText(): string {
+        return this.getText('.search-result-container');
     }
 
     public get searchResults(): string[] {

--- a/projects/examples/src/components/spotlight-search/spotlight-search-example.component.html
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-example.component.html
@@ -24,4 +24,8 @@ Press <kbd>Command</kbd>+<kbd>f</kbd> on MacOS / <kbd>Ctrl</kbd>+<kbd>f</kbd> on
     </vcd-form-input>
 </form>
 
-<vcd-spotlight-search [(open)]="spotlightOpen" [placeholder]="formGroup.value.placeholder"></vcd-spotlight-search>
+<vcd-spotlight-search [(open)]="spotlightOpen" [placeholder]="formGroup.value.placeholder">
+    <div class="no-search">
+        This content is visible only if no search has taken place, i.e. when the search field is empty.
+    </div>
+</vcd-spotlight-search>

--- a/projects/examples/src/components/spotlight-search/spotlight-search-example.component.scss
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-example.component.scss
@@ -1,0 +1,6 @@
+.no-search {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    text-align: center;
+}

--- a/projects/examples/src/components/spotlight-search/spotlight-search-example.component.ts
+++ b/projects/examples/src/components/spotlight-search/spotlight-search-example.component.ts
@@ -15,6 +15,7 @@ import Mousetrap from 'mousetrap';
 
 @Component({
     selector: 'vcd-spotlight-example',
+    styleUrls: ['./spotlight-search-example.component.scss'],
     templateUrl: './spotlight-search-example.component.html',
 })
 export class SpotlightSearchExampleComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
# Description
There is quite much empty space when there is no search which
to be utilized in one way or another.

One example is to display some helpful information on how the spotlight search can be used.


# Testing done:
By using the spotlight search examples add text which is shown when there is
search, i.e. the search input is empty.

Signed-off-by: Ivo Rahov <irahov@vmware.com>

# Screenshots
no-search text is shown when there is no search
![image](https://user-images.githubusercontent.com/866923/91834691-0e05f900-ec51-11ea-846f-c4f2372f6117.png)

no-search text is hidden when there is a search
![image](https://user-images.githubusercontent.com/866923/91708960-be5cfa00-eb8a-11ea-9e29-ddadc207d842.png)
