### PR TITLE
Replace [disabled] with [clrDisabled] on action menu buttons

### DIFF
--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -59,7 +59,7 @@
                         (click)="onItemClickedCb(action)"
                         (keydown.space)="onDropdownItemActivated($event)"
                         (keydown.enter)="onDropdownItemActivated($event)"
-                        [disabled]="isItemDisabledCb(action)"
+                        [clrDisabled]="isItemDisabledCb(action)"
                     >
                         <ng-container *ngIf="shouldShowText">{{
                             action.isTranslatable === false ? action.textKey : (action.textKey | translate)


### PR DESCRIPTION
## Problem:
The disabled attribute on dropdown menu buttons is not making them focusable. Instead, Clarity suggests using the [clrDisabled] attribute for the disabled visual style and ARIA attribute when needed

## Solution:
Replaced the disabled attribute with clrdisabled on dropdown menu buttons

## Testing done:
![menuItemClrDisabled](https://user-images.githubusercontent.com/10735165/98275926-3bc63180-1f63-11eb-9707-8b59eab42764.gif)
