### PR TITLE
[a11y] Add aria attributes to the Form Input component

### DIFF
--- a/projects/components/src/form/base-form-control.ts
+++ b/projects/components/src/form/base-form-control.ts
@@ -18,7 +18,17 @@ export class BaseFormControl implements ControlValueAccessor, CanBeReadOnly {
     /**
      * Auto generated ID for the input field.
      */
-    id: string;
+    readonly id: string = idGenerator.generate();
+
+    /**
+     * Auto generated ID for the description field.
+     */
+    readonly descriptionId: string = `${this.id}-description`;
+
+    /**
+     * Auto generated ID for the error field.
+     */
+    readonly errorsId: string = `${this.id}-errors`;
 
     /**
      * Change callback.
@@ -72,7 +82,6 @@ export class BaseFormControl implements ControlValueAccessor, CanBeReadOnly {
     protected initialValue: number | string | boolean;
 
     constructor(ngControl: NgControl) {
-        this.id = idGenerator.generate();
         if (ngControl) {
             ngControl.valueAccessor = this;
             this.formControlNameDirective = ngControl;

--- a/projects/components/src/form/form-input/form-input.component.html
+++ b/projects/components/src/form/form-input/form-input.component.html
@@ -1,6 +1,6 @@
 <div class="form-group">
     <div class="clr-form-control">
-        <label *ngIf="label" class="clr-control-label" [attr.for]="id" [ngClass]="{ 'required-field': showAsterisk }">{{
+        <label *ngIf="label" class="clr-control-label" [for]="id" [ngClass]="{ 'required-field': showAsterisk }">{{
         label
         }}</label>
         <div class="clr-control-container" [ngClass]="{ 'clr-error': showErrors }">
@@ -17,18 +17,20 @@
                     [min]="min"
                     [max]="max"
                     [attr.maxlength]="maxlength"
+                    [attr.aria-required]="showAsterisk"
+                    [attr.aria-describedby]="showErrors ? errorsId : descriptionId"
                     (blur)="inputChanged()"
                     (keyup.enter)="enterClicked.emit(true)"
                     (keyup.escape)="escapeClicked.emit(true)"
                 />
                 <clr-icon *ngIf="showErrors && !hint" class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
             </div>
-            <span class="clr-subtext" *ngIf="showErrors">
+            <span class="clr-subtext" *ngIf="showErrors" [id]="errorsId">
                 <div *ngFor="let key of errorKeys">
                     <div>{{ key | translate: formControl.value:min.toString():max }}</div>
                 </div>
             </span>
-            <span class="clr-subtext" *ngIf="!showErrors && description">
+            <span class="clr-subtext" *ngIf="!showErrors && description" [id]="descriptionId">
                 {{ description }}
             </span>
         </div>


### PR DESCRIPTION
- Added aria-required which depends on the 'showAsterisk' input.
The screen reader will announce if the field is required.
- Added aria-describedby for either errors or description in the input subtext.
- Added ids to the description and error elements using the IdGenerator.
- Fixed the 'for' attribute binding to the input label

Testing done:
- Tested with NVDA on the examples project
- Unit tests for each case