### PR TITLE
[a11y] Add ARIA role to the ErrorBannerComponent

### DIFF
--- a/projects/components/src/common/error/error-banner.component.html
+++ b/projects/components/src/common/error/error-banner.component.html
@@ -3,6 +3,7 @@
     [clrAlertType]="alertType"
     [clrAlertClosable]="alertClosable"
     (clrAlertClosedChange)="onAlertClosedChange($event)"
+    [attr.role]="alertType === 'danger' ? 'alert' : 'status'"
 >
     <div class="alert-item">
         <span class="alert-text">{{ errorMessage }}</span>

--- a/projects/components/src/common/error/error-banner.component.spec.ts
+++ b/projects/components/src/common/error/error-banner.component.spec.ts
@@ -8,11 +8,10 @@ import { TestBed } from '@angular/core/testing';
 import { WidgetFinder } from '../../utils/test/widget-object';
 import { ErrorBannerComponent } from './error-banner.component';
 import { VcdErrorBannerModule } from './error-banner.module';
+import { ErrorBannerWidgetObject } from './error-banner.wo';
 
 @Component({
-    template: `
-        <vcd-error-banner #banner [errorMessage]="message"></vcd-error-banner>
-    `,
+    template: ` <vcd-error-banner #banner [errorMessage]="message"></vcd-error-banner> `,
 })
 class TestErrorComponent {
     message: string;
@@ -24,7 +23,7 @@ interface HasFinderAndError {
 }
 
 describe('ErrorBannerComponent', () => {
-    beforeEach(async function(this: HasFinderAndError): Promise<void> {
+    beforeEach(async function (this: HasFinderAndError): Promise<void> {
         await TestBed.configureTestingModule({
             imports: [VcdErrorBannerModule],
             declarations: [TestErrorComponent],
@@ -34,12 +33,33 @@ describe('ErrorBannerComponent', () => {
         this.finder.detectChanges();
     });
 
-    it('can display an error when shown', function(this: HasFinderAndError): void {
+    it('can display an error when shown', function (this: HasFinderAndError): void {
         this.finder.hostComponent.message = 'Error!!';
         this.finder.detectChanges();
         expect(this.finder.hostComponent.errorBanner.closed).toBeFalsy();
         expect(this.finder.hostComponent.errorBanner.errorMessage).toEqual('Error!!');
         this.finder.hostComponent.errorBanner.onAlertClosedChange(true);
         expect(this.finder.hostComponent.errorBanner.errorMessage).toBeFalsy();
+    });
+
+    describe('ARIA role', () => {
+        it('is `alert` for the default alertType `danger`', function (this: HasFinderAndError): void {
+            const errorBannerWO = this.finder.find({ woConstructor: ErrorBannerWidgetObject });
+            expect(errorBannerWO.ariaRole).toBe('alert');
+        });
+
+        it('is `status` for the alertType `warning`', function (this: HasFinderAndError): void {
+            this.finder.hostComponent.errorBanner.alertType = 'warning';
+            this.finder.detectChanges();
+            const errorBannerWO = this.finder.find({ woConstructor: ErrorBannerWidgetObject });
+            expect(errorBannerWO.ariaRole).toBe('status');
+        });
+
+        it('is `status` for the alertType `info`', function (this: HasFinderAndError): void {
+            this.finder.hostComponent.errorBanner.alertType = 'info';
+            this.finder.detectChanges();
+            const errorBannerWO = this.finder.find({ woConstructor: ErrorBannerWidgetObject });
+            expect(errorBannerWO.ariaRole).toBe('status');
+        });
     });
 });

--- a/projects/components/src/common/error/error-banner.wo.ts
+++ b/projects/components/src/common/error/error-banner.wo.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { WidgetObject } from '../../utils/test/widget-object';
+import { ErrorBannerComponent } from './error-banner.component';
+
+/**
+ * Testing Widget Object for {@link ErrorBannerComponent}
+ */
+export class ErrorBannerWidgetObject extends WidgetObject<ErrorBannerComponent> {
+    static tagName = 'vcd-error-banner';
+
+    /**
+     * The ARIA role of the component.
+     */
+    get ariaRole(): string {
+        return this.findElement('clr-alert').nativeElement.getAttribute('role');
+    }
+}


### PR DESCRIPTION
# Description
Screen Readers were not able to read the content of the error banner.
To fix this ARIA role is added:
  role='alert'  - whenthe `alertType` is danger
  role='status' - for all other cases

# Testing
- unit tests
- manual tests: use VoiceOver MAC util and verify that the error message has been read



Signed-off-by: Ivo Rahov <irahov@vmware.com>