### PR TITLE
Number with unit input - various fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "npm run build:i18n && npm run build-components-doc && npm run generate-example-translations && npm run build-examples-doc && ng serve",
+    "start": "npm run build:i18n && npm run build:components && npm run build-components-doc && npm run generate-example-translations && npm run build-examples-doc && ng serve -- --poll=2000",
     "build:examples": "ng build examples",
     "build:examples-prod": "ng build examples --prod=true --base-href=/vmware-cloud-director-ui-components/",
     "build:examples-aot": "ng build examples --aot=true",

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.36",
+    "version": "1.0.0-dev.37",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -38,6 +38,7 @@ vcd.cc.units.hertz.GHz=GHz
 vcd.cc.units.hertz.THz=THz
 
 vcd.cc.units.percent=%
+vcd.cc.display.percent={0} %
 
 # FileSizeUnits
 # {0} is the value in the specified unit

--- a/projects/components/src/form/form.module.ts
+++ b/projects/components/src/form/form.module.ts
@@ -12,18 +12,9 @@ import { UnitFormatter } from '../utils/unit/unit-formatter';
 import { FormCheckboxComponent } from './form-checkbox/form-checkbox.component';
 import { FormInputComponent } from './form-input/form-input.component';
 import { FormSelectComponent } from './form-select/form-select.component';
-import {
-    MinMaxValidator,
-    NumberWithUnitFormInputComponent,
-} from './number-with-unit-input/number-with-unit-form-input.component';
+import { NumberWithUnitFormInputComponent } from './number-with-unit-input/number-with-unit-form-input.component';
 
-const declarations = [
-    FormInputComponent,
-    FormSelectComponent,
-    FormCheckboxComponent,
-    NumberWithUnitFormInputComponent,
-    MinMaxValidator,
-];
+const declarations = [FormInputComponent, FormSelectComponent, FormCheckboxComponent, NumberWithUnitFormInputComponent];
 
 @NgModule({
     imports: [ClarityModule, FormsModule, ReactiveFormsModule, CommonModule, I18nModule],

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -1,36 +1,34 @@
-<div class="form-group" *ngIf="isReadOnly">
-    <label>{{ label }}</label>
+<div class="form-group clr-form-control" *ngIf="isReadOnly">
+    <label class="clr-control-label">{{ label }}</label>
     <span class="readonly-text">{{ this.displayValue }}</span>
 </div>
-<form [formGroup]="formGroup" *ngIf="!isReadOnly" class="input-number-with-unit">
+<div *ngIf="!isReadOnly" class="input-number-with-unit">
     <vcd-form-input
-        formControlName="limited"
+        #limitedInput
+        [formControl]="formGroup.controls.limited"
         [placeholder]="placeholder"
         type="number"
         [size]="size"
-        [min]="min"
-        [max]="max"
+        [min]="unitMin"
+        [max]="unitMax"
         [maxlength]="maxlength"
         [showAsterisk]="showAsterisk"
         [label]="label"
         [description]="description"
-        [errorLabels]="errorLabels"
     >
-        <aside [ngSwitch]="unitOptions?.length">
+        <aside [ngSwitch]="unitOptions.length">
             <ng-container *ngSwitchCase="0">
                 <!-- Do not display unit -->
             </ng-container>
             <ng-container *ngSwitchCase="1">
-                <div class="single-option">
-                    {{ unitOptions[0].getUnitNameTranslationKey() | translate }}
-                </div>
+                <div class="single-option">{{ unitOptions[0].getUnitNameTranslationKey() | translate }}</div>
             </ng-container>
             <vcd-form-select
                 class="combo-options"
                 *ngSwitchDefault
                 #unitDropdown
                 [options]="comboOptions"
-                formControlName="comboUnitOptions"
+                [formControl]="formGroup.controls.comboUnitOptions"
             >
             </vcd-form-select>
             <clr-signpost *ngIf="hint">
@@ -39,8 +37,24 @@
                 </clr-signpost-content>
             </clr-signpost>
         </aside>
-        <footer *ngIf="showUnlimitedOption">
-            <vcd-form-checkbox [text]="'vcd.cc.unlimited' | translate" formControlName="unlimited"> </vcd-form-checkbox>
-        </footer>
     </vcd-form-input>
-</form>
+    <div class="clr-form-control errors" *ngIf="showErrors">
+        <label class="clr-control-label"></label>
+        <div class="clr-error">
+            <span class="clr-subtext">
+                <div *ngFor="let error of errors | keyvalue">
+                    <div>{{ error.key | translate: getErrorTranslationParams(error.value) }}</div>
+                </div>
+            </span>
+        </div>
+    </div>
+
+    <footer *ngIf="showUnlimitedOption">
+        <!-- Setting [label] to space ensures the label is created hence the checkbox aligned properly -->
+        <vcd-form-checkbox
+            [label]="' '"
+            [text]="'vcd.cc.unlimited' | translate"
+            [formControl]="formGroup.controls.unlimited"
+        ></vcd-form-checkbox>
+    </footer>
+</div>

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
@@ -13,6 +13,34 @@ single-option {
     }
 
     .input-number-with-unit {
+        .clr-subtext:empty {
+            display: none;
+        }
+
+        .clr-form-control.errors {
+            margin-top: 0;
+
+            label {
+                margin: 0;
+            }
+        }
+
+        clr-signpost {
+            button {
+                height: 1.3rem;
+                clr-icon {
+                    vertical-align: baseline;
+                    transform: none;
+                }
+            }
+        }
+
+        vcd-form-input {
+            input {
+                width: 5rem;
+            }
+        }
+
         .clr-control-label {
             + .clr-control-container {
                 width: auto;
@@ -32,6 +60,14 @@ single-option {
             margin-top: -1px !important;
             margin-left: 5px;
             vcd-form-select {
+                .clr-form-control {
+                    margin-top: 0;
+                }
+            }
+        }
+
+        footer {
+            vcd-form-checkbox {
                 .clr-form-control {
                     margin-top: 0;
                 }

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -5,7 +5,7 @@
 
 import { Component } from '@angular/core';
 import { fakeAsync, TestBed } from '@angular/core/testing';
-import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule, MockTranslationService, TranslationService } from '@vcd/i18n';
@@ -190,13 +190,12 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
     describe('Validation', () => {
         it('@Input min/max are inclusive', () => {
             numberWithUnitInput.formControl.setValue(MIN - 1);
-            expect(numberWithUnitInput.formControl.valid).toBe(false);
-            numberWithUnitInput.formControl.setValue(MIN);
+            expect(finder.hostComponent.cpuLimit.valid).toBe(true);
             expect(numberWithUnitInput.formControl.valid).toBe(true);
-            numberWithUnitInput.formControl.setValue(MAX + 1);
+            finder.hostComponent.cpuLimit.setValidators(Validators.min(MIN));
+            finder.hostComponent.cpuLimit.updateValueAndValidity();
+            expect(finder.hostComponent.cpuLimit.valid).toBe(false);
             expect(numberWithUnitInput.formControl.valid).toBe(false);
-            numberWithUnitInput.formControl.setValue(MAX);
-            expect(numberWithUnitInput.formControl.valid).toBe(true);
         });
     });
 

--- a/projects/examples/src/components/form-input/form-input-components.examples.module.ts
+++ b/projects/examples/src/components/form-input/form-input-components.examples.module.ts
@@ -17,6 +17,8 @@ import { FormInputExampleComponent } from './form-input.example.component';
 import { FormInputExampleModule } from './form-input.example.module';
 import { FormSelectExampleComponent } from './form-select.example.component';
 import { FormSelectExampleModule } from './form-select.example.module';
+import { NumberWithUnitFormInputUnitlessExampleComponent } from './number-with-unit-form-input-unitless.example.component';
+import { NumberWithUnitFormInputUnitlessExampleModule } from './number-with-unit-form-input-unitless.example.module';
 import { NumberWithUnitFormInputExampleComponent } from './number-with-unit-form-input.example.component';
 import { NumberWithUnitFormInputExampleModule } from './number-with-unit-form-input.example.module';
 
@@ -73,6 +75,12 @@ Documentation.registerDocumentationEntry({
             title: 'Number with unit form input',
             urlSegment: 'number-with-unit-form-input',
         },
+        {
+            component: NumberWithUnitFormInputUnitlessExampleComponent,
+            forComponent: null,
+            title: 'Unitless',
+            urlSegment: 'number-with-unit-form-input-unitless',
+        },
     ],
 });
 
@@ -85,6 +93,7 @@ Documentation.registerDocumentationEntry({
         FormSelectExampleModule,
         FormCheckboxExampleModule,
         NumberWithUnitFormInputExampleModule,
+        NumberWithUnitFormInputUnitlessExampleModule,
     ],
 })
 export class FormInputComponentsExamplesModule {}

--- a/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.html
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.html
@@ -1,0 +1,56 @@
+These examples show how you can use the <code>&lt;vcd-number-with-unit-form-input&gt;</code> component without units or
+with percent.
+<br />
+The "Warn Level" percent example also disables the "unlimited" functionality.
+<p>
+    You can play with the form below to examine validators, min/max values, unlimited values, readonly & disabled state
+    etc.
+</p>
+<form [formGroup]="formGroup" class="clr-form-horizontal">
+    <section>
+        <vcd-form-checkbox
+            [label]="'Readonly'"
+            [styling]="CheckBoxStyling.TOGGLESWITCH"
+            [formControlName]="'readonly'"
+        ></vcd-form-checkbox>
+        <vcd-form-checkbox
+            [label]="'Disabled'"
+            [styling]="CheckBoxStyling.TOGGLESWITCH"
+            [formControlName]="'disabled'"
+        ></vcd-form-checkbox>
+    </section>
+    <section>
+        <vcd-number-with-unit-form-input
+            [formControlName]="'noUnit'"
+            [label]="'Session Limit'"
+            [unitOptions]="[]"
+            [showAsterisk]="true"
+            [unlimitedValue]="noUnitUnlimited"
+            [isReadOnly]="formGroup.controls.readonly.value"
+        >
+        </vcd-number-with-unit-form-input>
+        <div class="value-container" *ngIf="!formGroup.controls.readonly.value">
+            <strong>Value:</strong>
+            {{ formGroup.get('noUnit').value }}
+        </div>
+    </section>
+
+    <section>
+        <vcd-form-checkbox
+            [label]="'Validator shows %'"
+            [styling]="CheckBoxStyling.TOGGLESWITCH"
+            [formControlName]="'validatorShowPercent'"
+        ></vcd-form-checkbox>
+        <vcd-number-with-unit-form-input
+            [formControlName]="'percentUnit'"
+            [label]="'Warn Level'"
+            [unitOptions]="[Percent.ZERO_TO_100]"
+            [max]="maxPercent"
+            [showUnlimitedOption]="false"
+            [isReadOnly]="formGroup.controls.readonly.value"
+        >
+        </vcd-number-with-unit-form-input>
+    </section>
+
+    <section class="form-valid"><strong>Form valid:</strong> {{ formGroup.valid }}</section>
+</form>

--- a/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.scss
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.scss
@@ -1,0 +1,3 @@
+.value-container {
+    margin-top: -1.2rem;
+}

--- a/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.ts
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.ts
@@ -1,0 +1,64 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, OnDestroy } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import {
+    CheckBoxStyling,
+    NumberWithUnitsFormValidatorsFactory,
+    Percent,
+    SubscriptionTracker,
+} from '@vcd/ui-components';
+
+@Component({
+    selector: 'vcd-number-with-unit-form-input-unitless-example-component',
+    styleUrls: ['number-with-unit-form-input-unitless.example.component.scss'],
+    templateUrl: 'number-with-unit-form-input-unitless.example.component.html',
+})
+export class NumberWithUnitFormInputUnitlessExampleComponent implements OnDestroy {
+    formGroup: FormGroup;
+    Percent = Percent;
+    CheckBoxStyling = CheckBoxStyling;
+
+    noUnitUnlimited = -100;
+    maxPercent = 100;
+
+    subscriptionTracker = new SubscriptionTracker(this);
+
+    constructor(fb: FormBuilder, numberWithUnitsFormValidators: NumberWithUnitsFormValidatorsFactory) {
+        const noUnitValidator = numberWithUnitsFormValidators.isInRange(1, 10, null, null, this.noUnitUnlimited);
+        const percentValidatorShowPercent = numberWithUnitsFormValidators.isInRange(
+            1,
+            this.maxPercent,
+            Percent.ZERO_TO_100,
+            [Percent.ZERO_TO_100],
+            null
+        );
+        const percentValidator = numberWithUnitsFormValidators.isInRange(1, this.maxPercent, null, null, null);
+
+        this.formGroup = fb.group({
+            readonly: new FormControl(false),
+            disabled: new FormControl(false),
+            validatorShowPercent: new FormControl(true),
+            noUnit: new FormControl(null, [Validators.required, noUnitValidator]),
+            percentUnit: new FormControl(null, [percentValidatorShowPercent]),
+        });
+        this.subscriptionTracker.subscribe(this.formGroup.controls.disabled.valueChanges, (value) => {
+            if (value) {
+                this.formGroup.controls.noUnit.disable();
+                this.formGroup.controls.percentUnit.disable();
+            } else {
+                this.formGroup.controls.noUnit.enable();
+                this.formGroup.controls.percentUnit.enable();
+            }
+        });
+        this.subscriptionTracker.subscribe(this.formGroup.controls.validatorShowPercent.valueChanges, (value) => {
+            this.formGroup.controls.percentUnit.setValidators([value ? percentValidatorShowPercent : percentValidator]);
+            this.formGroup.controls.percentUnit.updateValueAndValidity();
+        });
+    }
+
+    ngOnDestroy(): void {}
+}

--- a/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.module.ts
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.module.ts
@@ -8,12 +8,12 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { I18nModule } from '@vcd/i18n';
 import { VcdFormModule } from '@vcd/ui-components';
-import { NumberWithUnitFormInputExampleComponent } from './number-with-unit-form-input.example.component';
+import { NumberWithUnitFormInputUnitlessExampleComponent } from './number-with-unit-form-input-unitless.example.component';
 
 @NgModule({
-    declarations: [NumberWithUnitFormInputExampleComponent],
+    declarations: [NumberWithUnitFormInputUnitlessExampleComponent],
     imports: [CommonModule, VcdFormModule, ReactiveFormsModule, I18nModule],
-    exports: [NumberWithUnitFormInputExampleComponent],
-    entryComponents: [NumberWithUnitFormInputExampleComponent],
+    exports: [NumberWithUnitFormInputUnitlessExampleComponent],
+    entryComponents: [NumberWithUnitFormInputUnitlessExampleComponent],
 })
-export class NumberWithUnitFormInputExampleModule {}
+export class NumberWithUnitFormInputUnitlessExampleModule {}

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.html
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.html
@@ -1,30 +1,64 @@
+These examples show how you can use the <code>&lt;vcd-number-with-unit-form-input&gt;</code> component with different
+type of units.
+<p>
+    The "Memory" example also shows how you can specify the initial display unit in "MB" although the best match is in
+    "GB" while the second example "CPU speed" does not specify <code>[initialValueUnit]</code> so the initial value
+    "1500 MHz" is converted to the best match "1.5 GHz" and later on marked as "unlimited"
+    <br />
+    You can play with the form below to examine validators, min/max values, unlimited values, readonly & disabled state
+    etc.
+</p>
 <form [formGroup]="formGroup" class="clr-form-horizontal">
-    <vcd-number-with-unit-form-input
-        [formControlName]="'memory'"
-        [label]="'Memory'"
-        [unitOptions]="memoryOptions"
-        [inputValueUnit]="memoryFormControlValueUnit"
-        [hint]="
-            'Enter desired size of memory and chose memory units to see the memory getting converted and being ' +
-            'displayed in MB below. Checking the unlimited checkbox disables the input and sets input as -1'
-        "
-        [hintPosition]="'top-right'"
-    >
-    </vcd-number-with-unit-form-input>
-    <div>
-        <strong>Selected Memory:</strong>
-        {{ formGroup.get('memory').value + ' ' + memoryFormControlValueUnit.getUnitName() }}
-    </div>
+    <section>
+        <vcd-form-checkbox
+            [label]="'Readonly'"
+            [styling]="CheckBoxStyling.TOGGLESWITCH"
+            [formControlName]="'readonly'"
+        ></vcd-form-checkbox>
+        <vcd-form-checkbox
+            [label]="'Disabled'"
+            [styling]="CheckBoxStyling.TOGGLESWITCH"
+            [formControlName]="'disabled'"
+        ></vcd-form-checkbox>
+    </section>
+    <section>
+        <vcd-number-with-unit-form-input
+            [formControlName]="'memory'"
+            [label]="'Memory'"
+            [unitOptions]="memoryOptions"
+            [inputValueUnit]="memoryFormControlValueUnit"
+            [hint]="
+                'Enter desired size of memory and choose memory units to see the memory getting converted and being ' +
+                'displayed in MB below. Checking the unlimited checkbox disables the input and sets input as -1'
+            "
+            [hintPosition]="'top-right'"
+            [showAsterisk]="true"
+            [max]="maxMemoryAllowedMB"
+            [initialValueUnit]="Bytes.MB"
+            [isReadOnly]="formGroup.controls.readonly.value"
+        >
+        </vcd-number-with-unit-form-input>
+        <div class="value-container" *ngIf="!formGroup.controls.readonly.value">
+            <strong>Selected Memory:</strong>
+            {{ formGroup.get('memory').value + ' ' + memoryFormControlValueUnit.getUnitName() }}
+        </div>
+    </section>
 
-    <vcd-number-with-unit-form-input
-        [formControlName]="'cpuLimit'"
-        [label]="'Cpu speed'"
-        [unitOptions]="hertzOptions"
-        [inputValueUnit]="cpuSpeedFormControlValueUnit"
-    >
-    </vcd-number-with-unit-form-input>
-    <div>
-        <strong>Selected Cpu speed:</strong>
-        {{ formGroup.get('cpuLimit').value + ' ' + cpuSpeedFormControlValueUnit.getUnitName() }}
-    </div>
+    <section>
+        <vcd-number-with-unit-form-input
+            [formControlName]="'cpuLimit'"
+            [label]="'CPU speed'"
+            [unitOptions]="hertzOptions"
+            [max]="maxCpuAllowedMhz"
+            [inputValueUnit]="cpuSpeedFormControlValueUnit"
+            [isReadOnly]="formGroup.controls.readonly.value"
+        >
+        </vcd-number-with-unit-form-input>
+        <div class="value-container" *ngIf="!formGroup.controls.readonly.value">
+            <strong>Selected Cpu speed:</strong>
+            {{ formGroup.get('cpuLimit').value + ' ' + cpuSpeedFormControlValueUnit.getUnitName() }}
+        </div>
+    </section>
+
+    <section class="form-valid"><strong>Form valid:</strong> {{ formGroup.valid }}</section>
 </form>

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.scss
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.scss
@@ -1,0 +1,3 @@
+.value-container {
+    margin-top: -1.2rem;
+}

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.ts
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.ts
@@ -3,26 +3,72 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component } from '@angular/core';
-import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
-import { Bytes, Hertz, Unit } from '@vcd/ui-components';
+import { AfterViewInit, Component, OnDestroy } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import {
+    Bytes,
+    CheckBoxStyling,
+    Hertz,
+    NumberWithUnitsFormValidatorsFactory,
+    SubscriptionTracker,
+    Unit,
+} from '@vcd/ui-components';
 
 @Component({
     selector: 'vcd-number-with-unit-form-example-component',
+    styleUrls: ['./number-with-unit-form-input.example.component.scss'],
     templateUrl: './number-with-unit-form-input.example.component.html',
 })
-export class NumberWithUnitFormInputExampleComponent {
+export class NumberWithUnitFormInputExampleComponent implements AfterViewInit, OnDestroy {
     formGroup: FormGroup;
     hertzOptions: Unit[] = [Hertz.Mhz, Hertz.Ghz];
     cpuSpeedFormControlValueUnit: Unit = Hertz.Mhz;
+    maxCpuAllowedMhz = 2400;
 
+    maxMemoryAllowedMB = 10240;
     memoryOptions: Unit[] = [...Bytes.types];
     memoryFormControlValueUnit: Unit = Bytes.MB;
 
-    constructor(fb: FormBuilder) {
+    Bytes = Bytes;
+    CheckBoxStyling = CheckBoxStyling;
+
+    subscriptionTracker = new SubscriptionTracker(this);
+
+    constructor(fb: FormBuilder, numberWithUnitsFormValidators: NumberWithUnitsFormValidatorsFactory) {
+        const memoryValidator = numberWithUnitsFormValidators.isInRange(
+            10,
+            this.maxMemoryAllowedMB,
+            this.memoryFormControlValueUnit,
+            this.memoryOptions
+        );
+
+        const cpuValidator = numberWithUnitsFormValidators.isInRange(
+            0,
+            this.maxCpuAllowedMhz,
+            this.cpuSpeedFormControlValueUnit,
+            this.hertzOptions
+        );
+
         this.formGroup = fb.group({
-            cpuLimit: new FormControl(0),
-            memory: new FormControl(0),
+            readonly: new FormControl(false),
+            disabled: new FormControl(false),
+            cpuLimit: new FormControl(1500, [cpuValidator]),
+            memory: new FormControl(1024 * 2, [Validators.required, memoryValidator]),
+        });
+        this.subscriptionTracker.subscribe(this.formGroup.controls.disabled.valueChanges, (value) => {
+            if (value) {
+                this.formGroup.controls.cpuLimit.disable();
+                this.formGroup.controls.memory.disable();
+            } else {
+                this.formGroup.controls.cpuLimit.enable();
+                this.formGroup.controls.memory.enable();
+            }
         });
     }
+
+    ngAfterViewInit(): void {
+        this.formGroup.controls.cpuLimit.setValue(-1);
+    }
+
+    ngOnDestroy(): void {}
 }


### PR DESCRIPTION
# Description

Some of the changes are:
* Add new examples, enhance existing ones
* Enable the component to work with no units
* Remove internal validation but enable external ones only
* Add new validator: NumberWithUnitsFormValidatorsFactory.isInRange
* (in this component only) support not only `{ [key]: true }` error, but also `{ [key]: any }`
  This gives much more flexibility when translating errors 
* Use error style of the input, but show errors outside of the input component
  for 2 reasons:
  a) use the new supported format of errors and
  b) align the error not only under the input element but also under the unit dropdown
* Add initialValueUnit to prevent finding the best match for the initial value
* min/max values of the inner input are calculated according to the selected unit
* remember last real value when switching back and forth from 'unlimited' values
* fix buggy behavior when setting formValues from outside
* fix styling of readonly value
* fix misaligned 'unlimited' value
* fix disabled state not disabling unlimited value

# Testing done
Add new examples and play with them - setting different values, options etc.


Signed-off-by: Ivo Rahov <irahov@vmware.com>