### PR TITLE
Add functionality to open sub menus on hover

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.34",
+    "version": "1.0.0-dev.35",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/dropdown/dropdown.component.spec.ts
+++ b/projects/components/src/dropdown/dropdown.component.spec.ts
@@ -11,10 +11,10 @@ interface HasDropdownComponent {
 
 describe('DropdownComponent', () => {
     describe('shouldRenderAsSeparator', () => {
-        beforeEach(function(this: HasDropdownComponent): void {
-            this.dropdown = new DropdownComponent();
+        beforeEach(function (this: HasDropdownComponent): void {
+            this.dropdown = new DropdownComponent(null);
         });
-        it('returns false when separator is the first item in the list', function(this: HasDropdownComponent): void {
+        it('returns false when separator is the first item in the list', function (this: HasDropdownComponent): void {
             this.dropdown.items = [
                 {
                     isSeparator: true,
@@ -31,52 +31,53 @@ describe('DropdownComponent', () => {
             ];
             expect(this.dropdown.shouldRenderAsSeparator(0, this.dropdown.items[0])).toEqual(false);
         });
-        it('returns true only when the current item is a separator and the next item is not' + ' a separator', function(
-            this: HasDropdownComponent
-        ): void {
-            const separatorItemIndices = {
-                one: 1,
-                three: 3,
-                four: 4,
-            };
-            this.dropdown.items = [
-                {
-                    textKey: 'action.1',
-                },
-                {
-                    isSeparator: true,
-                },
-                {
-                    textKey: 'action.1',
-                },
-                {
-                    isSeparator: true,
-                },
-                {
-                    isSeparator: true,
-                },
-                {
-                    textKey: 'action.1',
-                },
-            ];
-            expect(this.dropdown.shouldRenderAsSeparator(0, this.dropdown.items[0])).toEqual(false);
-            expect(
-                this.dropdown.shouldRenderAsSeparator(
-                    separatorItemIndices.one,
-                    this.dropdown.items[separatorItemIndices.one]
-                )
-            ).toEqual(true);
-            expect(
-                this.dropdown.shouldRenderAsSeparator(
-                    separatorItemIndices.three,
-                    this.dropdown.items[separatorItemIndices.three]
-                )
-            ).toEqual(false);
-        });
+        it(
+            'returns true only when the current item is a separator and the next item is not' + ' a separator',
+            function (this: HasDropdownComponent): void {
+                const separatorItemIndices = {
+                    one: 1,
+                    three: 3,
+                    four: 4,
+                };
+                this.dropdown.items = [
+                    {
+                        textKey: 'action.1',
+                    },
+                    {
+                        isSeparator: true,
+                    },
+                    {
+                        textKey: 'action.1',
+                    },
+                    {
+                        isSeparator: true,
+                    },
+                    {
+                        isSeparator: true,
+                    },
+                    {
+                        textKey: 'action.1',
+                    },
+                ];
+                expect(this.dropdown.shouldRenderAsSeparator(0, this.dropdown.items[0])).toEqual(false);
+                expect(
+                    this.dropdown.shouldRenderAsSeparator(
+                        separatorItemIndices.one,
+                        this.dropdown.items[separatorItemIndices.one]
+                    )
+                ).toEqual(true);
+                expect(
+                    this.dropdown.shouldRenderAsSeparator(
+                        separatorItemIndices.three,
+                        this.dropdown.items[separatorItemIndices.three]
+                    )
+                ).toEqual(false);
+            }
+        );
         it(
             'irrespective of number of adjacent separators, it returns false for all the separators that do not have a dropdown item ' +
                 'next to them',
-            function(this: HasDropdownComponent): void {
+            function (this: HasDropdownComponent): void {
                 const separatorItemIndices = {
                     one: 1,
                     two: 2,
@@ -129,7 +130,7 @@ describe('DropdownComponent', () => {
                 ).toEqual(true);
             }
         );
-        it('returns false when separator is the last item in the list', function(this: HasDropdownComponent): void {
+        it('returns false when separator is the last item in the list', function (this: HasDropdownComponent): void {
             this.dropdown.items = [
                 {
                     textKey: 'action.1',

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -3,9 +3,24 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, Input, TrackByFunction } from '@angular/core';
+import {
+    Component,
+    Host,
+    HostListener,
+    Input,
+    Optional,
+    QueryList,
+    SkipSelf,
+    TrackByFunction,
+    ViewChild,
+    ViewChildren,
+} from '@angular/core';
+import { ClrDropdown } from '@clr/angular';
 import { TextIcon } from '../common/interfaces';
 import { CliptextConfig, TooltipSize } from '../lib/directives';
+
+const NESTED_DROPDOWN_TRIGGER_SELECTOR = 'clr-dropdown clr-dropdown > button';
+const DROPDOWN_ITEM_SELECTOR = 'clr-dropdown-menu > button';
 
 /**
  * Object representing an item of the dropdown
@@ -50,6 +65,29 @@ interface DropdownItem<T extends DropdownItem<T>> {
     styleUrls: ['./dropdown.component.scss'],
 })
 export class DropdownComponent<T extends DropdownItem<T>> {
+    /**
+     * Decides what goes into the action buttons
+     * @param textIcon An enum that describes the possible ways to display the button title
+     */
+    @Input() set dropdownItemContents(textIcon: TextIcon) {
+        this.shouldShowIcon = (TextIcon.ICON & textIcon) === TextIcon.ICON;
+        this.shouldShowText = (TextIcon.TEXT & textIcon) === TextIcon.TEXT;
+        this.shouldShowTooltip = textIcon === TextIcon.ICON;
+    }
+    get dropdownItemContents(): TextIcon {
+        return this._dropdownItemContents;
+    }
+    /**
+     * Nested list of dropdown objects
+     */
+    @Input() set items(items: T[]) {
+        this._items = this.flattenNestedItemsWithSingleChild(items);
+    }
+    get items(): T[] {
+        return this._items;
+    }
+
+    constructor(@Optional() @SkipSelf() @Host() private parentVcdDropdown: DropdownComponent<T>) {}
     /**
      * If a icon should be displayed inside contextual buttons
      */
@@ -118,37 +156,29 @@ export class DropdownComponent<T extends DropdownItem<T>> {
     @Input() isDropdownDisabled: boolean;
 
     private _dropdownItemContents: TextIcon = TextIcon.TEXT;
-    /**
-     * Decides what goes into the action buttons
-     * @param textIcon An enum that describes the possible ways to display the button title
-     */
-    @Input() set dropdownItemContents(textIcon: TextIcon) {
-        this.shouldShowIcon = (TextIcon.ICON & textIcon) === TextIcon.ICON;
-        this.shouldShowText = (TextIcon.TEXT & textIcon) === TextIcon.TEXT;
-        this.shouldShowTooltip = textIcon === TextIcon.ICON;
-    }
-    get dropdownItemContents(): TextIcon {
-        return this._dropdownItemContents;
-    }
 
     private _items: T[];
-    /**
-     * Nested list of dropdown objects
-     */
-    @Input() set items(items: T[]) {
-        this._items = this.flattenNestedItemsWithSingleChild(items);
-    }
-    get items(): T[] {
-        return this._items;
-    }
 
     /**
      * Css class name added to the dropdown trigger buttons
      */
     @Input() dropdownTriggerButtonClassName: string;
 
+    /**
+     * To toggle open an close states when hovered over
+     */
+    @ViewChild(ClrDropdown) clrDropdown: ClrDropdown;
+
+    /**
+     * List of nested dropdown children that belong to this dropdown. Used to close then when a different child in this menu list is
+     * hovered over
+     */
+    @ViewChildren(DropdownComponent) vcdDropdownChildren: QueryList<DropdownComponent<T>>;
+
+    private hideTimeout: number;
+
     private flattenNestedItemsWithSingleChild(items: T[]): T[] {
-        items.forEach(item => {
+        items.forEach((item) => {
             // Flatten out the dropdowns with single children at each level of dropdown
             this.flattenItemsWithSingleChild(items);
             if (item.children) {
@@ -167,7 +197,7 @@ export class DropdownComponent<T extends DropdownItem<T>> {
                 singleChildItemIndices.push(index);
             }
         });
-        singleChildItemIndices.forEach(singleChildItemIndex => {
+        singleChildItemIndices.forEach((singleChildItemIndex) => {
             // Delete them from the original list and add their children to the beginning of the current list
             const singleChildItem = items.splice(singleChildItemIndex, 1).pop();
             items.unshift(singleChildItem.children[0]);
@@ -185,5 +215,53 @@ export class DropdownComponent<T extends DropdownItem<T>> {
     shouldRenderAsSeparator(index: number, currentItem: DropdownItem<T>): boolean {
         const nextItem = this.items[index + 1];
         return index > 0 && currentItem.isSeparator && !!nextItem && !nextItem.isSeparator;
+    }
+
+    /**
+     * Handles the mouseover events on this dropdown's children that are of {@link #DROPDOWN_ITEM_SELECTOR} and
+     * {@link #NESTED_DROPDOWN_TRIGGER_SELECTOR} type. When mouse is hovered on a child of type...
+     * - DROPDOWN_ITEM_SELECTOR: Any open children of dropdown type have to be closed. This is because, user will always not mouse out of
+     * a nested dropdown host(<vcd-dropdown>) to trigger the close event. He can move the mouse from nested dropdown's item to this
+     * dropdown's item directly
+     * - NESTED_DROPDOWN_TRIGGER_SELECTOR: Any open children of parent dropdown have to be closed and this dropdown has to be opened. We ask
+     * the parent to close its children because, the mouse over events are not propagated upwards when hovered over a child of nested
+     * dropdown type
+     */
+    @HostListener('mouseover', ['$event'])
+    onMouseOver(event: unknown): void {
+        const tsEvent = event as Event;
+        tsEvent.stopPropagation();
+        if (this.hideTimeout) {
+            clearTimeout(this.hideTimeout);
+        }
+        const target = tsEvent.target as Element;
+        if (target.matches(DROPDOWN_ITEM_SELECTOR)) {
+            this.closeOpenVcdDropdownChildren();
+        }
+        if (target.matches(NESTED_DROPDOWN_TRIGGER_SELECTOR)) {
+            if (this.parentVcdDropdown) {
+                this.parentVcdDropdown.closeOpenVcdDropdownChildren();
+            }
+            this.clrDropdown.toggleService.open = true;
+        }
+    }
+
+    /**
+     * Handles the mouseout events on this dropdown's children that are of {@link #NESTED_DROPDOWN_TRIGGER_SELECTOR} type
+     */
+    @HostListener('mouseout', ['$event'])
+    onMouseOut(event: unknown): void {
+        const tsEvent = event as Event;
+        tsEvent.stopPropagation();
+        const target = tsEvent.target as Element;
+        if (target.matches(NESTED_DROPDOWN_TRIGGER_SELECTOR)) {
+            this.hideTimeout = setTimeout(() => (this.clrDropdown.toggleService.open = false), 400);
+        }
+    }
+
+    private closeOpenVcdDropdownChildren(): void {
+        this.vcdDropdownChildren
+            .filter((vcdDropdown: DropdownComponent<T>) => vcdDropdown.clrDropdown.toggleService.open)
+            .forEach((vcdDropdown: DropdownComponent<T>) => (vcdDropdown.clrDropdown.toggleService.open = false));
     }
 }

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -21,6 +21,7 @@ import { CliptextConfig, TooltipSize } from '../lib/directives';
 
 const NESTED_DROPDOWN_TRIGGER_SELECTOR = 'clr-dropdown clr-dropdown > button';
 const DROPDOWN_ITEM_SELECTOR = 'clr-dropdown-menu > button';
+const NESTED_MENU_HIDE_DELAY = 400;
 
 /**
  * Object representing an item of the dropdown
@@ -170,7 +171,7 @@ export class DropdownComponent<T extends DropdownItem<T>> {
     @ViewChild(ClrDropdown) clrDropdown: ClrDropdown;
 
     /**
-     * List of nested dropdown children that belong to this dropdown. Used to close then when a different child in this menu list is
+     * List of nested dropdown children that belong to this dropdown. Used to close when a different child in this menu list is
      * hovered over
      */
     @ViewChildren(DropdownComponent) vcdDropdownChildren: QueryList<DropdownComponent<T>>;
@@ -228,13 +229,12 @@ export class DropdownComponent<T extends DropdownItem<T>> {
      * dropdown type
      */
     @HostListener('mouseover', ['$event'])
-    onMouseOver(event: unknown): void {
-        const tsEvent = event as Event;
-        tsEvent.stopPropagation();
+    onMouseOver(event: Event): void {
+        event.stopPropagation();
         if (this.hideTimeout) {
             clearTimeout(this.hideTimeout);
         }
-        const target = tsEvent.target as Element;
+        const target = event.target as Element;
         if (target.matches(DROPDOWN_ITEM_SELECTOR)) {
             this.closeOpenVcdDropdownChildren();
         }
@@ -250,12 +250,14 @@ export class DropdownComponent<T extends DropdownItem<T>> {
      * Handles the mouseout events on this dropdown's children that are of {@link #NESTED_DROPDOWN_TRIGGER_SELECTOR} type
      */
     @HostListener('mouseout', ['$event'])
-    onMouseOut(event: unknown): void {
-        const tsEvent = event as Event;
-        tsEvent.stopPropagation();
-        const target = tsEvent.target as Element;
+    onMouseOut(event: Event): void {
+        event.stopPropagation();
+        const target = event.target as Element;
         if (target.matches(NESTED_DROPDOWN_TRIGGER_SELECTOR)) {
-            this.hideTimeout = setTimeout(() => (this.clrDropdown.toggleService.open = false), 400);
+            this.hideTimeout = window.setTimeout(
+                () => (this.clrDropdown.toggleService.open = false),
+                NESTED_MENU_HIDE_DELAY
+            );
         }
     }
 

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -44,7 +44,7 @@ interface DropdownItem<T extends DropdownItem<T>> {
      */
     isTranslatable?: boolean;
     /**
-     * Css class of the dropdown item. Must be unique among all dropdown items within the dropdown items list
+     * CSS class of the dropdown item. Must be unique among all dropdown items within the dropdown items list
      */
     class?: string;
     /**
@@ -263,7 +263,7 @@ export class DropdownComponent<T extends DropdownItem<T>> {
 
     private closeOpenVcdDropdownChildren(): void {
         this.vcdDropdownChildren
-            .filter((vcdDropdown: DropdownComponent<T>) => vcdDropdown.clrDropdown.toggleService.open)
-            .forEach((vcdDropdown: DropdownComponent<T>) => (vcdDropdown.clrDropdown.toggleService.open = false));
+            .filter((vcdDropdown) => vcdDropdown.clrDropdown.toggleService.open)
+            .forEach((vcdDropdown) => (vcdDropdown.clrDropdown.toggleService.open = false));
     }
 }

--- a/projects/examples/src/assets/our-translations.json
+++ b/projects/examples/src/assets/our-translations.json
@@ -7,6 +7,8 @@
         "power.actions": "Power Actions",
         "grouped.actions": "Grouped Actions",
         "grouped.actions2": "Grouped Actions 2",
+        "grouped.actions3": "Grouped Actions 3",
+        "grouped.actions4": "Grouped Actions 4",
         "grouped.actions.with.single.child": "Grouped actions with single child"
     },
     "de": {

--- a/projects/examples/src/assets/our-translations.json
+++ b/projects/examples/src/assets/our-translations.json
@@ -6,6 +6,7 @@
         "maxLengthError": "Input is too long",
         "power.actions": "Power Actions",
         "grouped.actions": "Grouped Actions",
+        "grouped.actions2": "Grouped Actions 2",
         "grouped.actions.with.single.child": "Grouped actions with single child"
     },
     "de": {

--- a/projects/examples/src/components/action-menu/action-menu.example.component.ts
+++ b/projects/examples/src/components/action-menu/action-menu.example.component.ts
@@ -140,6 +140,33 @@ export class ActionMenuExampleComponent<R extends Record, T extends HandlerData>
                 },
             ],
         },
+        {
+            textKey: 'grouped.actions2',
+            children: [
+                {
+                    textKey: 'Contextual featured',
+                    actionType: ActionType.CONTEXTUAL_FEATURED,
+                    handler: () => console.log('Contextual featured'),
+                    isTranslatable: false,
+                },
+                {
+                    textKey: 'Contextual 2',
+                    handler: () => console.log('Contextual action 2'),
+                    isTranslatable: false,
+                },
+                {
+                    textKey: 'grouped.actions.with.single.child',
+                    children: [
+                        {
+                            textKey: 'Single child',
+                            handler: () => null,
+                            availability: () => true,
+                            isTranslatable: false,
+                        },
+                    ],
+                },
+            ],
+        },
     ];
 
     isDropdownDisabled: boolean = false;

--- a/projects/examples/src/components/action-menu/action-menu.example.component.ts
+++ b/projects/examples/src/components/action-menu/action-menu.example.component.ts
@@ -165,6 +165,38 @@ export class ActionMenuExampleComponent<R extends Record, T extends HandlerData>
                         },
                     ],
                 },
+                {
+                    textKey: 'grouped.actions3',
+                    children: [
+                        {
+                            textKey: 'Contextual featured',
+                            actionType: ActionType.CONTEXTUAL_FEATURED,
+                            handler: () => console.log('Contextual featured'),
+                            isTranslatable: false,
+                        },
+                        {
+                            textKey: 'Contextual 2',
+                            handler: () => console.log('Contextual action 2'),
+                            isTranslatable: false,
+                        },
+                    ],
+                },
+                {
+                    textKey: 'grouped.actions4',
+                    children: [
+                        {
+                            textKey: 'Contextual featured',
+                            actionType: ActionType.CONTEXTUAL_FEATURED,
+                            handler: () => console.log('Contextual featured'),
+                            isTranslatable: false,
+                        },
+                        {
+                            textKey: 'Contextual 2',
+                            handler: () => console.log('Contextual action 2'),
+                            isTranslatable: false,
+                        },
+                    ],
+                },
             ],
         },
     ];


### PR DESCRIPTION
# What?
Open the nested menus at 2nd level in the action menu component by hovering over the dropdown items instead of having to click them

# Why?
Some of the menus like actions in vapp/vms now are 2 levels deep and having to click the menu item to open nested dropdowns is a little annoying

# Testing done:
Tested the functionality in examples app
![openOnHover](https://user-images.githubusercontent.com/10735165/92612180-9f93ed00-f287-11ea-8112-ba3af8aeb535.gif)

![subMenuOpenOnHoverInVcdUi](https://user-images.githubusercontent.com/10735165/92771784-2d93d480-f369-11ea-8161-dfe4d24fd0c5.gif)

# ToDo:
Unit tests for the mouse event handling methods - https://jira.eng.vmware.com/browse/VDUCC-324