### PR TITLE
Fixes the type clash between Jasmine and Chai in unit tests

### DIFF
--- a/cypress/integration/examples/data-exporter.spec.ts
+++ b/cypress/integration/examples/data-exporter.spec.ts
@@ -3,7 +3,34 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { CypressWidgetObjectFinder, DataExporterWidgetObject } from '@vcd/ui-components';
+import {
+    BaseWidgetObject,
+    CorrectReturnTypes,
+    CypressWidgetObjectFinder,
+    DataExporterWidgetObject,
+    FindableWidget,
+} from '@vcd/ui-components';
+
+/**
+ * Finds a single widget object. This is a convenience wrapper around the `CypressWidgetFinder`
+ * that should be copied into any application E2E tests that want to use this Widget Finder system.
+ *
+ * @param widgetConstructor - The constructor of the widget to use
+ * @param ancestor - The CSS query or alias of the parent to begin the search from.
+ *                 this will be passed to `cy.get` and is a global search.
+ * @param cssSelector - The cssSelector to append to the tagName for the search
+ *
+ */
+export function findCypressWidget<
+    W extends BaseWidgetObject<Cypress.Chainable>,
+    C extends FindableWidget<Cypress.Chainable, W>
+>(
+    widgetConstructor: C,
+    ancestor?: string,
+    cssSelector?: string
+): CorrectReturnTypes<InstanceType<C>, Cypress.Chainable> {
+    return new CypressWidgetObjectFinder<Cypress.Chainable>().find(widgetConstructor, ancestor, cssSelector);
+}
 
 context('Window', () => {
     beforeEach(() => {
@@ -13,7 +40,7 @@ context('Window', () => {
 
     it('lets you select many column', async () => {
         // https://on.cypress.io/window
-        const widget = new CypressWidgetObjectFinder<Cypress.Chainable>().find(DataExporterWidgetObject);
+        const widget = findCypressWidget(DataExporterWidgetObject);
         widget.getToggleSelectAll().click({
             force: true,
         });

--- a/cypress/integration/examples/data-exporter.spec.ts
+++ b/cypress/integration/examples/data-exporter.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { DataExporterWidgetObject, findCypressWidget } from '@vcd/ui-components';
+import { CypressWidgetObjectFinder, DataExporterWidgetObject } from '@vcd/ui-components';
 
 context('Window', () => {
     beforeEach(() => {
@@ -13,7 +13,7 @@ context('Window', () => {
 
     it('lets you select many column', async () => {
         // https://on.cypress.io/window
-        const widget = findCypressWidget(DataExporterWidgetObject);
+        const widget = new CypressWidgetObjectFinder<Cypress.Chainable>().find(DataExporterWidgetObject);
         widget.getToggleSelectAll().click({
             force: true,
         });

--- a/cypress/integration/examples/data-exporter.spec.ts
+++ b/cypress/integration/examples/data-exporter.spec.ts
@@ -3,34 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import {
-    BaseWidgetObject,
-    CorrectReturnTypes,
-    CypressWidgetObjectFinder,
-    DataExporterWidgetObject,
-    FindableWidget,
-} from '@vcd/ui-components';
-
-/**
- * Finds a single widget object. This is a convenience wrapper around the `CypressWidgetFinder`
- * that should be copied into any application E2E tests that want to use this Widget Finder system.
- *
- * @param widgetConstructor - The constructor of the widget to use
- * @param ancestor - The CSS query or alias of the parent to begin the search from.
- *                 this will be passed to `cy.get` and is a global search.
- * @param cssSelector - The cssSelector to append to the tagName for the search
- *
- */
-export function findCypressWidget<
-    W extends BaseWidgetObject<Cypress.Chainable>,
-    C extends FindableWidget<Cypress.Chainable, W>
->(
-    widgetConstructor: C,
-    ancestor?: string,
-    cssSelector?: string
-): CorrectReturnTypes<InstanceType<C>, Cypress.Chainable> {
-    return new CypressWidgetObjectFinder<Cypress.Chainable>().find(widgetConstructor, ancestor, cssSelector);
-}
+import { DataExporterWidgetObject } from '@vcd/ui-components';
+import { findCypressWidget } from '../../../projects/components/src/utils/test/widget-object/find-cypress-widget';
 
 context('Window', () => {
     beforeEach(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,12 @@
           "dev": true,
           "optional": true
         },
+        "parse5": {
+          "version": "4.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse5/-/parse5-4.0.0.tgz",
+          "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.13.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
@@ -14418,9 +14424,9 @@
       "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
     },
     "parse5": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "version": "6.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws=",
       "dev": true
     },
     "parseqs": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "karma-jasmine": "2.0.1",
     "karma-jasmine-html-reporter": "1.4.0",
     "ng-packagr": "9.0.0",
+    "parse5": "^6.0.1",
     "prettier": "2.1.1",
     "pretty-quick": "2.0.0",
     "protractor": "7.0.0",

--- a/projects/components/src/utils/test/widget-object/angular-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-finder.ts
@@ -40,7 +40,7 @@ export class AngularWidgetObjectFinder<H = unknown> {
      *
      * @param widgetConstructor - The constructor of the widget to use
      * @param ancestor - The parent DebugElement to begin the search from
-     * @param cssSelector - The cssSelector to post-pend to the tagName for the search
+     * @param cssSelector - The cssSelector to append to the tagName for the search
      *
      * @throws An error if the widget is not found or if there are multiple instances
      */

--- a/projects/components/src/utils/test/widget-object/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress-widget-finder.ts
@@ -12,6 +12,12 @@ const idGenerator = new IdGenerator('cy-id');
 
 /**
  * Knows how to find Cypress widget objects within the DOM.
+ *
+ * T is the type of data that this will output when you call `unwrap`.
+ * In almost all cases, this should be a `Cypress.Chainable`.
+ * We chose to provide this as a generic because for reasons seen in
+ * [this PR](https://github.com/vmware/vmware-cloud-director-ui-components/pull/248)
+ * we could not load the Cypress types in our library.
  */
 export class CypressWidgetObjectFinder<T> {
     /**

--- a/projects/components/src/utils/test/widget-object/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress-widget-finder.ts
@@ -26,7 +26,7 @@ export class CypressWidgetObjectFinder<T> {
      * @param widgetConstructor - The constructor of the widget to use
      * @param ancestor - The CSS query or alias of the parent to begin the search from.
      *                 this will be passed to `cy.get` and is a global search.
-     * @param cssSelector - The cssSelector to post-pend to the tagName for the search
+     * @param cssSelector - The cssSelector to append to the tagName for the search
      *
      */
     public find<W extends BaseWidgetObject<T>, C extends FindableWidget<T, W>>(

--- a/projects/components/src/utils/test/widget-object/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress-widget-finder.ts
@@ -4,15 +4,16 @@
  */
 
 import { IdGenerator } from '../../id-generator/id-generator';
-import { Chainable, CypressLocatorDriver } from './cypress-widget-object';
+import { CypressLocatorDriver } from './cypress-widget-object';
 import { BaseWidgetObject, CorrectReturnTypes, FindableWidget } from './widget-object';
 
+declare const cy;
 const idGenerator = new IdGenerator('cy-id');
 
 /**
  * Knows how to find Cypress widget objects within the DOM.
  */
-export class CypressWidgetObjectFinder {
+export class CypressWidgetObjectFinder<T> {
     /**
      * Finds a single widget object
      *
@@ -22,11 +23,11 @@ export class CypressWidgetObjectFinder {
      * @param cssSelector - The cssSelector to post-pend to the tagName for the search
      *
      */
-    public find<W extends BaseWidgetObject<Chainable>, C extends FindableWidget<Chainable, W>>(
+    public find<W extends BaseWidgetObject<T>, C extends FindableWidget<T, W>>(
         widgetConstructor: C,
         ancestor?: string,
         cssSelector?: string
-    ): CorrectReturnTypes<InstanceType<C>, Chainable> {
+    ): CorrectReturnTypes<InstanceType<C>, T> {
         let tagName = widgetConstructor.tagName;
         if (cssSelector) {
             tagName += `${cssSelector}`;
@@ -35,23 +36,6 @@ export class CypressWidgetObjectFinder {
         const search = ancestor ? cy.get(ancestor).find(tagName) : cy.get(tagName);
         const root = search.as(id);
         const widget = new widgetConstructor(new CypressLocatorDriver(root, true, id));
-        return (widget as any) as CorrectReturnTypes<InstanceType<C>, Chainable>;
+        return (widget as any) as CorrectReturnTypes<InstanceType<C>, T>;
     }
-}
-
-/**
- * Finds a single widget object
- *
- * @param widgetConstructor - The constructor of the widget to use
- * @param ancestor - The CSS query or alias of the parent to begin the search from.
- *                 this will be passed to `cy.get` and is a global search.
- * @param cssSelector - The cssSelector to post-pend to the tagName for the search
- *
- */
-export function findCypressWidget<W extends BaseWidgetObject<Chainable>, C extends FindableWidget<Chainable, W>>(
-    widgetConstructor: C,
-    ancestor?: string,
-    cssSelector?: string
-): CorrectReturnTypes<InstanceType<C>, Chainable> {
-    return new CypressWidgetObjectFinder().find(widgetConstructor);
 }

--- a/projects/components/src/utils/test/widget-object/cypress-widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/cypress-widget-object.ts
@@ -42,7 +42,7 @@ export class CypressLocatorDriver<T> implements LocatorDriver<T> {
      */
     parents(cssSelector: string, options?: unknown): CypressLocatorDriver<T> {
         const root = this.getBase();
-        return new CypressLocatorDriver(root.parent(cssSelector, options), false, this.alias);
+        return new CypressLocatorDriver(root.parents(cssSelector, options), false, this.alias);
     }
 
     /**

--- a/projects/components/src/utils/test/widget-object/cypress-widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/cypress-widget-object.ts
@@ -10,6 +10,12 @@ declare const cy;
 
 /**
  * Knows how to find Cypress chainables in the DOM.
+ *
+ * T is the type of data that this will output when you call `unwrap`.
+ * In almost all cases, this should be a `Cypress.Chainable`.
+ * We chose to provide this as a generic because for reasons seen in
+ * [this PR](https://github.com/vmware/vmware-cloud-director-ui-components/pull/248)
+ * we could not load the Cypress types in our library.
  */
 export class CypressLocatorDriver<T> implements LocatorDriver<T> {
     constructor(private chainable: T, private isRoot: boolean, private alias: string) {}

--- a/projects/components/src/utils/test/widget-object/find-cypress-widget.ts
+++ b/projects/components/src/utils/test/widget-object/find-cypress-widget.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { BaseWidgetObject, CorrectReturnTypes, CypressWidgetObjectFinder, FindableWidget } from '@vcd/ui-components';
+import Cypress from 'cypress';
+
+/**
+ * Finds a single widget object. This is a convenience wrapper around the `CypressWidgetFinder`
+ * that should be copied into any application E2E tests that want to use this Widget Finder system.
+ *
+ * @param widgetConstructor - The constructor of the widget to use
+ * @param ancestor - The CSS query or alias of the parent to begin the search from.
+ *                 this will be passed to `cy.get` and is a global search.
+ * @param cssSelector - The cssSelector to append to the tagName for the search
+ *
+ */
+export function findCypressWidget<
+    W extends BaseWidgetObject<Cypress.Chainable>,
+    C extends FindableWidget<Cypress.Chainable, W>
+>(
+    widgetConstructor: C,
+    ancestor?: string,
+    cssSelector?: string
+): CorrectReturnTypes<InstanceType<C>, Cypress.Chainable> {
+    return new CypressWidgetObjectFinder<Cypress.Chainable>().find(widgetConstructor, ancestor, cssSelector);
+}

--- a/projects/components/src/utils/test/widget-object/index.ts
+++ b/projects/components/src/utils/test/widget-object/index.ts
@@ -5,5 +5,5 @@
 
 export { BaseWidgetObject, FindableWidget } from './widget-object';
 export { TestElement } from './angular-widget-object';
-export { CypressWidgetObjectFinder, findCypressWidget } from './cypress-widget-finder';
+export { CypressWidgetObjectFinder } from './cypress-widget-finder';
 export { AngularWidgetObjectFinder } from './angular-widget-finder';

--- a/projects/components/src/utils/test/widget-object/index.ts
+++ b/projects/components/src/utils/test/widget-object/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-export { BaseWidgetObject, FindableWidget } from './widget-object';
+export { BaseWidgetObject, CorrectReturnTypes, FindableWidget } from './widget-object';
 export { TestElement } from './angular-widget-object';
 export { CypressWidgetObjectFinder } from './cypress-widget-finder';
 export { AngularWidgetObjectFinder } from './angular-widget-finder';

--- a/projects/components/tsconfig.spec.json
+++ b/projects/components/tsconfig.spec.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "../../out-tsc/spec",
+        "types": ["node", "jasmine"],
     },
     "files": ["src/test.ts"],
     "include": ["**/*.spec.ts", "**/*.d.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,19 @@
 {
   "compileOnSave": false,
-  "exclude": ["node_modules/cypress/**/*"],
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
-    "skipLibCheck": true,
-    "inlineSourceMap": false,
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es5",
-    "types": ["jasmine", "node", "cypress"],
-    "typeRoots": ["node_modules/@types"],
+    "typeRoots": [
+      "node_modules/@types"
+    ],
     "lib": [
       "es2018",
       "dom"


### PR DESCRIPTION
# Problem

When we loaded the Cypress types in our library via either `types: [..., "cypress"]` in the tsconfig or via `import * from 'cypress'` in a given file, it loads the `global namespace Cypress`. This also loads the global namespace for Chai (and Sinon and a few other libraries). This namespace was then loaded whenever a user imported anything from `@vcd/ui-components`. This meant that in unit tests Jasmine and Chai would have a clash on definitions. 

# Fix

Force users to supply the Cypress types externally. Meaning, `CypressWidgetFinder` now has one generic type T of what type the underlying locator will find (documentation more clear in the code). In the scope of our library, we don't have to load Cypress anymore because the typing is supplied externally. Then in the stepdef file, all the user has to do is `new CypressWidgetObjectFinder<**Cypress.Chainable**>().find(DataExporterWidgetObject);`. The only new part is what is in bold. The only side effect of this is that it no longer makes sense to have a function that wraps around the `CypressWidgetFinder` because the generics were just too confusing. 

# Other Options

1. Turn just the CypressWidgetFinder into its own project. This felt like a clunky solution and would require a lot of maintenance work. 
2. Add a sub-package (https://github.com/ng-packagr/ng-packagr/blob/master/docs/secondary-entrypoints.md). This might be better than the above idea because it is less hard to maintain, but for a few reasons I just couldn't get it to work. Most of this was due to how it scopes files when you use a sub-package. 
3. Set `skipLibCheck: true` to the `tsconfig.spec.ts` in any application that uses our library. Not the best because we are removing type safety.
4. Some other way that allows us to load a global namespace scoped to only one file. I just couldn't get this one to work. I tried for a **long** time too.

Signed-off-by: Ryan Bradford <rbradford@vmware.com>