### PR TITLE
[a11y] Labels is not associated with the form select element

### DIFF
--- a/projects/components/src/form/form-checkbox/form-checkbox.component.html
+++ b/projects/components/src/form/form-checkbox/form-checkbox.component.html
@@ -6,6 +6,7 @@
                 <input
                     type="checkbox"
                     [id]="id"
+                    [attr.aria-describedby]="showErrors ? errorsId : descriptionId"
                     [ngClass]="{ 'clr-checkbox': isCheckbox, 'clr-toggle': !isCheckbox }"
                     [formControl]="formControl"
                 />
@@ -14,12 +15,12 @@
                     {{ text }}
                 </label>
             </div>
-            <span class="clr-subtext" *ngIf="showErrors">
+            <span class="clr-subtext" *ngIf="showErrors" [id]="errorsId">
                 <div *ngFor="let key of errorKeys">
                     <div>{{ key | translate: formControl.value }}</div>
                 </div>
             </span>
-            <span class="clr-subtext" *ngIf="!showErrors && description">
+            <span class="clr-subtext" *ngIf="!showErrors && description" [id]="descriptionId">
                 {{ description }}
             </span>
         </div>

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -1,14 +1,19 @@
 <div class="form-group">
     <div class="clr-form-control">
-        <label *ngIf="label" [attr.for]="id" class="clr-control-label" [ngClass]="{ 'required-field': showAsterisk }">{{
-        label
+        <label *ngIf="label" [for]="id" class="clr-control-label" [ngClass]="{ 'required-field': showAsterisk }">{{
+            label
         }}</label>
         <span *ngIf="isReadOnly && selectedOption" class="readOnly">
             {{ selectedOption.isTranslatable ? (selectedOption.display | translate) : selectedOption.display }}
         </span>
         <div class="clr-control-container" [ngClass]="{ 'clr-error': showErrors }">
             <div class="clr-select-wrapper" *ngIf="!isReadOnly">
-                <select [id]="id" [formControl]="formControl">
+                <select
+                    [id]="id"
+                    [attr.aria-required]="showAsterisk"
+                    [attr.aria-describedby]="showErrors ? errorsId : ''"
+                    [formControl]="formControl"
+                >
                     <option *ngFor="let option of options" [value]="option.value">
                         {{ option.isTranslatable ? (option.display | translate) : option.display }}
                     </option>
@@ -17,7 +22,7 @@
 
             <ng-content select="aside"></ng-content>
 
-            <span class="clr-subtext" *ngIf="showErrors">
+            <span class="clr-subtext" *ngIf="showErrors" [id]="errorsId">
                 <div *ngFor="let key of errorKeys">
                     <div>{{ key | translate: [formControl.value] }}</div>
                 </div>


### PR DESCRIPTION
### Solution:
Fix for attribute on label - form select
And aria-describedby - form select, checkbox
Add aria-required form select

### Test Steps:
I tested manually on Windows 10 in Mozilla Firefox and Chrome with NVDA and Developer Tool. Click on input reader reads label. On error reader reads message.

Signed-off-by: Tsvetomir Tsvetanov <ttsvetanov@vmware.com>