### PR TITLE
Fixed 'Cannot read mouseoutDelay of null'

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.37",
+    "version": "1.0.0-dev.38",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/lib/directives/show-clipped-text.directive.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.ts
@@ -109,7 +109,9 @@ const tip = {
     },
 
     onMouseLeave(): void {
-        tip.hideTooltip(tip.mouseoutDelay);
+        if (tip.currentDirective) {
+            tip.hideTooltip(tip.mouseoutDelay);
+        }
     },
 
     hideTooltip(delay: number): void {


### PR DESCRIPTION
# Description

This bug occurs because of a timing issue. It happens when you show the cliptext, move off, and just as the cliptext bubble is disappearing, hover over the element and immediately leave again. What happens is that the directive is cleared from the first hiding, and then the leave event for the singleton from the second event fires before the enter event for the second event. This causes the error seen.

# Testing

Before this fix, I was able to easily reproduce the error on the datagrid example. After this fix, I could not get the error to happen again. 

Fixes https://github.com/vmware/vmware-cloud-director-ui-components/issues/120
 
Signed-off-by: Ryan Bradford <rbradford@vmware.com>