### PR TITLE
[a11y] Add hints to checkbox component

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Enabled hints for vcd-form-checkbox
+- Fixed previous bad vcdResponsiveInput commits. Module was incorrectly setup and vcdResponsiveInput had
+  been added as  a class name instead of an attribute (directive)
 
 ## [1.0.0-a11y.4] - 2020-11-18
 ### Fixed

--- a/projects/components/src/form/form-checkbox/form-checkbox.component.html
+++ b/projects/components/src/form/form-checkbox/form-checkbox.component.html
@@ -10,10 +10,18 @@
                     [ngClass]="{ 'clr-checkbox': isCheckbox, 'clr-toggle': !isCheckbox }"
                     [formControl]="formControl"
                 />
-                <label class="clr-control-label right-label" [for]="id">
+                <label class="clr-control-label" [for]="id">
                     <clr-icon *ngIf="iconShape" [attr.shape]="iconShape"></clr-icon>
                     {{ text }}
                 </label>
+                <clr-signpost *ngIf="hint">
+                    <button type="button" class="btn-blank" clrSignpostTrigger>
+                        <clr-icon shape="info-circle" size="24"></clr-icon>
+                    </button>
+                    <clr-signpost-content [clrPosition]="hintPosition" *clrIfOpen>
+                        <p>{{ hint }}</p>
+                    </clr-signpost-content>
+                </clr-signpost>
             </div>
             <span class="clr-subtext" *ngIf="showErrors" [id]="errorsId">
                 <div *ngFor="let key of errorKeys">

--- a/projects/components/src/form/form-checkbox/form-checkbox.component.scss
+++ b/projects/components/src/form/form-checkbox/form-checkbox.component.scss
@@ -1,0 +1,16 @@
+label.clr-control-label {
+    display: inline-block;
+}
+
+.clr-checkbox-wrapper,
+.clr-toggle-wrapper {
+    display: flex;
+    align-items: center;
+}
+
+.btn-blank {
+    background-color: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}

--- a/projects/components/src/form/form-checkbox/form-checkbox.component.ts
+++ b/projects/components/src/form/form-checkbox/form-checkbox.component.ts
@@ -26,6 +26,7 @@ export enum CheckBoxStyling {
 @Component({
     selector: 'vcd-form-checkbox',
     templateUrl: './form-checkbox.component.html',
+    styleUrls: ['./form-checkbox.component.scss'],
 })
 export class FormCheckboxComponent extends BaseFormControl {
     /**
@@ -47,6 +48,16 @@ export class FormCheckboxComponent extends BaseFormControl {
      * A shape for the icon that appears next to the checkbox.
      */
     @Input() iconShape: string;
+
+    /**
+     * The direction for displaying the hint
+     */
+    @Input() hintPosition = 'top-left';
+
+    /**
+     * Hint to display in the content of a signpost
+     */
+    @Input() hint: string;
 
     get isCheckbox(): boolean {
         return this.styling === CheckBoxStyling.CHECKBOX;

--- a/projects/components/src/form/form-input/form-input.component.html
+++ b/projects/components/src/form/form-input/form-input.component.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-    <div class="clr-form-control vcdResponsiveInput">
+    <div class="clr-form-control" vcdResponsiveInput>
         <label *ngIf="label" class="clr-control-label" [for]="id" [ngClass]="{ 'required-field': showAsterisk }">{{
             label
         }}</label>

--- a/projects/components/src/form/form-input/form-input.component.scss
+++ b/projects/components/src/form/form-input/form-input.component.scss
@@ -2,11 +2,6 @@
     padding-left: 0;
 }
 
-.input-aside {
-    display: flex;
-    width: 100%;
-}
-
 :host-context(.modal):not(.adjust-aside-left) {
     .form-label {
         flex-grow: 1;

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-    <div class="clr-form-control vcdResponsiveInput">
+    <div class="clr-form-control" vcdResponsiveInput>
         <label *ngIf="label" [attr.for]="id" class="clr-control-label" [ngClass]="{ 'required-field': showAsterisk }">{{
             label
         }}</label>

--- a/projects/components/src/form/form.module.ts
+++ b/projects/components/src/form/form.module.ts
@@ -8,6 +8,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
+import { ResponsiveInputDirectiveModule } from '../lib/directives/responsive-input/responsive-input.module';
 import { UnitFormatter } from '../utils/unit/unit-formatter';
 import { FormCheckboxComponent } from './form-checkbox/form-checkbox.component';
 import { FormInputComponent } from './form-input/form-input.component';
@@ -17,9 +18,16 @@ import { NumberWithUnitFormInputComponent } from './number-with-unit-input/numbe
 const declarations = [FormInputComponent, FormSelectComponent, FormCheckboxComponent, NumberWithUnitFormInputComponent];
 
 @NgModule({
-    imports: [ClarityModule, FormsModule, ReactiveFormsModule, CommonModule, I18nModule],
+    imports: [
+        ClarityModule,
+        FormsModule,
+        ReactiveFormsModule,
+        CommonModule,
+        I18nModule,
+        ResponsiveInputDirectiveModule,
+    ],
     declarations,
     providers: [UnitFormatter],
-    exports: [...declarations],
+    exports: [...declarations, ResponsiveInputDirectiveModule],
 })
 export class VcdFormModule {}

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -1,4 +1,4 @@
-<div class="clr-form-control vcdResponsiveInput" *ngIf="isReadOnly">
+<div class="clr-form-control" vcdResponsiveInput *ngIf="isReadOnly">
     <label class="clr-control-label">{{ label }}</label>
     <span class="clr-control-container readonly-text">{{ this.displayValue }}</span>
 </div>
@@ -38,10 +38,10 @@
             </clr-signpost>
         </aside>
     </vcd-form-input>
-    <div class="clr-form-control errors vcdResponsiveInput" *ngIf="showErrors">
-        <!-- Label is here to take up space so that the error aligns with the right side only-->
-        <label class="clr-control-label clr-col-12 clr-col-md-2"></label>
-        <div class="clr-error clr-col">
+    <div class="clr-form-control errors" vcdResponsiveInput *ngIf="showErrors">
+        <!-- Label is here to take up space so that the error aligns with the right side only -->
+        <label class="clr-control-label"></label>
+        <div class="clr-error">
             <span class="clr-subtext">
                 <div *ngFor="let error of errors | keyvalue">
                     <div>{{ error.key | translate: getErrorTranslationParams(error.value) }}</div>

--- a/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
+++ b/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
@@ -15,7 +15,7 @@ import { AfterViewInit, Directive, ElementRef, HostBinding } from '@angular/core
     selector: '.clr-form-control[vcdResponsiveInput]',
 })
 export class ResponsiveInputDirective implements AfterViewInit {
-    @HostBinding('class.clr-row') private clrGridRow = true;
+    @HostBinding('class.clr-row') public clrGridRow = true;
     constructor(private el: ElementRef<HTMLElement>) {}
 
     ngAfterViewInit(): void {
@@ -24,7 +24,7 @@ export class ResponsiveInputDirective implements AfterViewInit {
     }
 
     private applyClasses(className: 'label' | 'container', mdSize: '2' | '10'): void {
-        const el = this.el.nativeElement.querySelector(`.clr-control-${className}`);
+        const el = this.el.nativeElement.querySelector(`:scope > .clr-control-${className}`);
         if (el) {
             el.classList.add('clr-col-12', `clr-col-md-${mdSize}`);
         }

--- a/projects/examples/src/components/form-input/form-checkbox.example.component.html
+++ b/projects/examples/src/components/form-input/form-checkbox.example.component.html
@@ -5,6 +5,7 @@
         [formControlName]="'checkboxInput'"
         [description]="'Toggle this checkbox to enable/disable the toggle switch below'"
         [text]="'Right Label'"
+        hint="Hints display in a signpost"
     >
     </vcd-form-checkbox>
 
@@ -14,6 +15,8 @@
         [styling]="styling.TOGGLESWITCH"
         [formControlName]="'toggleInput'"
         [description]="'Helper Text'"
+        text="another right label"
+        hint="Hints go inside the signpost, let's make it longer"
     >
     </vcd-form-checkbox>
 </form>


### PR DESCRIPTION
Also fixed some a bad previous commit:
* vcdResponsiveInput was added as a class name instead of an attribute
* Module for vcdResponsiveInput was incorrectly setup
* Make sure we only query for input labels and containers that are immediate children of clr-form-control

## Testing Done

- Verified the checkbox input hint's for both the regular checkbox and the toggle buttons.
- Installed this version in VCD's UI to make sure modules were working.

![image](https://user-images.githubusercontent.com/549331/99967346-b8c81800-2d65-11eb-8afc-b771f8307567.png)
![image](https://user-images.githubusercontent.com/549331/99967367-c4b3da00-2d65-11eb-9c79-eb0aca0029b7.png)

Signed-off-by: Juan Mendes <jmendes@vmware.com>