### PR TITLE
Remove margins from error banner

### DIFF
--- a/projects/components/src/common/error/error-banner.component.scss
+++ b/projects/components/src/common/error/error-banner.component.scss
@@ -4,6 +4,6 @@
  */
 
 clr-alert ::ng-deep .alert {
-    margin-left: 24px;
-    margin-right: 24px;
+    margin-left: 0;
+    margin-right: 0;
 }


### PR DESCRIPTION
Issue #172 The banner component margins were 24px and are now 0. 

## Testing Done
* Go to http://localhost:4200/errorBanner/example
* Verify that banner aligns with button above it

### Before
![image](https://user-images.githubusercontent.com/73592887/100123354-690e4d00-2e48-11eb-91a5-0028463e7701.png)

### After
 ![image](https://user-images.githubusercontent.com/73592887/100123192-3e23f900-2e48-11eb-8805-b624a7001458.png)

Signed off by Ria Mahoney mpatrice@vmware.com