### PR TITLE
Fixes bugs with the number with unit input

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.41",
+    "version": "1.0.0-dev.42",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -295,16 +295,19 @@ export class NumberWithUnitFormInputComponent
             return;
         }
 
-        this.computeBestUnitAndValue(value);
         if (this.showUnlimitedOption) {
             if (value !== this.unlimitedValue) {
+                this.computeBestUnitAndValue(value);
                 this.lastRealValue = this.bestValue;
                 input.setValue(this.bestValue);
                 this.selectedUnit = this.bestUnit.getMultiplier();
             }
             this.formGroup.get('unlimited').setValue(value === this.unlimitedValue);
         } else {
+            this.computeBestUnitAndValue(value);
+            this.lastRealValue = this.bestValue;
             input.setValue(this.bestValue);
+            this.selectedUnit = this.bestUnit.getMultiplier();
         }
 
         this.updateUnlimitedDisabledState();

--- a/projects/components/src/utils/unit/unit.ts
+++ b/projects/components/src/utils/unit/unit.ts
@@ -72,27 +72,27 @@ export abstract class Unit {
 }
 
 /**
- * Finds the bestUnit by trying groups of thousands
+ * Finds the bestUnit by trying groups of the comparison number
  */
-export abstract class ThousandsUnit extends Unit {
+abstract class NumberUnit extends Unit {
     /**
      * Calculates the best unit out of available units to display in UI cell for a given input Unit
      * and value
      *
-     * Best unit is a Unit whose converted value is less than 1000
+     * Best unit is a Unit whose converted value is less than the comparison number
      *
      * @param value - Value of input Unit
      * @param availableUnits - Array of available Units to display in UI cell
      * availableUnits array should be pre-sorted ascending by multiplier
      *
      */
-    findBestUnit(value: number, availableUnits: ThousandsUnit[] = this.getAllUnitTypes()): Unit {
-        if (value >= 1000) {
+    findBestUnit(value: number, availableUnits: NumberUnit[] = this.getAllUnitTypes()): Unit {
+        if (value >= this.getUnitMultiplier()) {
             const baseValue = this.getBaseValue(value);
             let outputNumber = baseValue;
             const unitTypes = availableUnits;
             let i = 0;
-            while (outputNumber >= 1000 && i < unitTypes.length) {
+            while (outputNumber >= this.getUnitMultiplier() && i < unitTypes.length) {
                 outputNumber = baseValue / unitTypes[i].getMultiplier();
                 i++;
             }
@@ -102,7 +102,32 @@ export abstract class ThousandsUnit extends Unit {
         }
     }
 
-    abstract getAllUnitTypes(): ThousandsUnit[];
+    abstract getAllUnitTypes(): NumberUnit[];
+
+    /**
+     * Returns the number that you multiply by to get the next order unit.
+     *
+     * @example 1024 would be the multiplier for Byte.
+     */
+    protected abstract getUnitMultiplier(): number;
+}
+
+/**
+ * Finds the bestUnit by trying groups of 1000
+ */
+export abstract class ThousandsUnit extends NumberUnit {
+    getUnitMultiplier(): number {
+        return 1000;
+    }
+}
+
+/**
+ * Finds the bestUnit by trying groups of 1024
+ */
+export abstract class PowerTwoUnit extends NumberUnit {
+    getUnitMultiplier(): number {
+        return 1024;
+    }
 }
 
 export class Hertz extends ThousandsUnit {
@@ -128,7 +153,7 @@ export class Hertz extends ThousandsUnit {
     }
 }
 
-export class Bytes extends ThousandsUnit {
+export class Bytes extends PowerTwoUnit {
     static valueWithUnitTranslationKeyPrefix = 'vcd.cc.filesize.unit.';
     static unitNameTranslationKeyPrefix = 'vcd.cc.units.bytes.';
     static B = new Bytes(1, 'B');


### PR DESCRIPTION
# Description

1. Fixes a bug where the findBestUnit method did not work correctly
2. Fixes a bug when on editing an input without an unlimited checkbox, the best unit was not selected. 

# Testing

Loaded into VCD_UI.
1. Created a Vapp from a template to show that best unit selection now works for their memory input. 
2. Edited a Kubernetes policy on a Org VDC to show their validators working with the correct units. 

![number-fix](https://user-images.githubusercontent.com/7528512/93922326-be5e9e80-fcdf-11ea-9387-0e2345eecec6.gif)
<img width="823" alt="Screen Shot 2020-09-22 at 1 46 01 PM" src="https://user-images.githubusercontent.com/7528512/93922327-be5e9e80-fcdf-11ea-84bd-d40e3f39ba0e.png">


