### PR TITLE
[a11y] Set the focus on input element when unlimited is unchecked

### DIFF
--- a/projects/components/src/form/form-input/form-input.component.ts
+++ b/projects/components/src/form/form-input/form-input.component.ts
@@ -143,6 +143,18 @@ export class FormInputComponent extends BaseFormControl implements AfterViewInit
         }
         this.onChange(value);
     }
+
+    /**
+     * Move the focus to the input element.
+     * Its content is also selected for quick editing.
+     */
+    focus(): void {
+        if (!this.textInput) {
+            return;
+        }
+        this.textInput.nativeElement.focus();
+        this.textInput.nativeElement.select();
+    }
 }
 
 /**

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -98,6 +98,14 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             expect(numberWithUnitInput.valueFormControl.disabled).toBeTruthy('Value field should have been disabled');
             expect(numberWithUnitInput.unitFormControl.disabled).toBeTruthy('Unit field should have been disabled');
         });
+
+        it('sets the focus on the input element when unlimited checkbox is unchecked', () => {
+            numberWithUnitInput.unlimitedFormControl.setValue(true);
+            numberWithUnitInput.detectChanges();
+            expect(numberWithUnitInput.isInputValueFucused()).toBe(false, 'Input element should not be on focus');
+            numberWithUnitInput.unlimitedFormControl.setValue(false);
+            expect(numberWithUnitInput.isInputValueFucused()).toBe(true, 'Input element should be on focus');
+        });
     });
 
     describe('unitOptions', () => {

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -5,6 +5,7 @@
 
 import {
     AfterContentChecked,
+    ChangeDetectorRef,
     Component,
     Injectable,
     Input,
@@ -197,7 +198,8 @@ export class NumberWithUnitFormInputComponent
         @Self() @Optional() controlDirective: NgControl,
         private fb: FormBuilder,
         private translationService: TranslationService,
-        private unitFormatter: UnitFormatter
+        private unitFormatter: UnitFormatter,
+        private changeDetector: ChangeDetectorRef
     ) {
         super(controlDirective);
     }
@@ -243,6 +245,12 @@ export class NumberWithUnitFormInputComponent
                     input.setValue(this.lastRealValue);
                 }
                 this.updateUnlimitedDisabledState();
+                if (!unlimitedChecked) {
+                    // Usability requirements imply the focus to be on the input element when 'unlimited checkbox' is
+                    // deselected in order to be easier for the user to modify the value.
+                    this.changeDetector.detectChanges();
+                    this.limitedInput.focus();
+                }
             });
         }
         this.tracker.subscribe(this.formGroup.get('comboUnitOptions').valueChanges, () => {

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.widget-object.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.widget-object.ts
@@ -49,6 +49,10 @@ export class NumberWithUnitFormInputWidgetObject extends WidgetObject<NumberWith
         this.component.inputValueUnit = unit;
     }
 
+    isInputValueFucused(): boolean {
+        return document.activeElement === this.inputElement;
+    }
+
     get selectedUnit(): number {
         return this.component.formGroup.get('comboUnitOptions').value;
     }
@@ -57,7 +61,7 @@ export class NumberWithUnitFormInputWidgetObject extends WidgetObject<NumberWith
         return (
             this.component.unitOptions
                 // tslint:disable-next-line:triple-equals
-                .find(item => item.getMultiplier() == this.selectedUnit)
+                .find((item) => item.getMultiplier() == this.selectedUnit)
                 .getUnitName()
         );
     }
@@ -88,5 +92,9 @@ export class NumberWithUnitFormInputWidgetObject extends WidgetObject<NumberWith
     get singleUnitDisplayText(): string {
         const element = this.getNativeElement('.single-option');
         return element ? element.innerHTML : '';
+    }
+
+    private get inputElement(): HTMLInputElement {
+        return this.getNativeElement('vcd-form-input input') as HTMLInputElement;
     }
 }


### PR DESCRIPTION
### Description
Usability requirements imply the focus to be on the input element when 'unlimited checkbox' is
deselected in order to be easier for the user to modify the value.

### Testing done
In the live examples for the number with unit input verify that the focus is moved to the imput element
when the unlimited checkbox is unchecked - either with a mouse click or with the keyboard

Signed-off-by: Ivo Rahov <irahov@vmware.com>