### PR TITLE
[A11y] Make form inputs responsive

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - Make input elements responsive so that labels and the input are on separate lines on small screens. Alllows keyboard
+   users zoomed in at 200% to view the label and input instead of it being clipped.
+
 ## [1.0.0-a11y.2] - 2020-10-28
 
 ### Added

--- a/projects/components/src/form/form-checkbox/form-checkbox.component.html
+++ b/projects/components/src/form/form-checkbox/form-checkbox.component.html
@@ -1,7 +1,7 @@
 <div class="form-group">
-    <div class="clr-form-control" [ngClass]="{ 'clr-form-control-disabled': disabled }">
-        <label class="clr-control-label" [for]="id" *ngIf="label">{{ label }}</label>
-        <div class="clr-control-container" [ngClass]="{ 'clr-error': showErrors }">
+    <div class="clr-form-control clr-row" [ngClass]="{ 'clr-form-control-disabled': disabled }">
+        <label class="clr-control-label clr-col-12 clr-col-md-2" [for]="id" *ngIf="label">{{ label }}</label>
+        <div class="clr-control-container clr-col-12 clr-col-md-10" [ngClass]="{ 'clr-error': showErrors }">
             <div [ngClass]="{ 'clr-checkbox-wrapper': isCheckbox, 'clr-toggle-wrapper': !isCheckbox }">
                 <input
                     type="checkbox"

--- a/projects/components/src/form/form-input/form-input.component.html
+++ b/projects/components/src/form/form-input/form-input.component.html
@@ -1,9 +1,13 @@
 <div class="form-group">
-    <div class="clr-form-control">
-        <label *ngIf="label" class="clr-control-label" [for]="id" [ngClass]="{ 'required-field': showAsterisk }">{{
-        label
-        }}</label>
-        <div class="clr-control-container" [ngClass]="{ 'clr-error': showErrors }">
+    <div class="clr-form-control clr-row">
+        <label
+            *ngIf="label"
+            class="clr-control-label clr-col-12 clr-col-md-2"
+            [for]="id"
+            [ngClass]="{ 'required-field': showAsterisk }"
+            >{{ label }}</label
+        >
+        <div class="clr-control-container clr-col-12 clr-col-md-10" [ngClass]="{ 'clr-error': showErrors }">
             <div class="clr-input-wrapper">
                 <input
                     [attr.type]="type"
@@ -24,6 +28,12 @@
                     (keyup.escape)="escapeClicked.emit(true)"
                 />
                 <clr-icon *ngIf="showErrors && !hint" class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+                <ng-content select="aside"></ng-content>
+                <clr-signpost *ngIf="hint">
+                    <clr-signpost-content [clrPosition]="hintPosition" *clrIfOpen>
+                        <p>{{ hint }}</p>
+                    </clr-signpost-content>
+                </clr-signpost>
             </div>
             <span class="clr-subtext" *ngIf="showErrors" [id]="errorsId">
                 <div *ngFor="let key of errorKeys">
@@ -34,12 +44,6 @@
                 {{ description }}
             </span>
         </div>
-        <ng-content select="aside"></ng-content>
-        <clr-signpost *ngIf="hint">
-            <clr-signpost-content [clrPosition]="hintPosition" *clrIfOpen>
-                <p>{{ hint }}</p>
-            </clr-signpost-content>
-        </clr-signpost>
     </div>
 </div>
 <div class="clr-subtext">

--- a/projects/components/src/form/form-input/form-input.component.scss
+++ b/projects/components/src/form/form-input/form-input.component.scss
@@ -1,9 +1,3 @@
-.form-group >>> aside {
-    margin-top: 6px;
-    margin-bottom: 6px;
-    flex-grow: 1;
-}
-
 .form-group.hide-label {
     padding-left: 0;
 }

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -1,12 +1,16 @@
 <div class="form-group">
-    <div class="clr-form-control">
-        <label *ngIf="label" [for]="id" class="clr-control-label" [ngClass]="{ 'required-field': showAsterisk }">{{
-            label
-        }}</label>
+    <div class="clr-form-control clr-row">
+        <label
+            *ngIf="label"
+            [attr.for]="id"
+            class="clr-control-label clr-col-12 clr-col-md-2"
+            [ngClass]="{ 'required-field': showAsterisk }"
+            >{{ label }}</label
+        >
         <span *ngIf="isReadOnly && selectedOption" class="readOnly">
             {{ selectedOption.isTranslatable ? (selectedOption.display | translate) : selectedOption.display }}
         </span>
-        <div class="clr-control-container" [ngClass]="{ 'clr-error': showErrors }">
+        <div class="clr-control-container clr-col-12 clr-col-md-10" [ngClass]="{ 'clr-error': showErrors }">
             <div class="clr-select-wrapper" *ngIf="!isReadOnly">
                 <select
                     [id]="id"

--- a/projects/components/src/form/form.scss
+++ b/projects/components/src/form/form.scss
@@ -3,3 +3,6 @@
     color: red;
     padding-left: 5px;
 }
+.form-group ::ng-deep aside {
+    display: inline-block;
+}

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -38,9 +38,10 @@
             </clr-signpost>
         </aside>
     </vcd-form-input>
-    <div class="clr-form-control errors" *ngIf="showErrors">
-        <label class="clr-control-label"></label>
-        <div class="clr-error">
+    <div class="clr-form-control errors clr-row" *ngIf="showErrors">
+        <!-- Label is here to take up space so that the error aligns with the right side only-->
+        <label class="clr-control-label clr-col-12 clr-col-md-2"></label>
+        <div class="clr-error clr-col">
             <span class="clr-subtext">
                 <div *ngFor="let error of errors | keyvalue">
                     <div>{{ error.key | translate: getErrorTranslationParams(error.value) }}</div>

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
@@ -7,6 +7,15 @@ single-option {
     display: block;
 }
 
+aside > * {
+    display: inline-block;
+}
+
+/* Undo the nowrap added by .clr-input-container */
+clr-signpost-content {
+    white-space: normal;
+}
+
 :host ::ng-deep {
     .clr-control-container {
         flex: 0 1 auto;

--- a/projects/examples/src/components/form-input/form-input.example.component.html
+++ b/projects/examples/src/components/form-input/form-input.example.component.html
@@ -8,6 +8,7 @@
         [hintPosition]="'top-right'"
         [description]="'Input with required, email and maxLength(15) validators'"
     >
+        <aside>note, after input</aside>
     </vcd-form-input>
     <vcd-form-input
         [label]="'Number Input'"

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.html
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.html
@@ -36,6 +36,7 @@ type of units.
             [max]="maxMemoryAllowedMB"
             [initialValueUnit]="Bytes.MB"
             [isReadOnly]="formGroup.controls.readonly.value"
+            [description]="'Description below control'"
         >
         </vcd-number-with-unit-form-input>
         <div class="value-container" *ngIf="!formGroup.controls.readonly.value">


### PR DESCRIPTION
## Description

Followed Clarity's pattern of setting CSS grid classes. This allows
form inputs to be visible when zoom is set to 200% by moving labels and inputs to be on their own lines under small resolutions.

* The aside content is moved into the clr-input-container so that is always stays next to it
* number with unit input added some custom CSS to keep the select dropdown for the unit, and the hint signpost on the same line

## Testing Done
Check the following pages.
* [vcd-form-input](https://vmware.github.io/vmware-cloud-director-ui-components/formInputs/example)
* [vcd-form-select](https://vmware.github.io/vmware-cloud-director-ui-components/formSelect/documentation)
* [vcd-number-with-unit-input](https://vmware.github.io/vmware-cloud-director-ui-components/numberWithUnitFormInput/example/number-with-unit-form-input) and the [unit less example](https://vmware.github.io/vmware-cloud-director-ui-components/numberWithUnitFormInput/example/number-with-unit-form-input-unitless)
* [vcd-form-checkbox](https://vmware.github.io/vmware-cloud-director-ui-components/formCheckbox/example)

For all examples, the following behavior should apply
* Zooming the page to 200% with the screen at 1440×900 causes the labels and inputs to display on different lines 
* Description and validation errors display below the input, aligned with the label above it
* Signpost display next to the input (and text is word wrapped)

At regular zoom
* Inputs will behave mostly as they did before, except that making the page smaller will eventually display the label above the input field.


![checkbox](https://user-images.githubusercontent.com/549331/98732523-4458a680-236d-11eb-85a5-b6a3932256c3.gif)
![form-select](https://user-images.githubusercontent.com/549331/98732526-44f13d00-236d-11eb-92fa-93250ab02a64.gif)
![form-input](https://user-images.githubusercontent.com/549331/98732529-4589d380-236d-11eb-9bd1-171c2d8e04ac.gif)
![number-with-uni](https://user-images.githubusercontent.com/549331/98732531-4589d380-236d-11eb-998a-d4e5d053bdfe.gif)

Signed-off-by: Juan Mendes <jmendes@vmware.com>