### PR TITLE
[a11y] Display errors for invalid numbers

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Display error messages for invalid input on form controls accepting numbers
 
 ## [1.0.0-a11y.4] - 2020-11-18
 ### Fixed

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -66,9 +66,9 @@ vcd.cc.cpu.speed.unit.YHz={0} YHz
 
 # Validation error strings
 vcd.cc.warning.numRange=Only numbers in the range of {1} to {2} are allowed
-
 vcd.cc.numeric.filter.from=From:
 vcd.cc.numeric.filter.to=To:
+vcd.cc.bad.input=Invalid number
 
 vcd.cc.datagrid.actions=Actions
 

--- a/projects/components/src/form/form-input/form-input.component.ts
+++ b/projects/components/src/form/form-input/form-input.component.ts
@@ -14,8 +14,8 @@ import {
     Self,
     ViewChild,
 } from '@angular/core';
-import { NgControl } from '@angular/forms';
-import { BaseFormControl } from '../base-form-control';
+import { AbstractControl, FormControl, NgControl, ValidationErrors } from '@angular/forms';
+import { BaseFormControl, defaultValidatorForControl } from '../base-form-control';
 
 /**
  * A {@link FormControl} that contains an input that supports string, number and datetime-local input types
@@ -122,6 +122,9 @@ export class FormInputComponent extends BaseFormControl implements AfterViewInit
         // The textInput view child element is only defined after this life cycle hook. So, the writeValue is called
         // here.
         this.writeValue(this.initialValue);
+        if (this.type === 'number') {
+            defaultValidatorForControl(this.formControl, (control) => this.validateNumber(control));
+        }
     }
 
     inputChanged(): void {
@@ -154,6 +157,13 @@ export class FormInputComponent extends BaseFormControl implements AfterViewInit
         }
         this.textInput.nativeElement.focus();
         this.textInput.nativeElement.select();
+    }
+
+    /**
+     * Default validator that looks at the input's [validity](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
+     */
+    validateNumber(control: AbstractControl): ValidationErrors {
+        return this.textInput.nativeElement.validity.badInput ? { 'vcd.cc.bad.input': true } : null;
     }
 }
 

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -14,7 +14,7 @@
         [maxlength]="maxlength"
         [showAsterisk]="showAsterisk"
         [label]="label"
-        [description]="description"
+        [description]="formControl.valid && description"
     >
         <aside [ngSwitch]="unitOptions.length">
             <ng-container *ngSwitchCase="0">

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -5,7 +5,7 @@
 <div *ngIf="!isReadOnly" class="input-number-with-unit">
     <vcd-form-input
         #limitedInput
-        [formControl]="formGroup.controls.limited"
+        [formControl]="numberInput"
         [placeholder]="placeholder"
         type="number"
         [size]="size"
@@ -28,7 +28,7 @@
                 *ngSwitchDefault
                 #unitDropdown
                 [options]="comboOptions"
-                [formControl]="formGroup.controls.comboUnitOptions"
+                [formControl]="unitCombo"
             >
             </vcd-form-select>
             <clr-signpost *ngIf="hint">
@@ -55,7 +55,7 @@
         <vcd-form-checkbox
             [label]="' '"
             [text]="'vcd.cc.unlimited' | translate"
-            [formControl]="formGroup.controls.unlimited"
+            [formControl]="unlimitedCheckbox"
         ></vcd-form-checkbox>
     </footer>
 </div>


### PR DESCRIPTION
## Problem 
This fixes an issue where the form control's value was null if the user input could not be parsed as a number. We did not display any validation error to the user explaining that the input is invalid.

## Solution
`form-input` uses an internal default validator that checks for HTML's [validity](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) for `badInput`

Note that I created getters for the internal form controls as a refactor. Therefore, the more relevant part of the review is https://github.com/vmware/vmware-cloud-director-ui-components/pull/258/commits/702b562ebb61be1d8b803a92f37b0f4a745d460c


`number-with-unit` also uses an internal default validator that checks the error state of its internal `form-input`

## Implementation notes
The internal `form-input` within `number-with-unit` does not display any errors but it does display the description.

## Testing Done

### Form with unit example
* Displays "Invalid number" if user types `e`, `1e`, `-e` 
  * In Firefox, anything is allowed so typing abc also displays "Invalid number"
### Form with unit - unit-less example
* Type -1 into warn level
  * See message indicating that number must be 1-100
* Type `-1e`
  * See message saying "Invalid number"
* Toggle box that says "Validator shows *" 
  * Make sure message still says "Invalid number" 

### Form input
* Displays "Invalid number" if user types `e`, `1e`, `-e` 
  * In Firefox, anything is allowed so typing abc also displays "Invalid number"
* Make sure "Input is required" displays for empty required f
![form-input-parsing](https://user-images.githubusercontent.com/549331/100048938-19963580-2de4-11eb-821e-91298782d7b6.gif)
![number-with-unit-parsing](https://user-images.githubusercontent.com/549331/100048941-1a2ecc00-2de4-11eb-8c8b-6eecff26ae85.gif)


 