### PR TITLE
Display total number of results per search provider.

### DIFF
--- a/projects/components/src/action-search-provider/action-search.provider.spec.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.spec.ts
@@ -41,20 +41,20 @@ const getMockActionsList = (): ActionItem<MockRecord, any>[] => [
 ];
 
 describe('ActionSearchProvider', () => {
-    beforeEach(function(this: HasActionSearchProvider): void {
+    beforeEach(function (this: HasActionSearchProvider): void {
         this.actionSearchProvider = new ActionSearchProvider(new MockTranslationService());
     });
     describe('actions', () => {
-        it('when set, the search method will give the action that matches with the search' + ' text', function(
+        it('when set, the search method will give the action that matches with the search' + ' text', function (
             this: HasActionSearchProvider
         ): void {
-            const searchResultList = this.actionSearchProvider.search('sta');
-            expect(searchResultList).toEqual([]);
+            const searchResults = this.actionSearchProvider.search('sta');
+            expect(searchResults.items).toEqual([]);
             this.actionSearchProvider.actions = getMockActionsList();
-            const searchResultList2 = this.actionSearchProvider.search('sta');
-            expect(searchResultList2[0].displayText).toEqual('Start');
-            const searchResultList1 = this.actionSearchProvider.search('sto');
-            expect(searchResultList1[0].displayText).toEqual('Stop');
+            const searchResults2 = this.actionSearchProvider.search('sta');
+            expect(searchResults2.items[0].displayText).toEqual('Start');
+            const searchResults1 = this.actionSearchProvider.search('sto');
+            expect(searchResults1.items[0].displayText).toEqual('Stop');
         });
     });
 
@@ -62,19 +62,19 @@ describe('ActionSearchProvider', () => {
         it(
             'when set with an entity that will yield ActionItem.availability as false, the search method does not return the ActionItem' +
                 ' as it is unavailable',
-            function(this: HasActionSearchProvider): void {
+            function (this: HasActionSearchProvider): void {
                 this.actionSearchProvider.actions = getMockActionsList();
 
-                let searchResultList = this.actionSearchProvider.search('sto');
-                expect(searchResultList[0].displayText).toEqual('Stop');
+                let searchResults = this.actionSearchProvider.search('sto');
+                expect(searchResults.items[0].displayText).toEqual('Stop');
 
                 this.actionSearchProvider.selectedEntities = [
                     {
                         stopped: true,
                     },
                 ];
-                searchResultList = this.actionSearchProvider.search('sto');
-                expect(searchResultList).toEqual([]);
+                searchResults = this.actionSearchProvider.search('sto');
+                expect(searchResults.items).toEqual([]);
             }
         );
     });

--- a/projects/components/src/action-search-provider/action-search.provider.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.ts
@@ -5,7 +5,12 @@
 
 import { TranslationService } from '@vcd/i18n';
 import { ActionItem } from '../common/interfaces';
-import { QuickSearchProvider, QuickSearchProviderDefaults, QuickSearchResult } from '../quick-search';
+import {
+    QuickSearchProvider,
+    QuickSearchProviderDefaults,
+    QuickSearchResultItem,
+    QuickSearchResults,
+} from '../quick-search';
 import { CommonUtil } from '../utils';
 
 export const DEFAULT_ACTION_SEARCH_SECTION_HEADER_PREFIX = 'vcd.cc.action.provider.section.title';
@@ -39,21 +44,21 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
      * Searches through nested actions and finds all the actions that match with entered search text on the
      * {@link QuickSearchComponent}
      */
-    search(criteria: string): QuickSearchResult[] {
+    search(criteria: string): QuickSearchResults {
         if (!criteria) {
-            return [];
+            return { items: [] };
         }
 
         if (this.flatListOfAvailableActions == null) {
             this.flatListOfAvailableActions = this.getFlatListOfAvailableActions(this._actions);
         }
 
-        return this.getActions(criteria.toLowerCase());
+        return { items: this.getActions(criteria.toLowerCase()) };
     }
 
-    private getActions(searchCriteria: string): QuickSearchResult[] {
+    private getActions(searchCriteria: string): QuickSearchResultItem[] {
         return this.flatListOfAvailableActions
-            .filter((action) => action.textKey.toLowerCase().includes(searchCriteria))
+            .filter((action) => action.textKey?.toLowerCase().includes(searchCriteria))
             .map((action) => ({
                 displayText: action.textKey,
                 handler: () => action.handler(this._selectedEntities, action.handlerData),

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -21,6 +21,8 @@ vcd.cc.friendly.names.hint=User friendly column headers or object field names?
 vcd.cc.export.all=Export All Columns
 vcd.cc.exporter.downloading=Downloading...
 vcd.cc.exporter.writing=Writing File...
+vcd.cc.quickSearch.partialResultNotation=({lastItem} of {totalItems})
+vcd.cc.quickSearch.refineQuery=The search shows a maximum of {max} results. Refine your query to improve the accuracy.
 
 vcd.cc.units.bytes.B=B
 vcd.cc.units.bytes.KB=KB

--- a/projects/components/src/quick-search/quick-search-result.ts
+++ b/projects/components/src/quick-search/quick-search-result.ts
@@ -4,11 +4,36 @@
  */
 
 /**
- * The interface a spotlight search result item should implement
+ * The interface of a quick search result
  */
-export interface QuickSearchResult {
+export interface QuickSearchResults {
     /**
-     * The text that will be displayed in the spotlight search component
+     * Item list returned by the search
+     */
+    items: QuickSearchResultItem[];
+
+    /**
+     * The current page returned by the search
+     */
+    page?: number;
+
+    /**
+     * The current page size returned by the search
+     */
+    pageSize?: number;
+
+    /**
+     * Total number of items
+     */
+    total?: number;
+}
+
+/**
+ * The interface a quick search result item should implement
+ */
+export interface QuickSearchResultItem {
+    /**
+     * The text that will be displayed in the quick search component
      */
     displayText: string;
 
@@ -20,6 +45,6 @@ export interface QuickSearchResult {
 }
 
 /**
- * The type of the spotlight search result which can be a promise
+ * The type of the quick search result which can be a promise
  */
-export type QuickSearchResultType = QuickSearchResult[] | Promise<QuickSearchResult[]>;
+export type QuickSearchResultsType = QuickSearchResults | Promise<QuickSearchResults>;

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -23,6 +23,9 @@
             >
                 <h5 *ngIf="showSectionTitle(searchSection)" class="search-result-section-title">
                     {{ searchSection.provider.sectionName }}
+                    <span *ngIf="hasPartialResult(searchSection); let partial" class="partial-result">
+                        {{ 'vcd.cc.quickSearch.partialResultNotation' | translate: partial }}
+                    </span>
                 </h5>
                 <div *ngIf="searchSection.isLoading">
                     <div class="spinner spinner-inline"></div>
@@ -32,11 +35,26 @@
                     <li
                         class="search-result-item"
                         role="button"
-                        *ngFor="let item of searchSection.results"
+                        *ngFor="let item of searchSection.result?.items"
                         (click)="itemClicked(item)"
                         [ngClass]="item == selectedItem ? 'selected' : ''"
                     >
                         {{ item.displayText }}
+                    </li>
+                    <li>
+                        <clr-alert
+                            *ngIf="hasPartialResult(searchSection)"
+                            [clrAlertType]="'warning'"
+                            [clrAlertSizeSmall]="true"
+                            [clrAlertClosable]="false"
+                        >
+                            <clr-alert-item>
+                                {{
+                                    'vcd.cc.quickSearch.refineQuery'
+                                        | translate: { max: searchSection.result.items.length }
+                                }}
+                            </clr-alert-item>
+                        </clr-alert>
                     </li>
                 </ul>
             </section>

--- a/projects/components/src/quick-search/quick-search.component.scss
+++ b/projects/components/src/quick-search/quick-search.component.scss
@@ -35,6 +35,10 @@
             margin-top: 0;
         }
 
+        .partial-result {
+            color: var(--clr-color-neutral-500);
+        }
+
         .search-result-item {
             padding-left: 8px;
 

--- a/projects/components/src/quick-search/quick-search.provider.ts
+++ b/projects/components/src/quick-search/quick-search.provider.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { QuickSearchResultType } from './quick-search-result';
+import { QuickSearchResultsType } from './quick-search-result';
 
 /**
  * The interface a search providers should implement in order to register itself with the {@link QuickSearchService}
@@ -15,7 +15,7 @@ export interface QuickSearchProvider {
     sectionName: string;
 
     /**
-     * The order of the section in the spotlight search results. The lower the order, the closer to the beginning of the list.
+     * The order of the section in the quick search results. The lower the order, the closer to the beginning of the list.
      * -1 means append
      */
     order: number;
@@ -24,10 +24,11 @@ export interface QuickSearchProvider {
      * Returns an array or a promise of array of items that comply with the search criteria.
      * @param criteria The search string provided by the user when typing in the Quick Search Component
      */
-    search(criteria: string): QuickSearchResultType;
+    search(criteria: string): QuickSearchResultsType;
 }
 
-export abstract class QuickSearchProviderDefaults {
+export abstract class QuickSearchProviderDefaults implements QuickSearchProvider {
     sectionName = '';
     order = -1;
+    abstract search(criteria: string): QuickSearchResultsType;
 }

--- a/projects/components/src/quick-search/quick-search.service.spec.ts
+++ b/projects/components/src/quick-search/quick-search.service.spec.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { QuickSearchResultType } from './quick-search-result';
+import { QuickSearchResultsType } from './quick-search-result';
 import { QuickSearchProvider } from './quick-search.provider';
 import { QuickSearchService } from './quick-search.service';
 
 class SimpleSearchProvider implements QuickSearchProvider {
     constructor(public sectionName: string = '', public order: number = -1) {}
-    search(criteria: string): QuickSearchResultType {
-        return [];
+    search(criteria: string): QuickSearchResultsType {
+        return { items: [] };
     }
 }
 

--- a/projects/examples/src/components/quick-search/quick-search-no-title.example.component.ts
+++ b/projects/examples/src/components/quick-search/quick-search-no-title.example.component.ts
@@ -7,8 +7,8 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import {
     QuickSearchProvider,
     QuickSearchRegistrarService,
-    QuickSearchResult,
-    QuickSearchResultType,
+    QuickSearchResultItem,
+    QuickSearchResultsType,
 } from '@vcd/ui-components';
 import Mousetrap from 'mousetrap';
 
@@ -47,7 +47,7 @@ export class ActionsSearchProvider implements QuickSearchProvider {
 
     sectionName: '';
 
-    private actions: QuickSearchResult[];
+    private actions: QuickSearchResultItem[];
 
     constructor() {
         // Build actions
@@ -62,8 +62,9 @@ export class ActionsSearchProvider implements QuickSearchProvider {
         });
     }
 
-    search(criteria: string): QuickSearchResultType {
+    search(criteria: string): QuickSearchResultsType {
         criteria = criteria ? criteria.toLowerCase() : '';
-        return this.actions.filter((action) => action.displayText.toLowerCase().includes(criteria));
+        const items = this.actions.filter((action) => action.displayText.toLowerCase().includes(criteria));
+        return { items };
     }
 }

--- a/projects/examples/src/components/quick-search/quick-search-sync-async.example.component.html
+++ b/projects/examples/src/components/quick-search/quick-search-sync-async.example.component.html
@@ -1,6 +1,6 @@
 Press <kbd>Command</kbd>+<kbd>f</kbd> on MacOS / <kbd>Ctrl</kbd>+<kbd>f</kbd> on PC or click
 <a href="javascript: void(0);" (click)="spotlightOpen = true">here</a> to open the Quick Search.
-<p>There are two sections. One does the search asynchronously while the other synchronously.</p>
+<p>There several sections - some that do the search asynchronously while the other synchronously.</p>
 <p>
     Use the keyboard arrow keys to move through the search result. You can do this even while the results are still
     loading.
@@ -13,7 +13,7 @@ Press <kbd>Command</kbd>+<kbd>f</kbd> on MacOS / <kbd>Ctrl</kbd>+<kbd>f</kbd> on
         label="Placeholder"
         [type]="'text'"
         [formControlName]="'placeholder'"
-        description="The text to be shown in the spotlight search input field when it is empty"
+        description="The text to be shown in the quick search input field when it is empty"
     >
     </vcd-form-input>
 </form>

--- a/projects/examples/src/components/quick-search/quick-search.examples.module.ts
+++ b/projects/examples/src/components/quick-search/quick-search.examples.module.ts
@@ -13,7 +13,7 @@ import { QuickSearchSyncAsyncExampleModule } from './quick-search-sync-async.exa
 Documentation.registerDocumentationEntry({
     component: QuickSearchComponent,
     displayName: 'Quick Search',
-    urlSegment: 'spotlightSearch',
+    urlSegment: 'quickSearch',
     examples: [
         {
             component: QuickSearchSyncAsyncExampleComponent,


### PR DESCRIPTION
# Description
The search result of a provider can return a subsection of the total number
of items that match the criteria. Such an example is a backend query. The ideal
behavior is to be able to load the next page but we are still not there to implement this.

The current solution for this scenario is to show the number of the found items,
the total number of items and a warning message to the user.

# Changes
The changes include:
- modify the QuickSearchResult to contain items, page, pageSize and total
- update the search component to
  -- show the partial results found
  -- display a warning message if there are more items
- add new SearchProvider for the sync-async example

# Screenshots
![image](https://user-images.githubusercontent.com/866923/92131771-0ab86c00-ee0f-11ea-8900-8f463ddffbc4.png)
![image](https://user-images.githubusercontent.com/866923/91975342-ed5ca280-ed27-11ea-802a-a7d250b6f60c.png)
