### PR TITLE
Fix actions not shown until entity is loaded bug and action search result availability calculation bug

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.43",
+    "version": "1.0.0-dev.44",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-search-provider/action-search.provider.spec.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.spec.ts
@@ -45,15 +45,15 @@ describe('ActionSearchProvider', () => {
         this.actionSearchProvider = new ActionSearchProvider(new MockTranslationService());
     });
     describe('actions', () => {
-        it('when set, the search method will give the action that matches with the search' + ' text', function (
+        it('when set, the search method will give the action that matches with the search' + ' text', async function (
             this: HasActionSearchProvider
-        ): void {
-            const searchResults = this.actionSearchProvider.search('sta');
+        ): Promise<void> {
+            const searchResults = await this.actionSearchProvider.search('sta');
             expect(searchResults.items).toEqual([]);
             this.actionSearchProvider.actions = getMockActionsList();
-            const searchResults2 = this.actionSearchProvider.search('sta');
+            const searchResults2 = await this.actionSearchProvider.search('sta');
             expect(searchResults2.items[0].displayText).toEqual('Start');
-            const searchResults1 = this.actionSearchProvider.search('sto');
+            const searchResults1 = await this.actionSearchProvider.search('sto');
             expect(searchResults1.items[0].displayText).toEqual('Stop');
         });
     });
@@ -62,10 +62,10 @@ describe('ActionSearchProvider', () => {
         it(
             'when set with an entity that will yield ActionItem.availability as false, the search method does not return the ActionItem' +
                 ' as it is unavailable',
-            function (this: HasActionSearchProvider): void {
+            async function (this: HasActionSearchProvider): Promise<void> {
                 this.actionSearchProvider.actions = getMockActionsList();
 
-                let searchResults = this.actionSearchProvider.search('sto');
+                let searchResults = await this.actionSearchProvider.search('sto');
                 expect(searchResults.items[0].displayText).toEqual('Stop');
 
                 this.actionSearchProvider.selectedEntities = [
@@ -73,7 +73,7 @@ describe('ActionSearchProvider', () => {
                         stopped: true,
                     },
                 ];
-                searchResults = this.actionSearchProvider.search('sto');
+                searchResults = await this.actionSearchProvider.search('sto');
                 expect(searchResults.items).toEqual([]);
             }
         );

--- a/projects/components/src/action-search-provider/action-search.provider.spec.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.spec.ts
@@ -78,4 +78,45 @@ describe('ActionSearchProvider', () => {
             }
         );
     });
+
+    describe('pause and unpause', () => {
+        it(
+            'when pause is not called by default, search returns a promise which is resolved without having to' +
+                'call unpause',
+            async function (this: HasActionSearchProvider): Promise<void> {
+                this.actionSearchProvider.actions = getMockActionsList();
+                let searchResultsBeforePausing;
+                searchResultsBeforePausing = await this.actionSearchProvider.search('sta');
+                expect(searchResultsBeforePausing.items[0].displayText).toEqual('Start');
+            }
+        );
+        it(
+            'when pause method is called, search returns a promise which is not resolved until unpause' + 'is called',
+            async function (this: HasActionSearchProvider): Promise<void> {
+                this.actionSearchProvider.actions = getMockActionsList();
+                const unpauseAfter1second = (): void => {
+                    setTimeout(() => {
+                        this.actionSearchProvider.unPause();
+                    }, 1000);
+                };
+                const checkResultsAfter500ms = (): void => {
+                    setTimeout(() => {
+                        expect(searchResultsAfterPausing).toEqual(undefined);
+                    }, 500);
+                };
+
+                const checkResultsAfter1second = (): void => {
+                    setTimeout(() => {
+                        expect(searchResultsAfterPausing.items[0].displayText).toEqual('Start');
+                    }, 1000);
+                };
+
+                this.actionSearchProvider.pause();
+                unpauseAfter1second();
+                checkResultsAfter500ms();
+                checkResultsAfter1second();
+                const searchResultsAfterPausing = await this.actionSearchProvider.search('sta');
+            }
+        );
+    });
 });

--- a/projects/components/src/action-search-provider/action-search.provider.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.ts
@@ -16,21 +16,10 @@ import { CommonUtil } from '../utils';
 export const DEFAULT_ACTION_SEARCH_SECTION_HEADER_PREFIX = 'vcd.cc.action.provider.section.title';
 
 export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults implements QuickSearchProvider {
-    private flatListOfAvailableActions: ActionItem<R, T>[];
-
-    /**
-     * Initialized by the calling component and is used for searching of the search criteria entered in {@link QuickSearchComponent}
-     */
-    private _actions: ActionItem<R, T>[] = [];
     set actions(actions: ActionItem<R, T>[]) {
         this._actions = actions;
         this.flatListOfAvailableActions = null;
     }
-
-    /**
-     * Used in {@link isActionDisabled} to calculate disabled state of actions  and also in action handler
-     */
-    private _selectedEntities: R[] = [];
     set selectedEntities(entities: R[]) {
         this._selectedEntities = entities;
         this.flatListOfAvailableActions = null;
@@ -39,12 +28,55 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
     constructor(private ts: TranslationService) {
         super();
     }
+    private flatListOfAvailableActions: ActionItem<R, T>[];
+
+    /**
+     * Initialized by the calling component and is used for searching of the search criteria entered in {@link QuickSearchComponent}
+     */
+    private _actions: ActionItem<R, T>[] = [];
+
+    /**
+     * Used in {@link isActionDisabled} to calculate disabled state of actions  and also in action handler
+     */
+    private _selectedEntities: R[] = [];
+
+    private resolveIsReadyToSearch: (value?: null) => void;
+    private isReadyToSearchPromise: Promise<null> = this.readyToSearchPromiseFactory();
+    private shouldWait = false;
+
+    /**
+     * Pause searching for actions. For example, Call this method when searching for actions has to be paused until
+     * some data has to be fetched asynchronously
+     */
+    pause(): void {
+        this.shouldWait = true;
+    }
+
+    /**
+     * Resume searching for actions. To unpause searching for actions functionality that might have been paused earlier
+     * using pause method above
+     */
+    unPause(): void {
+        this.shouldWait = false;
+        this.resolveIsReadyToSearch();
+        this.isReadyToSearchPromise = this.readyToSearchPromiseFactory();
+    }
+
+    private readyToSearchPromiseFactory(): Promise<null> {
+        return new Promise<null>((resolve, reject) => {
+            this.resolveIsReadyToSearch = resolve;
+        });
+    }
 
     /**
      * Searches through nested actions and finds all the actions that match with entered search text on the
      * {@link QuickSearchComponent}
      */
-    search(criteria: string): QuickSearchResults {
+    async search(criteria: string): Promise<QuickSearchResults> {
+        if (this.shouldWait) {
+            await this.isReadyToSearchPromise;
+        }
+
         if (!criteria) {
             return { items: [] };
         }
@@ -52,7 +84,6 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
         if (this.flatListOfAvailableActions == null) {
             this.flatListOfAvailableActions = this.getFlatListOfAvailableActions(this._actions);
         }
-
         return { items: this.getActions(criteria.toLowerCase()) };
     }
 
@@ -81,7 +112,11 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
     }
 
     private isActionAvailable(action: ActionItem<R, T>): boolean {
-        return (!action.availability || action.availability(this._selectedEntities)) && !this.isActionDisabled(action);
+        return (
+            !action.isSeparator &&
+            (!action.availability || action.availability(this._selectedEntities)) &&
+            !this.isActionDisabled(action)
+        );
     }
 
     private isActionDisabled(action: ActionItem<R, T>): boolean {

--- a/projects/examples/src/components/action-menu/action-menu-search-pause-and-unpause.example.component.html
+++ b/projects/examples/src/components/action-menu/action-menu-search-pause-and-unpause.example.component.html
@@ -1,0 +1,26 @@
+<h4 style="margin-top: 0">Use case</h4>
+<p>
+    In some cases, the data required for searching for available actions is not readily available when the component is
+    initialized. It can be fetched asynchronously and is available at a later point in time. During that time, if a user
+    searches for actions, we want to display a loading indicator and display results that match the search criteria
+    after the data is fetched. This example showcases that behavior by pausing the display of action search results when
+    a data fetch is initialized and un pauses it after the data has been fetched
+</p>
+
+<h4>Example description</h4>
+<p>
+    Press the button below to open quick search and also to initialize a mock data fetch which is resolved after 5
+    seconds. Notice that even as you are typing, a loading indicator is displayed for 5 seconds and only then it is
+    replaced by the search results.
+</p>
+&nbsp;
+<div>
+    <button (click)="openActionSearch()" class="btn btn-primary">Open action search</button>
+    <vcd-action-menu
+        [actions]="actions"
+        [selectedEntities]="selectedEntities"
+        [dropdownTriggerBtnText]="'vcd.cc.action.menu.actions'"
+    >
+    </vcd-action-menu>
+</div>
+<vcd-quick-search [(open)]="spotlightOpen" [placeholder]="'Search contextual actions'"></vcd-quick-search>

--- a/projects/examples/src/components/action-menu/action-menu-search-pause-and-unpause.example.component.ts
+++ b/projects/examples/src/components/action-menu/action-menu-search-pause-and-unpause.example.component.ts
@@ -1,0 +1,175 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { TranslationService } from '@vcd/i18n';
+import { ActionItem, ActionSearchProvider, QuickSearchService } from '@vcd/ui-components';
+
+interface Record {
+    value: string;
+    paused: boolean;
+}
+
+interface HandlerData {
+    foo: string;
+    bar: string;
+}
+
+@Component({
+    selector: 'vcd-action-menu-search-pause-unpause-example',
+    templateUrl: 'action-menu-search-pause-and-unpause.example.component.html',
+})
+export class ActionMenuSearchPauseUnpauseExampleComponent<R extends Record, T extends HandlerData>
+    implements OnInit, OnDestroy {
+    constructor(private spotlightSearchService: QuickSearchService, private translationService: TranslationService) {}
+    kbdShortcut = 'mod+.';
+    spotlightOpen: boolean;
+
+    actions: ActionItem<R, T>[] = [
+        {
+            textKey: 'Contextual 1',
+            availability: (rec: R[]) => rec.length === 1,
+            handler: () => console.log('Contextual 1'),
+            isTranslatable: false,
+        },
+        {
+            textKey: 'power.actions',
+            children: [
+                {
+                    textKey: 'Start',
+                    handler: (rec: R[]) => {
+                        console.log('Starting ' + rec[0].value);
+                        rec[0].paused = false;
+                        this.selectedEntities = rec;
+                    },
+                    availability: (rec: R[]) => rec.length === 1 && rec[0].paused,
+                    isTranslatable: false,
+                    class: 'start',
+                },
+                {
+                    textKey: 'Stop',
+                    handler: (rec: R[]) => {
+                        console.log('Stopping ' + (rec as R[])[0].value);
+                        rec[0].paused = true;
+                        this.selectedEntities = rec;
+                    },
+                    availability: (rec: R[]) => rec.length === 1 && !rec[0].paused,
+                    isTranslatable: false,
+                    class: 'stop',
+                },
+            ],
+        },
+        {
+            textKey: 'grouped.actions',
+            children: [
+                {
+                    textKey: 'Contextual featured',
+                    handler: () => console.log('Contextual featured'),
+                    isTranslatable: false,
+                },
+                {
+                    textKey: 'Contextual 2',
+                    handler: () => console.log('Contextual action 2'),
+                    isTranslatable: false,
+                },
+                {
+                    textKey: 'grouped.actions.with.single.child',
+                    children: [
+                        {
+                            textKey: 'Single child',
+                            handler: () => null,
+                            availability: () => true,
+                            isTranslatable: false,
+                        },
+                    ],
+                },
+            ],
+        },
+    ];
+
+    selectedEntities: Record[] = [{ value: 'Selected entity', paused: false }] as R[];
+
+    actionSearchProvider = new ActionSearchProvider(this.translationService);
+
+    openActionSearch(): void {
+        this.actionSearchProvider.pause();
+        this.actionSearchProvider.actions = null;
+        this.spotlightOpen = true;
+        setTimeout(() => {
+            this.actionSearchProvider.actions = [
+                {
+                    textKey: 'Contextual 1',
+                    availability: (rec: R[]) => rec.length === 1,
+                    handler: () => console.log('Contextual 1'),
+                    isTranslatable: false,
+                },
+                {
+                    textKey: 'power.actions',
+                    children: [
+                        {
+                            textKey: 'Start',
+                            handler: (rec: R[]) => {
+                                console.log('Starting ' + rec[0].value);
+                                rec[0].paused = false;
+                                this.selectedEntities = rec;
+                            },
+                            availability: (rec: R[]) => rec.length === 1 && rec[0].paused,
+                            isTranslatable: false,
+                            class: 'start',
+                        },
+                        {
+                            textKey: 'Stop',
+                            handler: (rec: R[]) => {
+                                console.log('Stopping ' + (rec as R[])[0].value);
+                                rec[0].paused = true;
+                                this.selectedEntities = rec;
+                            },
+                            availability: (rec: R[]) => rec.length === 1 && !rec[0].paused,
+                            isTranslatable: false,
+                            class: 'stop',
+                        },
+                    ],
+                },
+                {
+                    textKey: 'grouped.actions',
+                    children: [
+                        {
+                            textKey: 'Contextual featured',
+                            handler: () => console.log('Contextual featured'),
+                            isTranslatable: false,
+                        },
+                        {
+                            textKey: 'Contextual 2',
+                            handler: () => console.log('Contextual action 2'),
+                            isTranslatable: false,
+                        },
+                        {
+                            textKey: 'grouped.actions.with.single.child',
+                            children: [
+                                {
+                                    textKey: 'Single child',
+                                    handler: () => null,
+                                    availability: () => true,
+                                    isTranslatable: false,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ];
+            this.actionSearchProvider.unPause();
+        }, 5000);
+    }
+
+    ngOnInit(): void {
+        this.actionSearchProvider.actions = this.actions;
+        this.actionSearchProvider.selectedEntities = this.selectedEntities;
+        this.spotlightSearchService.registerProvider(this.actionSearchProvider);
+    }
+
+    ngOnDestroy(): void {
+        this.spotlightSearchService.unregisterProvider(this.actionSearchProvider);
+    }
+}

--- a/projects/examples/src/components/action-menu/action-menu-search-pause-and-unpause.example.module.ts
+++ b/projects/examples/src/components/action-menu/action-menu-search-pause-and-unpause.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { QuickSearchModule, VcdActionMenuModule } from '@vcd/ui-components';
+import { ActionMenuSearchPauseUnpauseExampleComponent } from './action-menu-search-pause-and-unpause.example.component';
+
+@NgModule({
+    declarations: [ActionMenuSearchPauseUnpauseExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdActionMenuModule, QuickSearchModule],
+    exports: [ActionMenuSearchPauseUnpauseExampleComponent],
+    entryComponents: [ActionMenuSearchPauseUnpauseExampleComponent],
+})
+export class ActionMenuSearchPauseAndUnpauseExampleModule {}

--- a/projects/examples/src/components/action-menu/action-menu.example.component.ts
+++ b/projects/examples/src/components/action-menu/action-menu.example.component.ts
@@ -277,5 +277,7 @@ export class ActionMenuExampleComponent<R extends Record, T extends HandlerData>
         this.spotlightSearchService.registerProvider(this.actionSearchProvider);
     }
 
-    ngOnDestroy(): void {}
+    ngOnDestroy(): void {
+        this.spotlightSearchService.unregisterProvider(this.actionSearchProvider);
+    }
 }

--- a/projects/examples/src/components/action-menu/action-menu.examples.module.ts
+++ b/projects/examples/src/components/action-menu/action-menu.examples.module.ts
@@ -7,6 +7,8 @@ import { NgModule } from '@angular/core';
 
 import { ActionMenuComponent } from '@vcd/ui-components';
 import { Documentation } from '@vmw/ng-live-docs';
+import { ActionMenuSearchPauseUnpauseExampleComponent } from './action-menu-search-pause-and-unpause.example.component';
+import { ActionMenuSearchPauseAndUnpauseExampleModule } from './action-menu-search-pause-and-unpause.example.module';
 import { ActionMenuWithSeparatorsExampleComponent } from './action-menu-with-separators.example.component';
 import { ActionMenuWithSeparatorsExampleModule } from './action-menu-with-separators.example.module';
 import { ActionMenuExampleComponent } from './action-menu.example.component';
@@ -28,10 +30,16 @@ Documentation.registerDocumentationEntry({
             title: 'Action Menu with separators',
             urlSegment: 'action-menu-with-separators',
         },
+        {
+            component: ActionMenuSearchPauseUnpauseExampleComponent,
+            forComponent: null,
+            title: 'Action search pause and unpause',
+            urlSegment: 'action-search-pause-unpause',
+        },
     ],
 });
 
 @NgModule({
-    imports: [ActionMenuWithSeparatorsExampleModule],
+    imports: [ActionMenuWithSeparatorsExampleModule, ActionMenuSearchPauseAndUnpauseExampleModule],
 })
 export class ActionMenuExamplesModule {}


### PR DESCRIPTION
## This fixes the following bugs:
- Displaying `?undefined` in the action search result section. This is happening because of not filtering out the `separator` objects from the action list.
- Actions are not shown after the entity is done loading. The search text has to be changed for them to get updated.

## Testing done:
- Verified that the vm and vapp entity details screens of vcd ui don't show errors 1 and 2

![actionSeach_bugs1 2](https://user-images.githubusercontent.com/10735165/94292951-a3806a00-ff2b-11ea-94ec-e073443106a0.gif)

## ToDo:
- Unit tests for newly added code in action search provider
- Example showcasing the added pause and unpause functionality of action search