### PR TITLE
Add UTF-8 BOM mark to CSV exported file.

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.44",
+    "version": "1.0.0-dev.45",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/data-exporter/csv-exporter.service.spec.ts
+++ b/projects/components/src/data-exporter/csv-exporter.service.spec.ts
@@ -10,65 +10,146 @@ describe('CsvExporterService', () => {
     describe('hasPotentialInjection', () => {
         it('doesnt detect injection on a row without formulas', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.hasPotentialInjection([['a+', 'b'], [1, 2]])).toBeFalsy();
+            expect(
+                service.hasPotentialInjection([
+                    ['a+', 'b'],
+                    [1, 2],
+                ])
+            ).toBeFalsy();
         });
 
         it('does detect injection on a row with formulas', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.hasPotentialInjection([['+', 'b'], [1, 2]])).toBeTruthy();
-            expect(service.hasPotentialInjection([['-', 'b'], [1, 2]])).toBeTruthy();
-            expect(service.hasPotentialInjection([['=', 'b'], [1, 2]])).toBeTruthy();
-            expect(service.hasPotentialInjection([['@', 'b'], [1, 2]])).toBeTruthy();
+            expect(
+                service.hasPotentialInjection([
+                    ['+', 'b'],
+                    [1, 2],
+                ])
+            ).toBeTruthy();
+            expect(
+                service.hasPotentialInjection([
+                    ['-', 'b'],
+                    [1, 2],
+                ])
+            ).toBeTruthy();
+            expect(
+                service.hasPotentialInjection([
+                    ['=', 'b'],
+                    [1, 2],
+                ])
+            ).toBeTruthy();
+            expect(
+                service.hasPotentialInjection([
+                    ['@', 'b'],
+                    [1, 2],
+                ])
+            ).toBeTruthy();
         });
     });
-
+    // Byte order mark for UTF-8
+    const BOM = '\ufeff';
     describe('createCsv', () => {
+        it('adds an UTF-8 BOM mark so it can be opened when non ASCII characters are present', () => {
+            const service: CsvExporterService = TestBed.inject(CsvExporterService);
+            expect(service.createCsv([['a'], [1]])).toEqual(BOM + 'a\n1');
+        });
         it('creates a csv out of 2D array of cell values', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.createCsv([['a', 'b'], [1, 2]])).toEqual('a,b\n1,2');
+            expect(
+                service.createCsv([
+                    ['a', 'b'],
+                    [1, 2],
+                ])
+            ).toEqual(BOM + 'a,b\n1,2');
         });
 
         it('encodes new lines by wrapping with double quotes', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.createCsv([['a', 'b'], ['1\n1', 2]])).toEqual('a,b\n"1\n1",2');
+            expect(
+                service.createCsv([
+                    ['a', 'b'],
+                    ['1\n1', 2],
+                ])
+            ).toEqual(BOM + 'a,b\n"1\n1",2');
         });
 
         it('encodes commas by wrapping with double quotes', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.createCsv([['a', 'b'], ['1,1', 2]])).toEqual('a,b\n"1,1",2');
+            expect(
+                service.createCsv([
+                    ['a', 'b'],
+                    ['1,1', 2],
+                ])
+            ).toEqual(BOM + 'a,b\n"1,1",2');
         });
 
         it('encodes double quotes with ""', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.createCsv([['a', 'b'], ['1"2', 2]])).toEqual('a,b\n"1""2",2');
+            expect(
+                service.createCsv([
+                    ['a', 'b'],
+                    ['1"2', 2],
+                ])
+            ).toEqual(BOM + 'a,b\n"1""2",2');
         });
 
         it('encodes dates with locale strings', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
             const date = new Date(0);
             const localeString = date.toLocaleString();
-            expect(service.createCsv([['a', 'b'], [date, 2]])).toEqual(`a,b
+            expect(
+                service.createCsv([
+                    ['a', 'b'],
+                    [date, 2],
+                ])
+            ).toEqual(`${BOM}a,b
 "${localeString}",2`);
         });
 
         it('prints null and undefined as an empty string', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.createCsv([['a', 'b'], [null, undefined]])).toEqual('a,b\n,');
+            expect(
+                service.createCsv([
+                    ['a', 'b'],
+                    [null, undefined],
+                ])
+            ).toEqual(BOM + 'a,b\n,');
         });
 
         it('adds a tab character if the value begins with any special characters', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.createCsv([['+', '-', '@', '='], [null, undefined]], true)).toEqual('\t+,\t-,\t@,\t=\n,');
+            expect(
+                service.createCsv(
+                    [
+                        ['+', '-', '@', '='],
+                        [null, undefined],
+                    ],
+                    true
+                )
+            ).toEqual(BOM + '\t+,\t-,\t@,\t=\n,');
         });
 
         it('does not add a tab character if the value contains but does not begin with with any special characters', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.createCsv([['a+', 'a-', 'a@', 'a='], [null, undefined]], true)).toEqual('a+,a-,a@,a=\n,');
+            expect(
+                service.createCsv(
+                    [
+                        ['a+', 'a-', 'a@', 'a='],
+                        [null, undefined],
+                    ],
+                    true
+                )
+            ).toEqual(BOM + 'a+,a-,a@,a=\n,');
         });
 
         it('encodes JavaScript object to JSON string', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            expect(service.createCsv([['a', 'b', 'c'], [{a: 1, b: 2}, [1, 2], 10]])).toEqual('a,b,c\n"{""a"":1,""b"":2}","[1,2]",10');
+            expect(
+                service.createCsv([
+                    ['a', 'b', 'c'],
+                    [{ a: 1, b: 2 }, [1, 2], 10],
+                ])
+            ).toEqual(BOM + 'a,b,c\n"{""a"":1,""b"":2}","[1,2]",10');
         });
     });
 
@@ -92,7 +173,11 @@ describe('CsvExporterService', () => {
 
         it('uses navigator.msSaveBlob if available', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            const rows = [['a', 'b'], ['1"2', 2], [3, 4]];
+            const rows = [
+                ['a', 'b'],
+                ['1"2', 2],
+                [3, 4],
+            ];
             const csvString = service.createCsv(rows);
 
             // Don't use spyOn, otherwise it would restore the empty function in its own afterEach()
@@ -118,7 +203,11 @@ describe('CsvExporterService', () => {
         });
         it('creates and clicks an invisible link', () => {
             const service: CsvExporterService = TestBed.inject(CsvExporterService);
-            const rows = [['a', 'b'], ['1"2', 2], [3, 4]];
+            const rows = [
+                ['a', 'b'],
+                ['1"2', 2],
+                [3, 4],
+            ];
             const csvString = service.createCsv(rows);
             spyOn(document.body, 'appendChild');
             spyOn(document.body, 'removeChild');

--- a/projects/components/src/data-exporter/csv-exporter.service.ts
+++ b/projects/components/src/data-exporter/csv-exporter.service.ts
@@ -19,7 +19,8 @@ export class CsvExporterService {
      * possible code injection
      */
     public createCsv(rows: any[][], shouldSanitize = false): string {
-        return rows.map(row => processRow(row, shouldSanitize)).join('\n');
+        // BOM Mark to help Excel open the CSV when it contains UTF-8 characters
+        return '\ufeff' + rows.map((row) => processRow(row, shouldSanitize)).join('\n');
     }
 
     /**
@@ -60,7 +61,7 @@ const LEADING_CONTROL_CHAR = /^[-+=@]/;
  * Whether the given row data is at risk of code injection when exported to CSV.
  */
 function hasPotentialInjection(row: unknown[]): boolean {
-    return row.some(cell => LEADING_CONTROL_CHAR.test(encodeValue(cell, false)));
+    return row.some((cell) => LEADING_CONTROL_CHAR.test(encodeValue(cell, false)));
 }
 
 /**
@@ -70,7 +71,7 @@ function hasPotentialInjection(row: unknown[]): boolean {
  * possible code injection
  */
 function processRow(row: unknown[], shouldSanitize: boolean): string {
-    return row.map(cell => encodeValue(cell, shouldSanitize)).join(',');
+    return row.map((cell) => encodeValue(cell, shouldSanitize)).join(',');
 }
 
 /**

--- a/projects/components/src/data-exporter/data-exporter.component.spec.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.spec.ts
@@ -239,8 +239,10 @@ describe('VcdExportTableComponent', () => {
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake(async (e: DataExportRequestEvent) => {
                     await e.exportData(TestData.exportDataWrongField);
                     this.finder.detectChanges();
+                    // Byte order mark for UTF-8
+                    const BOM = '\ufeff';
                     expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(
-                        'noexist\nJack\nJill',
+                        BOM + 'noexist\nJack\nJill',
                         exporter.component.fileName
                     );
                     done();


### PR DESCRIPTION
Microsoft for Excel for the Mac was not able to detect the UTF encoding
on its own, so it didn't show non-ASCII characters.


## Testing Done
* Using our examples container, exported a CSV where the header contained Japanese characters
* Open the CSV with Excel and make sure you can see the Japanese characters.

![image](https://user-images.githubusercontent.com/549331/94852472-ec3a9600-03f7-11eb-98ff-d0135599c878.png)
