### PR TITLE
Modify sendKeyboardEvent to be more versatile

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.46",
+    "version": "1.0.0-dev.47",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/quick-search/quick-search.component.spec.ts
+++ b/projects/components/src/quick-search/quick-search.component.spec.ts
@@ -724,19 +724,19 @@ export class QuickSearchWidgetObject extends WidgetObject<QuickSearchComponent> 
     }
 
     public pressEscape(): void {
-        this.sendKeyboardEvent('escape', '.search-input-container input');
+        this.sendKeyboardEvent('keyup', { key: 'escape' }, '.search-input-container input');
     }
 
     public pressEnter(): void {
-        this.sendKeyboardEvent('enter', '.search-input-container input');
+        this.sendKeyboardEvent('keydown', { key: 'enter' }, '.search-input-container input');
     }
 
     public pressArrowUp(): void {
-        this.sendKeyboardEvent('ArrowUp', '.search-input-container input');
+        this.sendKeyboardEvent('keydown', { key: 'ArrowUp' }, '.search-input-container input');
     }
 
     public pressArrowDown(): void {
-        this.sendKeyboardEvent('ArrowDown', '.search-input-container input');
+        this.sendKeyboardEvent('keydown', { key: 'ArrowDown' }, '.search-input-container input');
     }
 
     public get searchResults(): string[] {


### PR DESCRIPTION
# Description
Some libraries like mousetrap use deprecated, read-only keyboard event properties
like `which`. This makes it impossible to use the general `new KeyboardEvent`
mechanism of creating the event and dispatching it later. To overcome this
we have used `Object.defineProperty`.

In addition to this, the method signature was also changed to allow more versatile
approach of setting different event properties.

# Testing done
This functionality is related entirely to unit testing

Signed-off-by: Ivo Rahov <irahov@vmware.com>