### PR TITLE
Two way binding for selection

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.28",
+    "version": "1.0.0-dev.29",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -7,8 +7,8 @@
     [clrDgLoading]="isLoading"
     [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent-grid']"
     (clrDgRefresh)="gridStateChanged($event)"
-    (clrDgSelectedChange)="selectionChanged.emit($event)"
-    (clrDgSingleSelectedChange)="selectionChanged.emit([$event])"
+    (clrDgSelectedChange)="datagridSelectionChange.emit($event)"
+    (clrDgSingleSelectedChange)="datagridSelectionChange.emit([$event])"
 >
     <clr-dg-placeholder>{{ emptyGridPlaceholder }}</clr-dg-placeholder>
     <clr-dg-action-bar class="top-action-bar" *ngIf="shouldShowActionBarOnTop">

--- a/projects/examples/src/components/datagrid/datagrid-row-select.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-row-select.example.component.ts
@@ -4,7 +4,13 @@
  */
 
 import { Component } from '@angular/core';
-import { GridColumn, GridDataFetchResult, GridSelectionType, GridState } from '@vcd/ui-components';
+import {
+    GridColumn,
+    GridDataFetchResult,
+    GridSelectionType,
+    GridState,
+    PaginationConfiguration,
+} from '@vcd/ui-components';
 
 interface Data {
     href: string;
@@ -21,13 +27,15 @@ interface Data {
         <button class="btn btn-primary" (click)="selectionType = GridSelectionType.Single">Single Select</button>
         <button class="btn btn-primary" (click)="selectionType = GridSelectionType.Multi">Multi Select Select</button>
         <button class="btn btn-primary" (click)="selectionType = GridSelectionType.None">No Select Select</button>
-        <button class="btn btn-primary" (click)="this.newData()">New Data</button>
         <vcd-datagrid
             [gridData]="gridData"
             (gridRefresh)="refresh($event)"
             [columns]="columns"
             [selectionType]="selectionType"
-            (selectionChanged)="selectionChanged($event)"
+            (datagridSelectionChange)="selectionChanged($event)"
+            [(datagridSelection)]="selectedItems"
+            [pagination]="paginationInfo"
+            [preserveSelection]="true"
         ></vcd-datagrid>
     `,
 })
@@ -46,21 +54,23 @@ export class DatagridRowSelectExampleComponent {
         },
     ];
 
+    selectedItems = [{ href: 'c' }];
+
+    paginationInfo: PaginationConfiguration = {
+        pageSize: 2,
+    };
+
     selectionChanged(selected: Data[]): void {
         console.log(selected);
     }
 
     refresh(eventData: GridState<Data>): void {
         this.gridData = {
-            items: [{ href: 'a', data: 5 }, { href: 'b', data: 5 }, { href: 'c', data: 5 }],
-            totalItems: 2,
-        };
-    }
-
-    newData(): void {
-        this.gridData = {
-            items: [{ href: 'a', data: 6 }, { href: 'b', data: 6 }, { href: 'd', data: 6 }],
-            totalItems: 2,
+            items: [{ href: 'a', data: 5 }, { href: 'b', data: 5 }, { href: 'c', data: 5 }].slice(
+                (eventData.pagination.pageNumber - 1) * eventData.pagination.itemsPerPage,
+                eventData.pagination.pageNumber * eventData.pagination.itemsPerPage
+            ),
+            totalItems: 3,
         };
     }
 }


### PR DESCRIPTION
# Description

The grid now has two generics:
B  - an object that contains only the single property that identifies this record. So for example a { href: string }. This is the same property that your trackBy MUST return.
R - the record itself. This type extends B.
The property datagridSelection is now a two way binding that accepts/returns a (R | B)[]. If you want to set some list of preselected items, create a list of B's and bind to datagridSelection . datagridSelection will then continue to output a type B for all unloaded entities, but will output a full type R for any entity that has been loaded to the grid.

This grid also has an input preserveSelection that defaults to false. preserveSelection must be set to true for selection to be maintained across multiple pages/filters.

### Not a breaking change

The default behavior is the same as it was before. It is only when you set preserveSelection to true does the behavior change.

# Testing

1. Viewed the examples app and saw selection work across many pages.
2. Added some unit tests
3. Loaded into VCD_UI and saw selection continue to work.

![select-change](https://user-images.githubusercontent.com/7528512/91733026-0a05a880-eb77-11ea-84ac-887f4be690bb.gif)

Signed-off-by: Ryan Bradford <rbradford@vmware.com>