### PR TITLE
Fix quickSearch mouse over color on dark theme

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.41",
+    "version": "1.0.0-dev.42",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/quick-search/quick-search.component.scss
+++ b/projects/components/src/quick-search/quick-search.component.scss
@@ -55,7 +55,7 @@
                 background-color: var(--clr-global-selection-color);
             }
             &:hover {
-                background-color: var(--clr-global-hover-color);
+                background-color: var(--clr-tree-link-hover-color);
             }
         }
     }


### PR DESCRIPTION
The reason of this change is, `--clr-global-hover-color` makes hover color of quick search result item on dark theme the same as for the regular theme. Change it to `--clr-tree-link-hover-color` could make it same as edit blocking task modal, which looks good for both default theme and dark theme.

**Test done:**

On Dark theme:
 - Open quick search modal
 - Write some characters
 - Observe that hover color is not the same as for the regular theme and now it looks good on dark theme


Default Theme:
![Untitled](https://user-images.githubusercontent.com/49406822/94039148-52d70880-fd95-11ea-8a8b-190c508a4a8c.gif)


Dark Theme:
![Untitled](https://user-images.githubusercontent.com/49406822/94039000-28854b00-fd95-11ea-85e9-8eecae59cad7.gif)


Cassini Theme:
![Untitled](https://user-images.githubusercontent.com/49406822/94038649-b7de2e80-fd94-11ea-8e77-ddc45136859e.gif)


Signed-off-by: yumengwu <yumengwu95@gmail.com>