### PR TITLE
Add custom focus handling logic for dropdown menu

### DIFF
--- a/projects/components/src/action-menu/action-menu.component.html
+++ b/projects/components/src/action-menu/action-menu.component.html
@@ -11,6 +11,7 @@
         </ng-container>
 
         <vcd-dropdown
+            vcdDropdownFocusHandler
             class="inline-action-dropdown"
             *ngIf="shouldDisplayContextualActionsDropdownInline"
             [items]="contextualActions"
@@ -34,6 +35,7 @@
 </div>
 
 <vcd-dropdown
+    vcdDropdownFocusHandler
     *ngIf="shouldDisplayStaticAndStaticFeaturedActionsDropdown"
     [items]="staticDropdownActions"
     [trackByFunction]="actionsTrackBy"
@@ -48,6 +50,7 @@
 ></vcd-dropdown>
 
 <vcd-dropdown
+    vcdDropdownFocusHandler
     *ngIf="shouldDisplayContextualActionsDropdown"
     [items]="contextualActions"
     [trackByFunction]="actionsTrackBy"

--- a/projects/components/src/dropdown/dropdown-focus-handler.directive.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.directive.ts
@@ -160,13 +160,17 @@ export class DropdownFocusHandlerDirective<T> implements AfterViewInit, OnDestro
     private linkMenuItems(): void {
         const menuChildren: Element[] = Array.from(this.clrDropdownMenuEl.children);
         this.menuItems = menuChildren.map((child) => ({
-            element:
-                child.nodeName === BUTTON_NODE_NAME
-                    ? (child as HTMLElement)
-                    : (child.querySelector('clr-dropdown > button') as HTMLElement),
+            element: (child.matches('button') ? child : child.querySelector('clr-dropdown > button')) as HTMLElement,
+            left: this.menuTrigger,
         }));
         this.linkVertical();
-        this.linkMenuToTrigger();
+        // Lint to menu trigger
+        if (this.isRootDropdown) {
+            this.menuTrigger.down = this.menuItems[0];
+        } else {
+            // If there is a parent dropdown, We have to link these menu items to their trigger in the parent dropdown
+            this.menuTrigger.right = this.menuItems[0];
+        }
     }
 
     private get rootMenuTrigger(): MenuItem {
@@ -186,16 +190,6 @@ export class DropdownFocusHandlerDirective<T> implements AfterViewInit, OnDestro
             this.hostVcdDropdown.clrDropdown.toggleService.open = false;
         };
         return menuTrigger;
-    }
-
-    private linkMenuToTrigger(): void {
-        if (this.isRootDropdown) {
-            this.menuTrigger.down = this.menuItems[0];
-            return;
-        }
-        // If there is a parent dropdown, We have to link these menu items to their trigger in the parent dropdown
-        this.menuTrigger.right = this.menuItems[0];
-        this.menuItems.forEach((item) => (item.left = this.menuTrigger));
     }
 
     private linkVertical(): void {

--- a/projects/components/src/dropdown/dropdown-focus-handler.directive.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.directive.ts
@@ -1,0 +1,165 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { AfterViewInit, Directive, Host, OnDestroy, Optional, SkipSelf } from '@angular/core';
+import { ClrPopoverToggleService } from '@clr/angular';
+import { Subscription } from 'rxjs';
+import { SubscriptionTracker } from '../common/subscription';
+import { DropdownFocusHandlerService } from './dropdown-focus-handler.service';
+import { DropdownComponent } from './dropdown.component';
+
+const BUTTON_NODE_NAME = 'BUTTON';
+
+/**
+ * Arrow keys directions
+ */
+export enum Direction {
+    UP = 'up',
+    DOWN = 'down',
+    LEFT = 'left',
+    RIGHT = 'right',
+}
+
+/**
+ * Object wrapping the focusable HTML elements of dropdown menu with the neighbors in 4 directions of each menu item.
+ */
+export interface MenuItem {
+    element: HTMLElement;
+    up?: MenuItem;
+    down?: MenuItem;
+    left?: MenuItem;
+    right?: MenuItem;
+    closeMenu?: (event: Event) => void;
+}
+
+/**
+ * Added on to vcd-dropdown component to vertically link menu items of the dropdown on which this directive is added. It also, then links
+ * the vertically linked menu items horizontally to their menu trigger. It then uses the {@link DropdownFocusHandlerService} to move the
+ * DOM focus between the menu items.
+ *
+ * @Example:
+ * <vcd-dropdown
+ *        vcdDropdownFocusHandler
+ *        [items]="contextualActions"
+ *        [onItemClickedCb]="runActionHandler.bind(this)"
+ *        [isItemDisabledCb]="isActionDisabled.bind(this)"
+ * ></vcd-dropdown>
+ */
+@Directive({
+    selector: 'vcd-dropdown[vcdDropdownFocusHandler]',
+})
+export class DropdownFocusHandlerDirective<T> implements AfterViewInit, OnDestroy {
+    constructor(
+        @Optional() @SkipSelf() private parentVcdDropdown: DropdownComponent<T>,
+        @Optional() @SkipSelf() private parentFocusHandler: DropdownFocusHandlerDirective<T>,
+        @Host() private hostVcdDropdown: DropdownComponent<T>,
+        private focusHandlerService: DropdownFocusHandlerService
+    ) {}
+
+    /**
+     * List of focusable menu items with their neighbors in 4 directions.
+     */
+    menuItems: MenuItem[];
+
+    private menuTrigger: MenuItem;
+    private isRootDropdown = !this.parentVcdDropdown;
+    private timeoutId: number;
+    private subscriptionTracker = new SubscriptionTracker(this);
+
+    /**
+     * After a dropdown menu is opened, it creates {@link MenuItem} for each of the menu items along with their trigger menu item and links
+     * them. It also then moves the focus to first item in the opened menu list.
+     */
+    ngAfterViewInit(): void {
+        this.subscriptionTracker.subscribe(this.hostVcdDropdown.dropdownMenuUpdated, (updated) => {
+            if (!updated) {
+                return;
+            }
+            this.createMenuTrigger();
+            this.linkMenuItems();
+            this.registerRootMenuContainer();
+            this.moveFocusToFirstItem();
+        });
+    }
+
+    ngOnDestroy(): void {}
+
+    private registerRootMenuContainer(): void {
+        if (this.isRootDropdown) {
+            const rootMenuContainer = this.hostVcdDropdown._clrDropdownMenuEl;
+            this.focusHandlerService.listenToArrowKeys(rootMenuContainer);
+        }
+    }
+
+    private moveFocusToFirstItem(): void {
+        this.focusHandlerService.moveFocusTo(this.menuTrigger);
+        // After the menu is opened, the ClrDropdownMenu wouldn't be attached to the DOM until the next change detection cycle.
+        // So setTimeout is the only way to wait for the ClrDropdownMenu to be ready to move focus to first item.
+        this.timeoutId = window.setTimeout(() => {
+            if (this.parentVcdDropdown) {
+                this.focusHandlerService.moveFocus(Direction.RIGHT);
+            } else {
+                this.focusHandlerService.moveFocus(Direction.DOWN);
+            }
+            window.clearTimeout(this.timeoutId);
+        });
+    }
+
+    private linkMenuItems(): void {
+        const menuChildren: Element[] = Array.from(this.hostVcdDropdown._clrDropdownMenuEl.children);
+        this.menuItems = menuChildren.map((child) => ({
+            element:
+                child.nodeName === BUTTON_NODE_NAME
+                    ? (child as HTMLElement)
+                    : (child.querySelector('clr-dropdown > button') as HTMLElement),
+        }));
+
+        this.linkVertical();
+
+        this.linkMenuToTrigger();
+    }
+
+    private createMenuTrigger(): void {
+        const closeMenu = (event: Event) => {
+            this.hostVcdDropdown.clrDropdown.toggleService.open = false;
+        };
+        if (this.isRootDropdown) {
+            this.menuTrigger = {
+                element: this.hostVcdDropdown._dropdownTriggerEl,
+                closeMenu,
+            };
+            return;
+        }
+        this.menuTrigger = this.parentFocusHandler.menuItems.find((item) => {
+            return Object.is(item.element.innerText, this.hostVcdDropdown._dropdownTriggerEl.innerText);
+        });
+        this.menuTrigger.closeMenu = closeMenu;
+    }
+
+    private linkMenuToTrigger(): void {
+        if (this.isRootDropdown) {
+            this.menuTrigger.down = this.menuItems[0];
+            return;
+        }
+        // If there is a parent dropdown, We have to link these menu items to their trigger in the parent dropdown
+        this.menuTrigger.right = this.menuItems[0];
+        this.menuItems.forEach((item) => (item.left = this.menuTrigger));
+    }
+
+    private linkVertical(): void {
+        this.menuItems.forEach((menuItem: MenuItem, index: number) => {
+            if (index > 0) {
+                menuItem.up = this.menuItems[index - 1];
+            }
+            if (index < this.menuItems.length - 1) {
+                menuItem.down = this.menuItems[index + 1];
+            }
+        });
+        if (this.menuItems.length > 1) {
+            this.menuItems[0].up = this.menuItems[this.menuItems.length - 1];
+            this.menuItems[this.menuItems.length - 1].down = this.menuItems[0];
+        }
+    }
+}

--- a/projects/components/src/dropdown/dropdown-focus-handler.service.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.service.ts
@@ -1,0 +1,96 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Injectable, OnDestroy, Renderer2 } from '@angular/core';
+import { Direction, MenuItem } from './dropdown-focus-handler.directive';
+
+/**
+ * Provided at the injector level of root {@link DropdownComponent}. The same service object is used for all the nested menus along
+ * with the root menu. This is responsible for listening to arrow key presses within the root dropdown menu container and updating the
+ * focused item on the DOM across all the nested and root menus.
+ */
+@Injectable()
+export class DropdownFocusHandlerService implements OnDestroy {
+    private currentFocusedItem: MenuItem;
+    private _unlistenFuncs: ((...argArray: any[]) => any)[] = [];
+
+    constructor(private renderer: Renderer2) {}
+
+    ngOnDestroy(): void {
+        this._unlistenFuncs.forEach((unlisten) => unlisten());
+    }
+
+    /**
+     * Moves the focus to HTML element in the given direction
+     */
+    moveFocus(direction: Direction): void {
+        switch (direction) {
+            case Direction.DOWN:
+                this.moveFocusTo(this.currentFocusedItem.down);
+                break;
+            case Direction.LEFT:
+                this.moveFocusTo(this.currentFocusedItem.left);
+                break;
+            case Direction.UP:
+                this.moveFocusTo(this.currentFocusedItem.up);
+                break;
+            case Direction.RIGHT:
+                this.moveFocusTo(this.currentFocusedItem.right);
+                break;
+        }
+    }
+
+    /**
+     * Calls the HTML focus method on the HTML element passed
+     */
+    moveFocusTo(item: MenuItem): void {
+        if (!item) {
+            return;
+        }
+        if (this.currentFocusedItem) {
+            // Sometimes, when navigating to a nested menu using right arrow, the nested menu trigger gets focused multiple times
+            if (Object.is(this.currentFocusedItem.element, item.element)) {
+                return;
+            }
+            this.currentFocusedItem.element.blur();
+        }
+        item.element.focus();
+        this.currentFocusedItem = item;
+    }
+
+    /**
+     * Attaches arrow key event listeners to the root menu container in all direction except right. This is because, when a right arrow is
+     * pressed, Clarity opens the nested dropdown menu and the logic inside {@link DropdownFocusHandlerDirective.ngAfterViewInit}
+     * automatically moves the focus to first item in the menu on the right side
+     */
+    listenToArrowKeys(menuContainer: HTMLElement): void {
+        this._unlistenFuncs.push(
+            this.renderer.listen(menuContainer, 'keydown.arrowdown', (event: Event) => {
+                this.moveFocus(Direction.DOWN);
+                event.preventDefault();
+                event.stopPropagation();
+            })
+        );
+        this._unlistenFuncs.push(
+            this.renderer.listen(menuContainer, 'keydown.arrowup', (event: Event) => {
+                this.moveFocus(Direction.UP);
+                event.preventDefault();
+                event.stopPropagation();
+            })
+        );
+        this._unlistenFuncs.push(
+            this.renderer.listen(menuContainer, 'keydown.arrowleft', (event: Event) => {
+                if (!this.currentFocusedItem.left) {
+                    return;
+                }
+                // Close the nested menu before moving focus to left side
+                this.currentFocusedItem.left.closeMenu(event);
+                this.moveFocus(Direction.LEFT);
+                event.preventDefault();
+                event.stopPropagation();
+            })
+        );
+    }
+}

--- a/projects/components/src/dropdown/dropdown-focus-handler.service.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.service.ts
@@ -14,7 +14,7 @@ import { Direction, MenuItem } from './dropdown-focus-handler.directive';
 @Injectable()
 export class DropdownFocusHandlerService implements OnDestroy {
     currentFocusedItem: MenuItem;
-    unlistenFuncs: ((...argArray: any[]) => any)[] = [];
+    unlistenFuncs: (() => void)[] = [];
 
     constructor(private renderer: Renderer2) {}
 
@@ -69,14 +69,12 @@ export class DropdownFocusHandlerService implements OnDestroy {
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowdown', (event: Event) => {
                 this.moveFocus(Direction.DOWN);
-                event.preventDefault();
                 event.stopPropagation();
             })
         );
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowup', (event: Event) => {
                 this.moveFocus(Direction.UP);
-                event.preventDefault();
                 event.stopPropagation();
             })
         );
@@ -88,7 +86,6 @@ export class DropdownFocusHandlerService implements OnDestroy {
                 // Close the nested menu before moving focus to left side
                 this.currentFocusedItem.left.closeMenu(event);
                 this.moveFocus(Direction.LEFT);
-                event.preventDefault();
                 event.stopPropagation();
             })
         );

--- a/projects/components/src/dropdown/dropdown-focus-handler.service.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.service.ts
@@ -13,13 +13,13 @@ import { Direction, MenuItem } from './dropdown-focus-handler.directive';
  */
 @Injectable()
 export class DropdownFocusHandlerService implements OnDestroy {
-    private currentFocusedItem: MenuItem;
-    private _unlistenFuncs: ((...argArray: any[]) => any)[] = [];
+    currentFocusedItem: MenuItem;
+    unlistenFuncs: ((...argArray: any[]) => any)[] = [];
 
     constructor(private renderer: Renderer2) {}
 
     ngOnDestroy(): void {
-        this._unlistenFuncs.forEach((unlisten) => unlisten());
+        this.unlistenFuncs.forEach((unlisten) => unlisten());
     }
 
     /**
@@ -66,21 +66,21 @@ export class DropdownFocusHandlerService implements OnDestroy {
      * automatically moves the focus to first item in the menu on the right side
      */
     listenToArrowKeys(menuContainer: HTMLElement): void {
-        this._unlistenFuncs.push(
+        this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowdown', (event: Event) => {
                 this.moveFocus(Direction.DOWN);
                 event.preventDefault();
                 event.stopPropagation();
             })
         );
-        this._unlistenFuncs.push(
+        this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowup', (event: Event) => {
                 this.moveFocus(Direction.UP);
                 event.preventDefault();
                 event.stopPropagation();
             })
         );
-        this._unlistenFuncs.push(
+        this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowleft', (event: Event) => {
                 if (!this.currentFocusedItem.left) {
                     return;

--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -1,4 +1,4 @@
-<clr-dropdown vcdDynamicDropdown class="nested-dropdown">
+<clr-dropdown [clrCloseMenuOnItemClick]="false" vcdDynamicDropdown class="nested-dropdown">
     <button
         [ngClass]="[
             dropdownTriggerBtnTxt ? 'btn btn-link' : '',
@@ -32,6 +32,7 @@
 
                 <ng-container *ngIf="!action.isSeparator && action.children && action.children.length">
                     <vcd-dropdown
+                        vcdDropdownFocusHandler
                         [items]="action.children"
                         [dropdownTriggerBtnTxt]="
                             action.isTranslatable === false ? action.textKey : (action.textKey | translate)

--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -57,6 +57,8 @@
                         ]"
                         clrDropdownItem
                         (click)="onItemClickedCb(action)"
+                        (keydown.space)="onDropdownItemActivated($event)"
+                        (keydown.enter)="onDropdownItemActivated($event)"
                         [disabled]="isItemDisabledCb(action)"
                     >
                         <ng-container *ngIf="shouldShowText">{{

--- a/projects/components/src/dropdown/dropdown.component.spec.ts
+++ b/projects/components/src/dropdown/dropdown.component.spec.ts
@@ -244,6 +244,7 @@ describe('DropdownComponent', () => {
 @Component({
     template: `
         <vcd-dropdown
+            vcdDropdownFocusHandler
             [items]="items"
             [dropdownTriggerBtnTxt]="'Dropdown'"
             [dropdownTriggerButtonClassName]="primaryDropdownClassName"

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -339,4 +339,15 @@ export class DropdownComponent<T extends DropdownItem<T>> implements AfterViewIn
             .filter((vcdDropdown) => vcdDropdown.clrDropdown.toggleService.open)
             .forEach((vcdDropdown) => (vcdDropdown.clrDropdown.toggleService.open = false));
     }
+
+    /**
+     * When space or enter key is pressed on the focused dropdown menu item, it has to be clicked
+     * @param event Space or Enter key press event
+     */
+    onDropdownItemActivated(event: Event): void {
+        if (!event) {
+            return;
+        }
+        (event.target as HTMLElement).click();
+    }
 }

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -11,6 +11,7 @@ import {
     Host,
     HostListener,
     Input,
+    OnDestroy,
     Optional,
     Output,
     Provider,
@@ -109,7 +110,7 @@ export class DropdownComponent<T extends DropdownItem<T>> implements AfterViewIn
         return this._items;
     }
 
-    @Output() dropdownMenuUpdated = new EventEmitter<boolean>();
+    @Output() dropdownMenuUpdated = new EventEmitter<{ menu: HTMLElement }>();
 
     constructor(@Optional() @SkipSelf() private parentVcdDropdown: DropdownComponent<T>) {}
 
@@ -120,7 +121,6 @@ export class DropdownComponent<T extends DropdownItem<T>> implements AfterViewIn
             return;
         }
         // Disable Claritys focus handling logic
-        console.log(`${this._dropdownTriggerEl.innerText}s menu is opened. ${this.clrDropdown.toggleService.open}`);
         this._clrDropdownMenu.items.reset([]);
         this._clrDropdownMenu.items.notifyOnChanges();
     }
@@ -135,10 +135,13 @@ export class DropdownComponent<T extends DropdownItem<T>> implements AfterViewIn
     @ViewChild(ClrDropdownMenu, { read: ElementRef, static: false })
     set clrDropdownMenuEl(val: ElementRef<HTMLElement>) {
         if (!val) {
+            this.dropdownMenuUpdated.emit(null);
             return;
         }
         this._clrDropdownMenuEl = val.nativeElement;
-        this.dropdownMenuUpdated.emit(true);
+        this.dropdownMenuUpdated.emit({
+            menu: this._clrDropdownMenuEl,
+        });
     }
     _clrDropdownMenuEl: HTMLElement;
     /**

--- a/projects/components/src/dropdown/dropdown.module.ts
+++ b/projects/components/src/dropdown/dropdown.module.ts
@@ -9,12 +9,13 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
 import { ShowClippedTextDirectiveModule } from '../lib/directives/show-clipped-text.directive.module';
+import { DropdownFocusHandlerDirective } from './dropdown-focus-handler.directive';
 import { DropdownComponent } from './dropdown.component';
 import { DynamicDropdownPositionDirective } from './dynamic-dropdown-position.directive';
 
 @NgModule({
-    declarations: [DropdownComponent, DynamicDropdownPositionDirective],
+    declarations: [DropdownComponent, DynamicDropdownPositionDirective, DropdownFocusHandlerDirective],
     imports: [CommonModule, ReactiveFormsModule, ClarityModule, I18nModule, ShowClippedTextDirectiveModule],
-    exports: [DropdownComponent, DynamicDropdownPositionDirective],
+    exports: [DropdownComponent, DynamicDropdownPositionDirective, DropdownFocusHandlerDirective],
 })
 export class DropdownModule {}


### PR DESCRIPTION
## Why this change:
Because the focus handling logic through the keyboard is not working correctly on the vcd-dropdown component. This is happening because the Clarity code is not able to recognize nested Vcd dropdown as content children. So we decided to write our own focus handling logic

## What is the change:
Disable the Claritys focus handling logic and then write our own focus handling logic. A directive to link the menu items and then service for updating the currently focused item. There is only one instance of this per root dropdown.

## Testing done:
![customFocusHandling_dropdown](https://user-images.githubusercontent.com/10735165/96726472-04ab2a00-1380-11eb-89d5-e69ca38f569d.gif)
