### PR TITLE
Display fieldName on 'export all columns' of data-exporter

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.31",
+    "version": "1.0.0-dev.32",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/data-exporter/data-exporter.component.html
+++ b/projects/components/src/data-exporter/data-exporter.component.html
@@ -65,7 +65,9 @@
                                         <clr-checkbox-wrapper class="column-checkbox">
                                             <input type="checkbox" clrCheckbox [formControlName]="col.fieldName" />
                                             <label>{{
-                                                this.friendlyFieldsControl.value ? col.displayName : col.fieldName
+                                                this.friendlyFieldsControl.value
+                                                    ? col.displayName || col.fieldName
+                                                    : col.fieldName
                                             }}</label>
                                         </clr-checkbox-wrapper>
                                     </li>
@@ -77,7 +79,7 @@
             </ul>
             <div [ngStyle]="{ visibility: shouldShowBubbles ? 'visible' : 'hidden' }" class="column-container">
                 <span class="label column-label" *ngFor="let column of selectedColumns">
-                    {{ this.friendlyFieldsControl.value ? column.displayName : column.fieldName }}
+                    {{ this.friendlyFieldsControl.value ? column.displayName || column.fieldName : column.fieldName }}
                     <clr-icon shape="close" class="badge badge-info" (click)="selectColumn(column, false)"> </clr-icon>
                 </span>
             </div>

--- a/projects/components/src/data-exporter/data-exporter.component.spec.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.spec.ts
@@ -48,16 +48,32 @@ describe('DataExporterColumnsWithoutDisplayName', () => {
                 ...TestData.exportDataWithoutDisplayName.map(row => Object.values(row)),
             ];
             const csvString = downloadService.createCsv(exportData);
-            expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(
-                csvString,
-                exporter.component.fileName
-            );
+            expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(csvString, exporter.component.fileName);
             this.finder.detectChanges();
             expect(this.finder.hostComponent.dataExporterOpen).toBe(false);
             done();
         });
 
         exporter.clickExport();
+    });
+
+    it('displays field name when there is no display name', function(this: TestExporterColumnsWithoutDisplayNameFinder, done): void {
+        const exporter = this.finder.find(DataExporterWidgetObject);
+        let dropdownMenu = document.querySelector('clr-dropdown-menu');
+        expect(dropdownMenu).toBeNull();
+        exporter.component.selectAllControl.setValue(false);
+        this.finder.detectChanges();
+        dropdownMenu = document.querySelector('clr-dropdown-menu');
+        const selections = dropdownMenu.querySelectorAll('li');
+        expect(selections.length).toEqual(2);
+        expect(selections[0].querySelector('label').innerText.trim()).toEqual('col1');
+        expect(selections[1].querySelector('label').innerText.trim()).toEqual('col2');
+
+        const columnLabels = document.querySelector('.column-container').querySelectorAll('span');
+        expect(columnLabels.length).toEqual(2);
+        expect(columnLabels[0].textContent.trim()).toEqual('col1');
+        expect(columnLabels[1].textContent.trim()).toEqual('col2');
+        done();
     });
 });
 
@@ -296,9 +312,9 @@ const TestData = {
     /** The progress calls that to updateProgress will be called with the following values */
     progressStates: [-1, 0.5, 1],
     exportColumns: [{ fieldName: 'name', displayName: 'Name' }, { fieldName: 'desc', displayName: 'Description' }],
-    exportColumnsWithoutDisplayName: [{fieldName: 'col1'}, {fieldName: 'col2'}],
+    exportColumnsWithoutDisplayName: [{ fieldName: 'col1' }, { fieldName: 'col2' }],
     exportData: [{ name: 'Jaak', desc: 'Tis what tis' }, { name: 'Jill', desc: 'Still tis what tis' }],
-    exportDataWithoutDisplayName: [{col1: 'hi', col2: 'alice'}, {col1: 'Hi', col2: 'Bob'}],
+    exportDataWithoutDisplayName: [{ col1: 'hi', col2: 'alice' }, { col1: 'Hi', col2: 'Bob' }],
     exportDataWrongField: [{ noexist: 'Jack' }, { noexist: 'Jill' }],
 };
 
@@ -332,6 +348,7 @@ class TestHostComponent {
 @Component({
     template: `
         <vcd-data-exporter
+            id="dataExporterWithoutDisplayName"
             *ngIf="dataExporterOpen"
             [(open)]="dataExporterOpen"
             [columns]="exportColumns"

--- a/projects/components/src/data-exporter/data-exporter.component.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.ts
@@ -78,10 +78,21 @@ export class DataExporterComponent implements OnInit, OnDestroy {
         });
     }
 
+    _columns: ExportColumn[] = [];
+
     /**
-     * List of columns that can be exported, user may deselect some before sending the download request
+     * List of columns that can be exported, user may deselect some before sending the download request.
+     * Display name defaults to field name if there is no displayName
      */
-    @Input() columns: ExportColumn[] = [];
+    @Input()
+    set columns(cols: ExportColumn[]) {
+        this._columns = cols;
+        this.updateFieldNameMap(cols);
+    }
+
+    get columns(): ExportColumn[] {
+        return this._columns;
+    }
 
     /**
      * The name of the file to be downloaded
@@ -222,6 +233,8 @@ export class DataExporterComponent implements OnInit, OnDestroy {
     }
     private _progress = 0;
 
+    private fieldNameMap = new Map<string, ExportColumn>();
+
     formGroup: FormGroup;
 
     exportStage: LazyString;
@@ -347,11 +360,18 @@ export class DataExporterComponent implements OnInit, OnDestroy {
     }
 
     private getDisplayNameForField(fieldName: string): string {
-        for (const column of this.columns) {
-            if (column.fieldName === fieldName) {
-                return column.displayName || column.fieldName;
-            }
+        if (this.fieldNameMap.has(fieldName)) {
+            const exportColumn = this.fieldNameMap.get(fieldName);
+            return exportColumn.displayName || exportColumn.fieldName;
+        } else {
+            return fieldName;
         }
-        return fieldName;
+    }
+
+    private updateFieldNameMap(cols: ExportColumn[]): void {
+        this.fieldNameMap.clear();
+        cols.forEach((column: ExportColumn) => {
+            this.fieldNameMap.set(column.fieldName, column);
+        });
     }
 }


### PR DESCRIPTION
Display `fieldName` on 'export all columns' of data exporter modal when there is no `displayName`.

**Why this change made?**
After making `displayName` an optional property, for those export columns only having `fieldName`, the column selection on data exporter will display empty text. This change could make it display fieldName.

Test Done:
 - Add a test case to verify `clr-dropdown-menu` and `column-container` display `fieldName` when there is no `displayName`.
 - manually: after opening the data exporter modal and unchecking 'export all columns', the export columns only having `fieldName` display `fieldName` now.

Before this change:
<img width="636" alt="1" src="https://user-images.githubusercontent.com/49406822/91760590-9af17980-eba1-11ea-895c-ea4844d52c4c.png">
<img width="614" alt="2" src="https://user-images.githubusercontent.com/49406822/91760596-9d53d380-eba1-11ea-9835-9c6c74b7c4ae.png">

After this change:
<img width="623" alt="Screen Shot 2020-08-31 at 3 37 47 PM" src="https://user-images.githubusercontent.com/49406822/91760607-a3e24b00-eba1-11ea-916c-c45d6c76aa57.png">
<img width="618" alt="Screen Shot 2020-08-31 at 3 37 59 PM" src="https://user-images.githubusercontent.com/49406822/91760615-a5ac0e80-eba1-11ea-8f07-86fe11b62126.png">

Signed-off-by: yumengwu <yumengwu95@gmail.com>