### PR TITLE
Allow null values for form select

### DIFF
--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -42,8 +42,8 @@ describe('FormSelectComponent', () => {
         selectInput = finder.find({ woConstructor: VcdFormSelectWidgetObject });
     });
 
-    describe('selectedOption returns the option whose value', () => {
-        it('matches with form control value', () => {
+    describe('selectedOption', () => {
+        it('matches form control value', () => {
             expect(hostComponent.selectInputComponent.selectedOption.value).toEqual(
                 hostComponent.selectInputComponent.formControl.value
             );
@@ -55,6 +55,16 @@ describe('FormSelectComponent', () => {
         it('is of number type, when it is selected', () => {
             selectInput.select(hostComponent.options.length - 1);
             expect(hostComponent.selectInputComponent.selectedOption).toEqual(getOptionWithValueAsNumber());
+        });
+        it('is undefined if the component does not have a value set', () => {
+            selectInput.component.formControl.setValue(null);
+            expect(selectInput.component.selectedOption).toBe(undefined);
+            selectInput.component.formControl.setValue(undefined);
+            expect(selectInput.component.selectedOption).toBe(undefined);
+        });
+        it('allows falsy  values', () => {
+            selectInput.component.formControl.setValue('');
+            expect(selectInput.component.selectedOption.value).toBe('');
         });
     });
 

--- a/projects/components/src/form/form-select/form-select.component.ts
+++ b/projects/components/src/form/form-select/form-select.component.ts
@@ -27,10 +27,10 @@ export class FormSelectComponent extends BaseFormControl {
     }
 
     get selectedOption(): SelectOption {
-        if (!this.options) {
+        if (!this.options || this.formControl.value === null || this.formControl.value === undefined) {
             return undefined;
         }
         // option.value and formControl.value can be of type number or string
-        return this.options.find(option => option.value.toString() === this.formControl.value.toString());
+        return this.options.find((option) => option.value.toString() === this.formControl.value.toString());
     }
 }


### PR DESCRIPTION
If you don't want any option pre-selected on a form-select, its value should be null. However, that was throwing an NPE.

## Testing Done
* Unit tests added that failed before the fix.

## Notes
* This problem only happens if you are calling the component's `selectedOption`


