### PR TITLE
Fix wide space on vcd-datagrid between action and datagrid (vmware#204)

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.40",
+    "version": "1.0.0-dev.41",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -28,7 +28,7 @@ $supported-buttons: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
 }
 
 clr-dg-action-bar.top-action-bar {
-    height: unset;
+    margin-bottom: 10px;
 }
 
 // The height properties need to be marked as important because of a bug in Clarity


### PR DESCRIPTION
On `vcd-datagrid`, space between action menu and `clr-datagrid` is a bit wide, which should be updated to match CSS with screens using clr-datagrid` directly.

**Test done:**
Now space between action and datagrid is the same as screens using `clr-datagrid`.

<img width="659" alt="Screen Shot 2020-09-17 at 10 54 04 AM" src="https://user-images.githubusercontent.com/49406822/93488235-1e1a0b80-f8d4-11ea-8506-8e0a9f08498f.png">


Signed-off-by: yumengwu <yumengwu95@gmail.com>