### PR TITLE
Prevent nested menus that are opened on hover from closing when clicked

### DIFF
--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    AfterViewInit,
     Component,
     Host,
     HostListener,
@@ -15,7 +16,7 @@ import {
     ViewChild,
     ViewChildren,
 } from '@angular/core';
-import { ClrDropdown } from '@clr/angular';
+import { ClrDropdown, ClrDropdownTrigger } from '@clr/angular';
 import { TextIcon } from '../common/interfaces';
 import { CliptextConfig, TooltipSize } from '../lib/directives';
 
@@ -58,14 +59,14 @@ interface DropdownItem<T extends DropdownItem<T>> {
 }
 
 /**
- * Dumb component used for displaying nested drop downs
+ * Component used for displaying nested drop downs
  */
 @Component({
     selector: 'vcd-dropdown',
     templateUrl: 'dropdown.component.html',
     styleUrls: ['./dropdown.component.scss'],
 })
-export class DropdownComponent<T extends DropdownItem<T>> {
+export class DropdownComponent<T extends DropdownItem<T>> implements AfterViewInit {
     /**
      * Decides what goes into the action buttons
      * @param textIcon An enum that describes the possible ways to display the button title
@@ -89,6 +90,7 @@ export class DropdownComponent<T extends DropdownItem<T>> {
     }
 
     constructor(@Optional() @SkipSelf() @Host() private parentVcdDropdown: DropdownComponent<T>) {}
+
     /**
      * If a icon should be displayed inside contextual buttons
      */
@@ -171,6 +173,12 @@ export class DropdownComponent<T extends DropdownItem<T>> {
     @ViewChild(ClrDropdown) clrDropdown: ClrDropdown;
 
     /**
+     * The button that opens this dropdown when clicked. Used for preventing the clarity frameworks click handler logic
+     * from executing
+     */
+    @ViewChild(ClrDropdownTrigger) clrDropdownTrigger: ClrDropdownTrigger;
+
+    /**
      * List of nested dropdown children that belong to this dropdown. Used to close when a different child in this menu list is
      * hovered over
      */
@@ -203,6 +211,18 @@ export class DropdownComponent<T extends DropdownItem<T>> {
             const singleChildItem = items.splice(singleChildItemIndex, 1).pop();
             items.unshift(singleChildItem.children[0]);
         });
+    }
+
+    /**
+     * Nested menus are toggled using the mouseover and mouseout events instead of mouse clicks. So the claritys
+     * click handler which conflicts with that is prevented from executing
+     */
+    ngAfterViewInit(): void {
+        if (this.parentVcdDropdown) {
+            this.clrDropdownTrigger.onDropdownTriggerClick = (event: Event) => {
+                event.stopPropagation();
+            };
+        }
     }
 
     /**


### PR DESCRIPTION
# Problem:
Nested-menus that are opened on hover are being closed for example when they are accidentally clicked upon. This is not a very good UX.

# Solution:
Looking at other dropdowns like... in Mac OS and Microsft outlook, we found out that the nested menus that are opened on hover are not reacting to mouse clicks. So, taking the inspiration from there, I have done something similar by preventing mouse clicks from happening on the nested menu triggers.

# Testing done:
![dropdown_notOpenOnClick](https://user-images.githubusercontent.com/10735165/95877505-2b46e080-0d42-11eb-95d8-f20692612248.gif)


