### PR TITLE
Rewrite `ClrDatagridWidget` with new Widget Object

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 4. INTERNAL: Rewrote helper method about creating datagrid filter unit test with new Widget Object.
 ### Removed
 1. BREAKING: Removed `WithGridBoldRenderer`. The functionality of `WithGridBoldRenderer` has been implemented in `ClrDatagridWidget`.
+### Deprecated
+1. Marked `WidgetFinder` as deprecated.
 
 ## [1.0.0-dev.50] - 2020-12-2
 ### Fixed

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-[internal]: Update `ng-live-docs` to 0.0.8 to enable `@vmw/ng-live-docs:add-example` schematic.
+1. INTERNAL: Update `ng-live-docs` to 0.0.8 to enable `@vmw/ng-live-docs:add-example` schematic.
 ### Changed
 1. BREAKING: Rewrote `VcdDatagridWidget` and `ClrDatagridWidget` with new Widget Object.
 2. Added convenience methods to the `TestElement`.

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0-dev.51] - 2020-12-4
 ### Added
 1. INTERNAL: Update `ng-live-docs` to 0.0.8 to enable `@vmw/ng-live-docs:add-example` schematic.
 ### Changed

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 [internal]: Update `ng-live-docs` to 0.0.8 to enable `@vmw/ng-live-docs:add-example` schematic.
+### Changed
+1. BREAKING: Rewrote `VcdDatagridWidget` and `ClrDatagridWidget` with new Widget Object.
+2. Added convenience methods to the `TestElement`.
+3. INTERNAL: Rewrote `datagrid.component` unit tests using new widget object.
+4. INTERNAL: Rewrote helper method about creating datagrid filter unit test with new Widget Object.
+### Removed
+1. BREAKING: Removed `WithGridBoldRenderer`. The functionality of `WithGridBoldRenderer` has been implemented in `ClrDatagridWidget`.
 
 ## [1.0.0-dev.50] - 2020-12-2
 ### Fixed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.50",
+    "version": "1.0.0-dev.51",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/data-exporter/data-exporter.wo.ts
+++ b/projects/components/src/data-exporter/data-exporter.wo.ts
@@ -14,17 +14,17 @@ export class DataExporterWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * The strings for the available column bubbles.
      */
-    getColumnBubbles = this.locatorForChild('.column-container .column-label');
+    getColumnBubbles = this.locatorForCssSelectors('.column-container .column-label');
 
     /**
      * The strings for the available column checkboxes.
      */
-    getColumnCheckboxes = this.locatorForChild('li .column-checkbox');
+    getColumnCheckboxes = this.locatorForCssSelectors('li .column-checkbox');
 
     /**
      * Gets the cancel button.
      */
-    getCancelButton = this.locatorForChild('.cancel');
+    getCancelButton = this.locatorForCssSelectors('.cancel');
 
     /**
      * Gets the export button.
@@ -34,27 +34,27 @@ export class DataExporterWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * Gets the arrow to open/close the column dropdown.
      */
-    getColumnDropdown = this.locatorForChild('.dropdown-button');
+    getColumnDropdown = this.locatorForCssSelectors('.dropdown-button');
 
     /**
      * Gets the export all switch
      */
-    getToggleSelectAll = this.locatorForChild('.export-all');
+    getToggleSelectAll = this.locatorForCssSelectors('.export-all');
 
     /**
      * Gets the sanitization switch
      */
-    getToggleSanitize = this.locatorForChild('.sanitize-cells');
+    getToggleSanitize = this.locatorForCssSelectors('.sanitize-cells');
 
     /**
      * Gets the friendly field names switch
      */
-    getToggleFriendlyNames = this.locatorForChild('.friendly-names');
+    getToggleFriendlyNames = this.locatorForCssSelectors('.friendly-names');
 
     /**
      * Gets the progress bar.
      */
-    getProgress = this.locatorForChild('progress');
+    getProgress = this.locatorForCssSelectors('progress');
 
     /**
      * Gets the checkbox next to a given column

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -53,8 +53,6 @@ interface HasFinderAndGrid {
     clrGridWidget: ClrDatagridWidgetObject<TestElement>;
     // The Widget Object for the VCD Datagrid
     vcdDatagrid: VcdDatagridWidgetObject<TestElement>;
-    // The instance of DatagridComponent
-    component: MockRecordDatagridComponent;
     hostComponent: HostWithDatagridComponent;
 }
 
@@ -76,10 +74,6 @@ describe('DatagridComponent', () => {
         // @ts-ignore
         this.vcdDatagrid = this.finder.find(VcdDatagridWidgetObject);
         this.clrGridWidget = this.vcdDatagrid.findClrDatagrid();
-        this.component = this.vcdDatagrid.unwrap().elements[0].componentInstance as DatagridComponent<
-            MockRecord,
-            RecordId
-        >;
         this.hostComponent = this.finder.hostComponent as HostWithDatagridComponent;
     });
 
@@ -124,7 +118,7 @@ describe('DatagridComponent', () => {
             it('gives proper css class for the grid', function (this: HasFinderAndGrid): void {
                 this.hostComponent.clrDatagridCssClass = 'some_class';
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.unwrap().classes()).toContain('some_class');
+                expect(this.clrGridWidget.component.classes()).toContain('some_class');
             });
 
             it('sets no default CSS classnames for the rows', function (this: HasFinderAndGrid): void {
@@ -172,7 +166,7 @@ describe('DatagridComponent', () => {
                 it('clips text when disableCliptext is unset', function (this: HasFinderAndGrid): void {
                     this.hostComponent.columns = [{ displayName: 'Name', renderer: 'name' }];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget.getCell(0, 0).elements[0].injector.get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeFalsy();
                 });
 
@@ -181,7 +175,7 @@ describe('DatagridComponent', () => {
                         { displayName: 'Name', renderer: 'name', cliptextConfig: { size: TooltipSize.md } },
                     ];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget.getCell(0, 0).elements[0].injector.get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeFalsy();
                 });
 
@@ -190,7 +184,7 @@ describe('DatagridComponent', () => {
                         { displayName: 'Name', renderer: 'name', cliptextConfig: { disabled: true } },
                     ];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget.getCell(0, 0).elements[0].injector.get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeTruthy();
                 });
             });
@@ -290,8 +284,7 @@ describe('DatagridComponent', () => {
                         tick();
                         this.clrGridWidget.getRowInput(1).click();
                         tick();
-                        const component = this.vcdDatagrid.unwrap().elements[0]
-                            .componentInstance as MockRecordDatagridComponent;
+                        const component = this.vcdDatagrid.component.getComponentInstance() as MockRecordDatagridComponent;
                         expect(component.datagridSelection).toEqual([mockData[1]]);
                         this.hostComponent.gridData = {
                             items: [mockData[0]],
@@ -543,31 +536,27 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() height', () => {
-                function getGridHeight(element: TestElement): string {
-                    return element.elements[0].nativeElement.style.getPropertyValue('--datagrid-height');
-                }
-
                 it('defaults to parent height when height is not set', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.unwrap().parent().classes()).toContain('fill-parent');
-                    expect(getGridHeight(this.clrGridWidget.unwrap().parent())).toEqual('unset');
+                    expect(this.vcdDatagrid.component.classes()).toContain('fill-parent');
+                    expect(this.vcdDatagrid.component.getStylePropertyValue('--datagrid-height')).toEqual('unset');
                 });
 
                 it('uses the given height when height is set', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(getGridHeight(this.clrGridWidget.unwrap().parent())).toEqual('200px');
+                    expect(this.vcdDatagrid.component.getStylePropertyValue('--datagrid-height')).toEqual('200px');
                 });
 
                 it('allows the height to be dynamically changed', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(getGridHeight(this.clrGridWidget.unwrap().parent())).toEqual('200px');
+                    expect(this.vcdDatagrid.component.getStylePropertyValue('--datagrid-height')).toEqual('200px');
                     this.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.unwrap().parent().classes()).toContain('fill-parent');
-                    expect(getGridHeight(this.clrGridWidget.unwrap().parent())).toEqual('unset');
+                    expect(this.vcdDatagrid.component.classes()).toContain('fill-parent');
+                    expect(this.vcdDatagrid.component.getStylePropertyValue('--datagrid-height')).toEqual('unset');
                 });
             });
         });
@@ -575,38 +564,38 @@ describe('DatagridComponent', () => {
         describe('@Input() emptyGridPlaceholder', () => {
             it('does not show the placeholder while the grid is loading', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeTruthy();
+                expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
                 expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('');
             });
 
             it('shows the placeholder if the grid is empty', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeTruthy();
+                expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
                 this.hostComponent.gridData = {
                     items: [],
                     totalItems: 0,
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeFalsy();
+                expect(this.clrGridWidget.getSpinner().length()).toEqual(0);
                 expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('Placeholder');
             });
 
             it('does not show the placeholder if the grid has data', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeTruthy();
+                expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
                 this.hostComponent.gridData = {
                     items: mockData,
                     totalItems: 2,
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeFalsy();
+                expect(this.clrGridWidget.getSpinner().length()).toEqual(0);
                 expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('');
             });
         });
 
         it('displays loading indicators while data is loading', function (this: HasFinderAndGrid): void {
             this.finder.detectChanges();
-            expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBe(
+            expect(this.clrGridWidget.component.getComponentInstance().loading).toBe(
                 true,
                 'Initially loading indicator should be true'
             );
@@ -615,7 +604,7 @@ describe('DatagridComponent', () => {
                 totalItems: 2,
             };
             this.finder.detectChanges();
-            expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBe(
+            expect(this.clrGridWidget.component.getComponentInstance().loading).toBe(
                 false,
                 'After setting gridData, loading indicator should not be visible'
             );
@@ -693,10 +682,10 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
 
-            it('opens one detail pane when you click the button', fakeAsync(function (this: HasFinderAndGrid): void {
+            it('opens one detail pane when you click the button', function (this: HasFinderAndGrid): void {
                 this.clrGridWidget.getDetailRowButtons().toArray()[0].click();
                 expect(this.clrGridWidget.getDetailRows().length()).toEqual(1);
-            }));
+            });
         });
 
         describe('@Input() isRowExpanded', () => {
@@ -849,6 +838,8 @@ describe('DatagridComponent', () => {
                 'adds the logic of calling datagrids actionReporter.monitorGet method to action handler' +
                     ' when the handler returns a promise',
                 function (this: HasFinderAndGrid): void {
+                    this.finder.detectChanges();
+                    const component = this.hostComponent.grid;
                     const actionHandlerWithoutPromise: ActionHandlerType<any, any> = () => null;
                     const actionHandlerThatReturnsPromise: ActionHandlerType<any, any> = () => new Promise(() => null);
                     this.hostComponent.indicatorType = ActivityIndicatorType.BANNER;
@@ -865,10 +856,10 @@ describe('DatagridComponent', () => {
                         },
                     ];
                     this.finder.detectChanges();
-                    const monitorGetSpy = spyOn(this.component.actionReporter, 'monitorGet').and.callFake(() => null);
-                    this.component.actions[0].handler();
+                    const monitorGetSpy = spyOn(component.actionReporter, 'monitorGet').and.callFake(() => null);
+                    component.actions[0].handler();
                     expect(monitorGetSpy).not.toHaveBeenCalled();
-                    this.component.actions[1].handler();
+                    component.actions[1].handler();
                     expect(monitorGetSpy).toHaveBeenCalled();
                 }
             );
@@ -898,6 +889,8 @@ describe('DatagridComponent', () => {
 
         describe('shouldShowActionBarOnTop', () => {
             it('returns true when there are static actions', function (this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                const component = this.hostComponent.grid;
                 this.hostComponent.actions = [
                     {
                         textKey: 'static.action',
@@ -907,9 +900,11 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.component.shouldShowActionBarOnTop).toBeTruthy();
+                expect(component.shouldShowActionBarOnTop).toBeTruthy();
             });
             it('returns true when there are contextual actions to be displayed on top', function (this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                const component = this.hostComponent.grid;
                 this.hostComponent.gridData = {
                     items: mockData,
                     totalItems: 2,
@@ -929,7 +924,7 @@ describe('DatagridComponent', () => {
                 // This is because contextual actions requires entities to be selected
                 this.clrGridWidget.getRowInput(0).click();
                 this.finder.detectChanges();
-                expect(this.component.shouldShowActionBarOnTop).toBeTruthy();
+                expect(component.shouldShowActionBarOnTop).toBeTruthy();
             });
         });
 
@@ -954,7 +949,7 @@ describe('DatagridComponent', () => {
             it('enables only sorting when queryFieldName is given but no filter is provided', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [{ displayName: 'Name', renderer: 'name', queryFieldName: 'name' }];
                 this.finder.detectChanges();
-                const el = this.clrGridWidget.unwrap().elements[0].componentInstance;
+                const el = this.clrGridWidget.component.getComponentInstance();
                 expect(el.columns.first.sortable).toEqual(true);
                 expect(el.columns.first.customFilter).toEqual(false);
             });
@@ -970,7 +965,7 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                const el = this.clrGridWidget.unwrap().elements[0].componentInstance;
+                const el = this.clrGridWidget.component.getComponentInstance();
                 expect(el.columns.first.sortable).toEqual(false);
                 expect(el.columns.first.customFilter).toEqual(true);
             });
@@ -985,7 +980,7 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                const el = this.clrGridWidget.unwrap().elements[0].componentInstance;
+                const el = this.clrGridWidget.component.getComponentInstance();
                 expect(el.columns.first.sortable).toEqual(true);
                 expect(el.columns.first.customFilter).toEqual(true);
             });
@@ -1091,7 +1086,9 @@ describe('DatagridComponent', () => {
 
         describe('getPaginationTranslation', () => {
             it('returns translated string', async function (this: HasFinderAndGrid): Promise<void> {
-                const translatedString = await (this.component.getPaginationTranslation({
+                this.finder.detectChanges();
+                const component = this.hostComponent.grid;
+                const translatedString = await (component.getPaginationTranslation({
                     firstItem: 1,
                     lastItem: 10,
                     totalItems: 100,

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -118,7 +118,7 @@ describe('DatagridComponent', () => {
             it('gives proper css class for the grid', function (this: HasFinderAndGrid): void {
                 this.hostComponent.clrDatagridCssClass = 'some_class';
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.component.classes()).toContain('some_class');
+                expect(this.clrGridWidget.clrDatagrid.classes()).toContain('some_class');
             });
 
             it('sets no default CSS classnames for the rows', function (this: HasFinderAndGrid): void {
@@ -284,7 +284,7 @@ describe('DatagridComponent', () => {
                         tick();
                         this.clrGridWidget.getRowInput(1).click();
                         tick();
-                        const component = this.vcdDatagrid.component.getComponentInstance() as MockRecordDatagridComponent;
+                        const component = this.vcdDatagrid.vcdDatagrid.getComponentInstance() as MockRecordDatagridComponent;
                         expect(component.datagridSelection).toEqual([mockData[1]]);
                         this.hostComponent.gridData = {
                             items: [mockData[0]],
@@ -539,24 +539,24 @@ describe('DatagridComponent', () => {
                 it('defaults to parent height when height is not set', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.vcdDatagrid.component.classes()).toContain('fill-parent');
-                    expect(this.vcdDatagrid.component.getStylePropertyValue('--datagrid-height')).toEqual('unset');
+                    expect(this.vcdDatagrid.vcdDatagrid.classes()).toContain('fill-parent');
+                    expect(this.vcdDatagrid.vcdDatagrid.getStylePropertyValue('--datagrid-height')).toEqual('unset');
                 });
 
                 it('uses the given height when height is set', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(this.vcdDatagrid.component.getStylePropertyValue('--datagrid-height')).toEqual('200px');
+                    expect(this.vcdDatagrid.vcdDatagrid.getStylePropertyValue('--datagrid-height')).toEqual('200px');
                 });
 
                 it('allows the height to be dynamically changed', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(this.vcdDatagrid.component.getStylePropertyValue('--datagrid-height')).toEqual('200px');
+                    expect(this.vcdDatagrid.vcdDatagrid.getStylePropertyValue('--datagrid-height')).toEqual('200px');
                     this.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.vcdDatagrid.component.classes()).toContain('fill-parent');
-                    expect(this.vcdDatagrid.component.getStylePropertyValue('--datagrid-height')).toEqual('unset');
+                    expect(this.vcdDatagrid.vcdDatagrid.classes()).toContain('fill-parent');
+                    expect(this.vcdDatagrid.vcdDatagrid.getStylePropertyValue('--datagrid-height')).toEqual('unset');
                 });
             });
         });
@@ -595,7 +595,7 @@ describe('DatagridComponent', () => {
 
         it('displays loading indicators while data is loading', function (this: HasFinderAndGrid): void {
             this.finder.detectChanges();
-            expect(this.clrGridWidget.component.getComponentInstance().loading).toBe(
+            expect(this.clrGridWidget.clrDatagrid.getComponentInstance().loading).toBe(
                 true,
                 'Initially loading indicator should be true'
             );
@@ -604,7 +604,7 @@ describe('DatagridComponent', () => {
                 totalItems: 2,
             };
             this.finder.detectChanges();
-            expect(this.clrGridWidget.component.getComponentInstance().loading).toBe(
+            expect(this.clrGridWidget.clrDatagrid.getComponentInstance().loading).toBe(
                 false,
                 'After setting gridData, loading indicator should not be visible'
             );
@@ -949,7 +949,7 @@ describe('DatagridComponent', () => {
             it('enables only sorting when queryFieldName is given but no filter is provided', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [{ displayName: 'Name', renderer: 'name', queryFieldName: 'name' }];
                 this.finder.detectChanges();
-                const el = this.clrGridWidget.component.getComponentInstance();
+                const el = this.clrGridWidget.clrDatagrid.getComponentInstance();
                 expect(el.columns.first.sortable).toEqual(true);
                 expect(el.columns.first.customFilter).toEqual(false);
             });
@@ -965,7 +965,7 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                const el = this.clrGridWidget.component.getComponentInstance();
+                const el = this.clrGridWidget.clrDatagrid.getComponentInstance();
                 expect(el.columns.first.sortable).toEqual(false);
                 expect(el.columns.first.customFilter).toEqual(true);
             });
@@ -980,7 +980,7 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                const el = this.clrGridWidget.component.getComponentInstance();
+                const el = this.clrGridWidget.clrDatagrid.getComponentInstance();
                 expect(el.columns.first.sortable).toEqual(true);
                 expect(el.columns.first.customFilter).toEqual(true);
             });

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component, HostBinding, TrackByFunction, ViewChild } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LoadingListener } from '@clr/angular';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
@@ -20,10 +20,11 @@ import {
     ActionType,
     TextIcon,
 } from '../common/interfaces/action-item.interface';
-import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
+import { ShowClippedTextDirective, TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { ClrDatagridWidgetObject } from '../utils/test/datagrid/datagrid.wo';
 import { VcdDatagridWidgetObject } from '../utils/test/datagrid/vcd-datagrid.wo';
-import { WidgetFinder } from '../utils/test/widget-object';
+import { AngularWidgetObjectFinder } from '../utils/test/widget-object/angular-widget-finder';
+import { TestElement } from '../utils/test/widget-object/angular-widget-object';
 import {
     ActivityIndicatorType,
     ContextualActionPosition,
@@ -39,7 +40,6 @@ import { DatagridStringFilter, WildCardPosition } from './filters/datagrid-strin
 import { ColumnComponentRendererSpec, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';
 import { mockData, MockRecord } from './mock-data';
 import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
-import { WithGridBoldRenderer } from './renderers/bold-text-renderer.wo';
 
 interface RecordId {
     name: string;
@@ -47,16 +47,15 @@ interface RecordId {
 
 type MockRecordDatagridComponent = DatagridComponent<MockRecord, RecordId>;
 
-class GridWithBoldRenderer extends WithGridBoldRenderer(VcdDatagridWidgetObject)<MockRecord> {}
-
 interface HasFinderAndGrid {
-    finder: WidgetFinder<HostWithDatagridComponent>;
+    finder: AngularWidgetObjectFinder;
     // The Widget Object for the underlying Clarity grid
-    clrGridWidget: ClrDatagridWidgetObject;
+    clrGridWidget: ClrDatagridWidgetObject<TestElement>;
     // The Widget Object for the VCD Datagrid
-    vcdDatagrid: GridWithBoldRenderer;
+    vcdDatagrid: VcdDatagridWidgetObject<TestElement>;
     // The instance of DatagridComponent
     component: MockRecordDatagridComponent;
+    hostComponent: HostWithDatagridComponent;
 }
 
 describe('DatagridComponent', () => {
@@ -73,81 +72,89 @@ describe('DatagridComponent', () => {
             declarations: [HostWithDatagridComponent, DatagridDetailsComponent, DatagridDetailsPaneComponent],
         }).compileComponents();
 
-        this.finder = new WidgetFinder(HostWithDatagridComponent);
-        this.vcdDatagrid = this.finder.find(GridWithBoldRenderer);
-        this.clrGridWidget = this.vcdDatagrid.clrDatagrid;
-        this.component = this.finder.find(VcdDatagridWidgetObject).component as DatagridComponent<MockRecord, RecordId>;
+        this.finder = new AngularWidgetObjectFinder(HostWithDatagridComponent);
+        // @ts-ignore
+        this.vcdDatagrid = this.finder.find(VcdDatagridWidgetObject);
+        this.clrGridWidget = this.vcdDatagrid.findClrDatagrid();
+        this.component = this.vcdDatagrid.unwrap().elements[0].componentInstance as DatagridComponent<
+            MockRecord,
+            RecordId
+        >;
+        this.hostComponent = this.finder.hostComponent as HostWithDatagridComponent;
     });
 
     describe('Grid', () => {
         describe('', () => {
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                (this.hostComponent as HostWithDatagridComponent).columns = [
                     { displayName: 'Name', renderer: 'name' },
                     { displayName: 'City', renderer: 'city' },
                 ];
                 this.finder.detectChanges();
             });
             it('displays number of columns', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.columnCount).toBe(this.finder.hostComponent.columns.length);
+                expect(this.clrGridWidget.getColumns().length()).toBe(this.hostComponent.columns.length);
             });
 
             it('displays columns with headers', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.columnHeaders).toEqual(
-                    this.finder.hostComponent.columns.map((col) => col.displayName)
-                );
-                expect(this.clrGridWidget.getColumnHeader(0)).toEqual(this.finder.hostComponent.columns[0].displayName);
+                expect(
+                    this.clrGridWidget
+                        .getColumnHeaders()
+                        .toArray()
+                        .map((columnHeader: TestElement) => columnHeader.text())
+                ).toEqual(this.hostComponent.columns.map((col) => col.displayName));
             });
 
             it('displays the correct headers even when columns are reloaded', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [{ displayName: 'One More', renderer: 'name' }];
+                this.hostComponent.columns = [{ displayName: 'One More', renderer: 'name' }];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.columnHeaders).toEqual(
-                    this.finder.hostComponent.columns.map((col) => col.displayName)
-                );
-                expect(this.clrGridWidget.getColumnHeader(0)).toEqual(this.finder.hostComponent.columns[0].displayName);
+                expect(
+                    this.clrGridWidget
+                        .getColumnHeaders()
+                        .toArray()
+                        .map((columnHeader: TestElement) => columnHeader.text())
+                ).toEqual(this.hostComponent.columns.map((col) => col.displayName));
+                expect(this.clrGridWidget.getColumnHeader(0).text()).toEqual(this.hostComponent.columns[0].displayName);
             });
 
             it('displays rows based on the grid data received', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.rowCount).toBe(mockData.length);
+                expect(this.clrGridWidget.getRows().length()).toBe(mockData.length);
             });
 
             it('gives proper css class for the grid', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.clrDatagridCssClass = 'some_class';
+                this.hostComponent.clrDatagridCssClass = 'some_class';
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.gridCssClass).toContain('some_class');
+                expect(this.clrGridWidget.unwrap().classes()).toContain('some_class');
             });
 
             it('sets no default CSS classnames for the rows', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.getRowsCssClass(0)).toEqual(['datagrid-row', 'ng-star-inserted']);
+                expect(this.clrGridWidget.getRow(0).classes()).toEqual(['datagrid-row', 'ng-star-inserted']);
             });
 
             it('sets CSS classnames on rows', function (this: HasFinderAndGrid): void {
                 const firstCall = ['firstRowA', 'secondRowA'];
                 const secondCall = ['firstRowB', 'secondRowB'];
-
-                this.finder.hostComponent.clrDatarowCssClassGetter = (rec: MockRecord, index: number) => {
+                this.hostComponent.clrDatarowCssClassGetter = (rec: MockRecord, index: number) => {
                     return firstCall[index];
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getRowsCssClass(0)).toContain(
+                expect(this.clrGridWidget.getRow(0).classes()).toContain(
                     'firstRowA',
                     'Expected the initial class to display for the first row.'
                 );
-                expect(this.clrGridWidget.getRowsCssClass(1)).toContain(
+                expect(this.clrGridWidget.getRow(1).classes()).toContain(
                     'secondRowA',
                     'Expected some different initial class to display for the second row.'
                 );
-
-                this.finder.hostComponent.clrDatarowCssClassGetter = (rec: MockRecord, index: number) => {
+                this.hostComponent.clrDatarowCssClassGetter = (rec: MockRecord, index: number) => {
                     return secondCall[index];
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getRowsCssClass(0)).toContain(
+                expect(this.clrGridWidget.getRow(0).classes()).toContain(
                     'firstRowB',
                     'Expected a new class to display for the first row.'
                 );
-                expect(this.clrGridWidget.getRowsCssClass(1)).toContain(
+                expect(this.clrGridWidget.getRow(1).classes()).toContain(
                     'secondRowB',
                     'Expected a different new class to display for the second row.'
                 );
@@ -155,7 +162,7 @@ describe('DatagridComponent', () => {
 
             describe('@Input() columns.disableCliptext', () => {
                 beforeEach(function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.gridData = {
+                    this.hostComponent.gridData = {
                         items: mockData,
                         totalItems: 2,
                     };
@@ -163,31 +170,34 @@ describe('DatagridComponent', () => {
                 });
 
                 it('clips text when disableCliptext is unset', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.columns = [{ displayName: 'Name', renderer: 'name' }];
+                    this.hostComponent.columns = [{ displayName: 'Name', renderer: 'name' }];
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.columnClippedTextDirective(0).disabled).toBeFalsy();
+                    const res = this.clrGridWidget.getCell(0, 0).elements[0].injector.get(ShowClippedTextDirective);
+                    expect(res.disabled).toBeFalsy();
                 });
 
                 it('clips text when disableCliptext is false', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.columns = [
+                    this.hostComponent.columns = [
                         { displayName: 'Name', renderer: 'name', cliptextConfig: { size: TooltipSize.md } },
                     ];
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.columnClippedTextDirective(0).disabled).toBeFalsy();
+                    const res = this.clrGridWidget.getCell(0, 0).elements[0].injector.get(ShowClippedTextDirective);
+                    expect(res.disabled).toBeFalsy();
                 });
 
                 it('does not clip text when disableCliptext is true', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.columns = [
+                    this.hostComponent.columns = [
                         { displayName: 'Name', renderer: 'name', cliptextConfig: { disabled: true } },
                     ];
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.columnClippedTextDirective(0).disabled).toBeTruthy();
+                    const res = this.clrGridWidget.getCell(0, 0).elements[0].injector.get(ShowClippedTextDirective);
+                    expect(res.disabled).toBeTruthy();
                 });
             });
 
             describe('@Input() columns.clrDgColumnClassName', () => {
                 beforeEach(function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.gridData = {
+                    this.hostComponent.gridData = {
                         items: mockData,
                         totalItems: 2,
                     };
@@ -195,154 +205,160 @@ describe('DatagridComponent', () => {
                 });
 
                 it('sets the width of the column to the given height', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.columns = [
+                    this.hostComponent.columns = [
                         { displayName: 'Name', renderer: 'name', clrDgColumnClassName: 'some-class' },
                         { displayName: 'Name', renderer: 'name' },
                     ];
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getColumnClasses(0)).toContain('some-class');
-                    expect(this.clrGridWidget.getColumnClasses(1)).not.toContain('some-class');
+                    expect(this.clrGridWidget.getColumn(0).classes()).toContain('some-class');
+                    expect(this.clrGridWidget.getColumn(1).classes()).not.toContain('some-class');
                 });
             });
 
             describe('@Input() selectionType', () => {
                 it('has multi selection capabilities when set to multi selection', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.selectionType = GridSelectionType.Multi;
+                    this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getSelectionType()).toBe(GridSelectionType.Multi);
+                    expect(this.clrGridWidget.getCheckboxWrapper().length()).toBeGreaterThan(0);
                 });
 
                 it('has single selection capabilities when set to single selection', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.selectionType = GridSelectionType.Single;
+                    this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getSelectionType()).toBe(GridSelectionType.Single);
+                    expect(this.clrGridWidget.getRadioWrapper().length()).toBeGreaterThan(0);
                 });
 
                 it('has none selection capabilities when set to none', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.selectionType = GridSelectionType.None;
+                    this.hostComponent.selectionType = GridSelectionType.None;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getSelectionType()).toBe(GridSelectionType.None);
+                    expect(this.clrGridWidget.getCheckboxWrapper().length()).toEqual(0);
+                    expect(this.clrGridWidget.getRadioWrapper().length()).toEqual(0);
                 });
             });
 
             describe('@Input() datagridSelection', () => {
-                it('emits multiple rows when set to multi selection', function(this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.selectionType = GridSelectionType.Multi;
+                it('emits multiple rows when set to multi selection', function (this: HasFinderAndGrid): void {
+                    this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
-                    this.clrGridWidget.selectRow(0);
-                    expect(this.finder.hostComponent.datagridSelection).toEqual([mockData[0]]);
-                    this.clrGridWidget.selectRow(1);
-                    expect(this.finder.hostComponent.datagridSelection).toEqual(mockData);
+                    this.clrGridWidget.getRowInput(0).click();
+                    expect(this.hostComponent.datagridSelection).toEqual([mockData[0]]);
+                    this.clrGridWidget.getRowInput(1).click();
+                    expect(this.hostComponent.datagridSelection).toEqual(mockData);
                 });
 
                 it('emits only one row when set to single selection', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.selectionType = GridSelectionType.Single;
+                    this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    this.clrGridWidget.selectRow(0);
-                    expect(this.finder.hostComponent.datagridSelection).toEqual([mockData[0]]);
-                    this.clrGridWidget.selectRow(1);
-                    expect(this.finder.hostComponent.datagridSelection).toEqual([mockData[1]]);
+                    this.clrGridWidget.getRowInput(0).click();
+                    expect(this.hostComponent.datagridSelection).toEqual([mockData[0]]);
+                    this.clrGridWidget.getRowInput(1).click();
+                    expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                 });
             });
 
             describe('@Output() selectionChanged', () => {
                 it('emits multiple rows when set to multi selection', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.selectionType = GridSelectionType.Multi;
+                    this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
-                    spyOn(this.finder.hostComponent, 'selectionChanged');
-                    this.clrGridWidget.selectRow(0);
-                    expect(this.finder.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
-                    this.clrGridWidget.selectRow(1);
-                    expect(this.finder.hostComponent.selectionChanged).toHaveBeenCalledWith(mockData);
+                    spyOn(this.hostComponent, 'selectionChanged');
+                    this.clrGridWidget.getRowInput(0).click();
+                    expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
+                    this.clrGridWidget.getRowInput(1).click();
+                    expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith(mockData);
                 });
 
                 it('emits only one row when set to single selection', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.selectionType = GridSelectionType.Single;
+                    this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    spyOn(this.finder.hostComponent, 'selectionChanged');
-                    this.clrGridWidget.selectRow(0);
-                    expect(this.finder.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
-                    this.clrGridWidget.selectRow(1);
-                    expect(this.finder.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[1]]);
+                    spyOn(this.hostComponent, 'selectionChanged');
+                    this.clrGridWidget.getRowInput(0).click();
+                    expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
+                    this.clrGridWidget.getRowInput(1).click();
+                    expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[1]]);
                 });
             });
 
             describe('@Input() gridData', () => {
                 describe('when data is refreshed removed a row selected a row if the row is removed', () => {
-                    it('in single selection', async function(this: HasFinderAndGrid): Promise<void> {
-                        this.finder.hostComponent.selectionType = GridSelectionType.Single;
-                        this.finder.hostComponent.gridData = {
+                    it('in single selection', fakeAsync(async function (this: HasFinderAndGrid): Promise<void> {
+                        this.hostComponent.selectionType = GridSelectionType.Single;
+                        this.hostComponent.gridData = {
                             items: mockData,
                             totalItems: 2,
                         };
                         this.finder.detectChanges();
-                        this.clrGridWidget.selectRow(1);
-                        expect(this.component.datagridSelection).toEqual([mockData[1]]);
-                        this.finder.hostComponent.gridData = {
+                        tick();
+                        this.clrGridWidget.getRowInput(1).click();
+                        tick();
+                        const component = this.vcdDatagrid.unwrap().elements[0]
+                            .componentInstance as MockRecordDatagridComponent;
+                        expect(component.datagridSelection).toEqual([mockData[1]]);
+                        this.hostComponent.gridData = {
                             items: [mockData[0]],
                             totalItems: 2,
                         };
                         this.finder.detectChanges();
-                        expect(this.component.datagridSelection).toEqual([]);
-                    });
+                        tick();
+                        expect(component.datagridSelection).toEqual([]);
+                    }));
 
-                    it('in multi selection', async function(this: HasFinderAndGrid): Promise<void> {
-                        this.finder.hostComponent.selectionType = GridSelectionType.Multi;
-                        this.finder.hostComponent.gridData = {
+                    it('in multi selection', async function (this: HasFinderAndGrid): Promise<void> {
+                        this.hostComponent.selectionType = GridSelectionType.Multi;
+                        this.hostComponent.gridData = {
                             items: mockData,
                             totalItems: 2,
                         };
                         this.finder.detectChanges();
-                        this.clrGridWidget.selectRow(0);
-                        this.clrGridWidget.selectRow(1);
-                        expect(this.finder.hostComponent.datagridSelection).toEqual(mockData);
-                        this.finder.hostComponent.gridData = {
+                        this.clrGridWidget.getRowInput(0).click();
+                        this.clrGridWidget.getRowInput(1).click();
+                        expect(this.hostComponent.datagridSelection).toEqual(mockData);
+                        this.hostComponent.gridData = {
                             items: [mockData[0]],
                             totalItems: 2,
                         };
                         this.finder.detectChanges();
-                        await new Promise(resolve => setTimeout(() => resolve()));
+                        await new Promise((resolve) => setTimeout(() => resolve()));
                         this.finder.detectChanges();
-                        expect(this.finder.hostComponent.datagridSelection).toEqual([mockData[0]]);
+                        expect(this.hostComponent.datagridSelection).toEqual([mockData[0]]);
                     });
                 });
 
                 it('keeps selected an item if the item is not removed on refresh', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.selectionType = GridSelectionType.Single;
+                    this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    this.clrGridWidget.selectRow(1);
-                    expect(this.finder.hostComponent.datagridSelection).toEqual([mockData[1]]);
-                    this.finder.hostComponent.gridData = {
+                    this.clrGridWidget.getRowInput(1).click();
+                    expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
+                    this.hostComponent.gridData = {
                         items: [mockData[1]],
                         totalItems: 2,
                     };
                     this.finder.detectChanges();
-                    expect(this.finder.hostComponent.datagridSelection).toEqual([mockData[1]]);
+                    expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                 });
 
-                it('allows you to initially select an item not on the current page', async function(this: HasFinderAndGrid): Promise<
+                it('allows you to initially select an item not on the current page', async function (this: HasFinderAndGrid): Promise<
                     void
                 > {
-                    this.finder.hostComponent.selectionType = GridSelectionType.Multi;
-                    this.finder.hostComponent.preserveSelection = true;
+                    this.hostComponent.selectionType = GridSelectionType.Multi;
+                    this.hostComponent.preserveSelection = true;
                     this.finder.detectChanges();
-                    this.finder.hostComponent.gridData = {
+                    this.hostComponent.gridData = {
                         items: [mockData[0]],
                         totalItems: 2,
                     };
                     this.finder.detectChanges();
-                    this.finder.hostComponent.datagridSelection = [{ name: mockData[1].name }];
+                    this.hostComponent.datagridSelection = [{ name: mockData[1].name }];
                     this.finder.detectChanges();
-                    expect(this.finder.hostComponent.datagridSelection).toEqual([{ name: mockData[1].name }]);
-                    this.finder.hostComponent.gridData = {
+                    expect(this.hostComponent.datagridSelection).toEqual([{ name: mockData[1].name }]);
+                    this.hostComponent.gridData = {
                         items: [mockData[1]],
                         totalItems: 2,
                     };
                     this.finder.detectChanges();
-                    await new Promise(resolve => setTimeout(() => resolve()));
+                    await new Promise((resolve) => setTimeout(() => resolve()));
                     this.finder.detectChanges();
-                    console.log(this.finder.hostComponent.datagridSelection);
-                    expect(this.finder.hostComponent.datagridSelection).toEqual([mockData[1]]);
+                    console.log(this.hostComponent.datagridSelection);
+                    expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                 });
             });
 
@@ -354,37 +370,40 @@ describe('DatagridComponent', () => {
                 describe('pageSize', () => {
                     it('can set the page size before AfterViewInit', function (this: HasFinderAndGrid): void {
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 5, totalItems: 150 },
                             ])
                         );
                     });
 
-                    it('finds the most rows that can fit in the set height with magic pagination', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.parentHeight = '2000px';
+                    it('finds the most rows that can fit in the set height with magic pagination', fakeAsync(function (
+                        this: HasFinderAndGrid
+                    ): void {
+                        this.hostComponent.parentHeight = '2000px';
                         this.finder.detectChanges();
-                        this.finder.hostComponent.pagination = {
+                        this.hostComponent.pagination = {
                             pageSize: 'Magic',
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                        tick();
+                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 52, totalItems: 150 },
                             ])
                         );
-                    });
+                    }));
 
                     it('shows a minimum of 15 rows', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.parentHeight = '200px';
+                        this.hostComponent.parentHeight = '200px';
                         this.finder.detectChanges();
-                        this.finder.hostComponent.pagination = {
+                        this.hostComponent.pagination = {
                             pageSize: 'Magic',
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 15, totalItems: 150 },
                             ])
@@ -392,43 +411,46 @@ describe('DatagridComponent', () => {
                     });
 
                     it('allows the user to set a custom row height with magic pagination ', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.parentHeight = '2000px';
+                        this.hostComponent.parentHeight = '2000px';
                         this.finder.detectChanges();
-                        this.finder.hostComponent.pagination = {
+                        this.hostComponent.pagination = {
                             pageSize: 'Magic',
                             pageSizeOptions: [10],
                             rowHeight: 100,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 19, totalItems: 150 },
                             ])
                         );
                     });
 
-                    it('uses grid height when height is set to calculate page size ', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.parentHeight = '2000px';
-                        this.finder.hostComponent.height = 1000;
-                        this.finder.hostComponent.pagination = {
+                    it('uses grid height when height is set to calculate page size ', fakeAsync(function (
+                        this: HasFinderAndGrid
+                    ): void {
+                        this.hostComponent.parentHeight = '2000px';
+                        this.hostComponent.height = 1000;
+                        this.hostComponent.pagination = {
                             pageSize: 'Magic',
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                        tick();
+                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 25, totalItems: 150 },
                             ])
                         );
-                    });
+                    }));
 
                     it('lets the user set rows per page', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.pagination = {
+                        this.hostComponent.pagination = {
                             pageSize: 100,
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 100, totalItems: 150 },
                             ])
@@ -436,8 +458,8 @@ describe('DatagridComponent', () => {
                     });
 
                     it('creates a smaller page when action buttons are present', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.parentHeight = '2000px';
-                        this.finder.hostComponent.actions = [
+                        this.hostComponent.parentHeight = '2000px';
+                        this.hostComponent.actions = [
                             {
                                 textKey: 'Add',
                                 availability: () => true,
@@ -445,14 +467,14 @@ describe('DatagridComponent', () => {
                                 actionType: ActionType.STATIC_FEATURED,
                             },
                         ];
-                        this.finder.hostComponent.contextualActionPosition = ContextualActionPosition.ROW;
+                        this.hostComponent.contextualActionPosition = ContextualActionPosition.ROW;
                         this.finder.detectChanges();
-                        this.finder.hostComponent.pagination = {
+                        this.hostComponent.pagination = {
                             pageSize: 'Magic',
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 51, totalItems: 150 },
                             ])
@@ -460,15 +482,15 @@ describe('DatagridComponent', () => {
                     });
 
                     it('creates a smaller page size when a header is present', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.parentHeight = '1990px';
-                        this.finder.hostComponent.header = 'Some Header';
+                        this.hostComponent.parentHeight = '1990px';
+                        this.hostComponent.header = 'Some Header';
                         this.finder.detectChanges();
-                        this.finder.hostComponent.pagination = {
+                        this.hostComponent.pagination = {
                             pageSize: 'Magic',
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 51, totalItems: 150 },
                             ])
@@ -478,70 +500,74 @@ describe('DatagridComponent', () => {
 
                 describe('pageSizeOptions', () => {
                     it('allows the user to input undefined', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.pagination = {
-                            ...this.finder.hostComponent.pagination,
+                        this.hostComponent.pagination = {
+                            ...this.hostComponent.pagination,
                             shouldShowPageSizeSelector: true,
                             pageSizeOptions: undefined,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationSizeSelectorText()).toEqual('Total Items5');
+                        expect(this.clrGridWidget.getPaginationSizeSelector().text()).toEqual('Total Items5');
                     });
                 });
 
                 describe('shouldShowPageSizeSelector', () => {
                     it('hides the dropdown when set to false', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.pagination = {
-                            ...this.finder.hostComponent.pagination,
+                        this.hostComponent.pagination = {
+                            ...this.hostComponent.pagination,
                             shouldShowPageSizeSelector: false,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationSizeSelectorText()).toEqual('');
+                        expect(this.clrGridWidget.getPaginationSizeSelector().length()).toEqual(0);
                     });
 
                     it('shows the dropdown when set to true', function (this: HasFinderAndGrid): void {
-                        this.finder.hostComponent.pagination = {
-                            ...this.finder.hostComponent.pagination,
+                        this.hostComponent.pagination = {
+                            ...this.hostComponent.pagination,
                             shouldShowPageSizeSelector: true,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationSizeSelectorText()).toEqual('Total Items52050100');
+                        expect(this.clrGridWidget.getPaginationSizeSelector().text()).toEqual('Total Items52050100');
                     });
                 });
             });
 
             describe('@Input() paginationDropdownText', () => {
                 it('displays the pagination dropdown information on page one', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.pagination = {
-                        ...this.finder.hostComponent.pagination,
+                    this.hostComponent.pagination = {
+                        ...this.hostComponent.pagination,
                         shouldShowPageSizeSelector: true,
                     };
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getPaginationSizeSelectorText()).toEqual('Total Items52050100');
+                    expect(this.clrGridWidget.getPaginationSizeSelector().text()).toEqual('Total Items52050100');
                 });
             });
 
             describe('@Input() height', () => {
+                function getGridHeight(element: TestElement): string {
+                    return element.elements[0].nativeElement.style.getPropertyValue('--datagrid-height');
+                }
+
                 it('defaults to parent height when height is not set', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.height = undefined;
+                    this.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.gridContainerClasses).toContain('fill-parent');
-                    expect(this.clrGridWidget.gridHeight).toEqual('unset');
+                    expect(this.clrGridWidget.unwrap().parent().classes()).toContain('fill-parent');
+                    expect(getGridHeight(this.clrGridWidget.unwrap().parent())).toEqual('unset');
                 });
 
                 it('uses the given height when height is set', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.height = 200;
+                    this.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.gridHeight).toEqual('200px');
+                    expect(getGridHeight(this.clrGridWidget.unwrap().parent())).toEqual('200px');
                 });
 
                 it('allows the height to be dynamically changed', function (this: HasFinderAndGrid): void {
-                    this.finder.hostComponent.height = 200;
+                    this.hostComponent.height = 200;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.gridHeight).toEqual('200px');
-                    this.finder.hostComponent.height = undefined;
+                    expect(getGridHeight(this.clrGridWidget.unwrap().parent())).toEqual('200px');
+                    this.hostComponent.height = undefined;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.gridContainerClasses).toContain('fill-parent');
-                    expect(this.clrGridWidget.gridHeight).toEqual('unset');
+                    expect(this.clrGridWidget.unwrap().parent().classes()).toContain('fill-parent');
+                    expect(getGridHeight(this.clrGridWidget.unwrap().parent())).toEqual('unset');
                 });
             });
         });
@@ -549,52 +575,59 @@ describe('DatagridComponent', () => {
         describe('@Input() emptyGridPlaceholder', () => {
             it('does not show the placeholder while the grid is loading', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.loading).toBeTruthy();
-                expect(this.clrGridWidget.placeholder).toEqual('');
+                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeTruthy();
+                expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('');
             });
 
             it('shows the placeholder if the grid is empty', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.loading).toBeTruthy();
-                this.finder.hostComponent.gridData = {
+                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeTruthy();
+                this.hostComponent.gridData = {
                     items: [],
                     totalItems: 0,
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.loading).toBeFalsy();
-                expect(this.clrGridWidget.placeholder).toEqual('Placeholder');
+                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeFalsy();
+                expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('Placeholder');
             });
 
             it('does not show the placeholder if the grid has data', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.loading).toBeTruthy();
-                this.finder.hostComponent.gridData = {
+                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeTruthy();
+                this.hostComponent.gridData = {
                     items: mockData,
                     totalItems: 2,
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.loading).toBeFalsy();
-                expect(this.clrGridWidget.placeholder).toEqual('');
+                expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBeFalsy();
+                expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('');
             });
         });
 
         it('displays loading indicators while data is loading', function (this: HasFinderAndGrid): void {
             this.finder.detectChanges();
-            expect(this.clrGridWidget.loading).toBe(true, 'Initially loading indicator should be true');
-            this.finder.hostComponent.gridData = {
+            expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBe(
+                true,
+                'Initially loading indicator should be true'
+            );
+            this.hostComponent.gridData = {
                 items: mockData,
                 totalItems: 2,
             };
             this.finder.detectChanges();
-            expect(this.clrGridWidget.loading).toBe(
+            expect(this.clrGridWidget.unwrap().elements[0].componentInstance.loading).toBe(
                 false,
                 'After setting gridData, loading indicator should not be visible'
             );
         });
 
         describe('Show/Hide Functionality', () => {
+            function isColumnDisplayed(element: TestElement): boolean {
+                return element.elements[0].classes['datagrid-hidden-column'] !== true;
+            }
+
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Component Renderer',
                         renderer: ColumnComponentRendererSpec({
@@ -626,67 +659,72 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
             it('shows the columns with hidable value of  "Never"', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.isColumnDisplayed(0)).toBe(true);
+                expect(isColumnDisplayed(this.clrGridWidget.getColumn(0))).toBe(true);
             });
 
             it('shows the columns with hidable value of  "Shown"', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.isColumnDisplayed(1)).toBe(true);
+                expect(isColumnDisplayed(this.clrGridWidget.getColumn(1))).toBe(true);
             });
 
             it('hides the columns with hidable value of  "Hidden"', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.isColumnDisplayed(2)).toBe(false);
-                expect(this.clrGridWidget.hiddenColumnHeaders).toEqual(['Default Renderer']);
+                expect(isColumnDisplayed(this.clrGridWidget.getColumn(2))).toBe(false);
+                expect(
+                    this.clrGridWidget
+                        .getHiddenColumnHeaders()
+                        .toArray()
+                        .map((header: TestElement) => header.text())
+                ).toEqual(['Default Renderer']);
             });
 
             it('shows the columns with hidable value of undefined', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.isColumnDisplayed(3)).toBe(true);
+                expect(isColumnDisplayed(this.clrGridWidget.getColumn(3))).toBe(true);
             });
         });
 
         describe('@Input() detailComponent', () => {
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Column',
                         renderer: 'name',
                     },
                 ];
-                this.finder.hostComponent.detailPane = undefined;
+                this.hostComponent.detailPane = undefined;
                 this.finder.detectChanges();
             });
 
-            it('opens one detail pane when you click the button', function (this: HasFinderAndGrid): void {
-                this.clrGridWidget.clickDetailRowButton(0);
-                expect(this.clrGridWidget.getAllDetailRowContents().length).toEqual(1);
-            });
+            it('opens one detail pane when you click the button', fakeAsync(function (this: HasFinderAndGrid): void {
+                this.clrGridWidget.getDetailRowButtons().toArray()[0].click();
+                expect(this.clrGridWidget.getDetailRows().length()).toEqual(1);
+            }));
         });
 
         describe('@Input() isRowExpanded', () => {
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Column',
                         renderer: 'name',
                     },
                 ];
-                this.finder.hostComponent.detailPane = undefined;
+                this.hostComponent.detailPane = undefined;
                 this.finder.detectChanges();
             });
 
             it('does NOT expand row when false', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.getAllDetailRowContents().length).toEqual(0);
+                expect(this.clrGridWidget.getDetailRows().length()).toEqual(0);
             });
 
             it('expands row when true', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.isRowExpanded = true;
+                this.hostComponent.isRowExpanded = true;
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getAllDetailRowContents().length).toEqual(2);
+                expect(this.clrGridWidget.getDetailRows().length()).toEqual(2);
             });
         });
 
         describe('@Input() detailPane', () => {
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Column',
                         renderer: 'name',
@@ -696,26 +734,26 @@ describe('DatagridComponent', () => {
             });
 
             it('opens one detail pane when you click the button', function (this: HasFinderAndGrid): void {
-                this.clrGridWidget.clickDetailPaneButton(0);
+                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getAllDetailPaneContents().length).toEqual(1);
-                expect(this.clrGridWidget.getDetailPaneHeader()).toEqual('Palo Alto');
+                expect(this.clrGridWidget.getDetailPanes().length()).toEqual(1);
+                expect(this.clrGridWidget.getDetailPaneHeader().text()).toEqual('Palo Alto');
             });
 
             it('gives the same config when called with the same arguments', function (this: HasFinderAndGrid): void {
-                this.clrGridWidget.clickDetailPaneButton(0);
+                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
                 this.finder.detectChanges();
-                expect(this.finder.hostComponent.grid.getDetailPaneRenderSpec(mockData[0])).toEqual(
-                    this.finder.hostComponent.grid.getDetailPaneRenderSpec(mockData[0])
+                expect(this.hostComponent.grid.getDetailPaneRenderSpec(mockData[0])).toEqual(
+                    this.hostComponent.grid.getDetailPaneRenderSpec(mockData[0])
                 );
             });
 
             it('updates the detail pane when the record changes', function (this: HasFinderAndGrid): void {
-                this.clrGridWidget.clickDetailPaneButton(0);
+                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getAllDetailPaneContents().length).toEqual(1);
-                expect(this.clrGridWidget.getDetailPaneHeader()).toEqual('Palo Alto');
-                this.finder.hostComponent.gridData = {
+                expect(this.clrGridWidget.getDetailPanes().length()).toEqual(1);
+                expect(this.clrGridWidget.getDetailPaneHeader().text()).toEqual('Palo Alto');
+                this.hostComponent.gridData = {
                     items: [
                         {
                             ...mockData[0],
@@ -725,14 +763,14 @@ describe('DatagridComponent', () => {
                     totalItems: 2,
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getAllDetailPaneContents().length).toEqual(1);
-                expect(this.clrGridWidget.getDetailPaneHeader()).toEqual('NEW');
+                expect(this.clrGridWidget.getDetailPanes().length()).toEqual(1);
+                expect(this.clrGridWidget.getDetailPaneHeader().text()).toEqual('NEW');
             });
         });
 
         describe('getRowLoadingListenerInjector()', () => {
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Column',
                         renderer: 'name',
@@ -744,7 +782,7 @@ describe('DatagridComponent', () => {
 
         describe('@Output() refresh', () => {
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Column',
                         renderer: 'name',
@@ -759,8 +797,8 @@ describe('DatagridComponent', () => {
             });
 
             it('emits the column information when the column sorted', function (this: HasFinderAndGrid): void {
-                const refreshMethod = spyOn(this.finder.hostComponent, 'refresh');
-                this.clrGridWidget.sortColumn(0);
+                const refreshMethod = spyOn(this.hostComponent, 'refresh');
+                this.clrGridWidget.getColumnHeader(0).click();
                 expect(refreshMethod).toHaveBeenCalledWith({
                     sortColumn: {
                         name: 'a',
@@ -768,7 +806,7 @@ describe('DatagridComponent', () => {
                     },
                     pagination: { pageNumber: 1, itemsPerPage: 5 },
                 });
-                this.clrGridWidget.sortColumn(0);
+                this.clrGridWidget.getColumnHeader(0).click();
                 expect(refreshMethod).toHaveBeenCalledWith({
                     sortColumn: {
                         name: 'a',
@@ -779,14 +817,14 @@ describe('DatagridComponent', () => {
             });
 
             it('does not sort a column without a queryFieldName', function (this: HasFinderAndGrid): void {
-                const refreshMethod = spyOn(this.finder.hostComponent, 'refresh');
-                this.clrGridWidget.sortColumn(1);
+                const refreshMethod = spyOn(this.hostComponent, 'refresh');
+                this.clrGridWidget.getColumnHeader(1).click();
                 expect(refreshMethod).toHaveBeenCalledTimes(0);
             });
 
             it('allows the user to change pages', function (this: HasFinderAndGrid): void {
-                const refreshMethod = spyOn(this.finder.hostComponent, 'refresh');
-                this.clrGridWidget.nextPage();
+                const refreshMethod = spyOn(this.hostComponent, 'refresh');
+                this.clrGridWidget.getNextButton().click();
                 expect(refreshMethod).toHaveBeenCalledWith({
                     pagination: {
                         pageNumber: 2,
@@ -796,9 +834,9 @@ describe('DatagridComponent', () => {
             });
 
             it('goes to page 1 when sorting is clicked', function (this: HasFinderAndGrid): void {
-                const refreshMethod = spyOn(this.finder.hostComponent, 'refresh');
-                this.clrGridWidget.nextPage();
-                this.clrGridWidget.sortColumn(0);
+                const refreshMethod = spyOn(this.hostComponent, 'refresh');
+                this.clrGridWidget.getNextButton().click();
+                this.clrGridWidget.getColumnHeader(0).click();
                 expect(refreshMethod).toHaveBeenCalledWith({
                     pagination: { pageNumber: 1, itemsPerPage: 5 },
                     sortColumn: { name: 'a', reverse: false },
@@ -813,8 +851,8 @@ describe('DatagridComponent', () => {
                 function (this: HasFinderAndGrid): void {
                     const actionHandlerWithoutPromise: ActionHandlerType<any, any> = () => null;
                     const actionHandlerThatReturnsPromise: ActionHandlerType<any, any> = () => new Promise(() => null);
-                    this.finder.hostComponent.indicatorType = ActivityIndicatorType.BANNER;
-                    this.finder.hostComponent.actions = [
+                    this.hostComponent.indicatorType = ActivityIndicatorType.BANNER;
+                    this.hostComponent.actions = [
                         {
                             textKey: 'ActionThatDoesNotReturnPromise',
                             handler: actionHandlerWithoutPromise,
@@ -836,13 +874,13 @@ describe('DatagridComponent', () => {
             );
 
             it('does not change what trackBy is used', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.gridData = {
+                this.hostComponent.gridData = {
                     items: mockData,
                     totalItems: 2,
                 };
                 this.finder.detectChanges();
 
-                this.finder.hostComponent.actions = [
+                this.hostComponent.actions = [
                     {
                         textKey: 'static.action',
                         handler: () => null,
@@ -852,15 +890,15 @@ describe('DatagridComponent', () => {
                 ];
                 this.finder.detectChanges();
 
-                console.log(this.finder.hostComponent.getGridTrackBy().toString());
+                console.log(this.hostComponent.getGridTrackBy().toString());
 
-                expect(this.finder.hostComponent.getGridTrackBy()(0, mockData[0])).toEqual(mockData[0].name);
+                expect(this.hostComponent.getGridTrackBy()(0, mockData[0])).toEqual(mockData[0].name);
             });
         });
 
         describe('shouldShowActionBarOnTop', () => {
             it('returns true when there are static actions', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.actions = [
+                this.hostComponent.actions = [
                     {
                         textKey: 'static.action',
                         handler: () => null,
@@ -871,15 +909,15 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
                 expect(this.component.shouldShowActionBarOnTop).toBeTruthy();
             });
-            it('returns true when there are contextual actions to be displayed on top', function(this: HasFinderAndGrid): void {
-                this.finder.hostComponent.gridData = {
+            it('returns true when there are contextual actions to be displayed on top', function (this: HasFinderAndGrid): void {
+                this.hostComponent.gridData = {
                     items: mockData,
                     totalItems: 2,
                 };
                 this.finder.detectChanges();
-                this.finder.hostComponent.selectionType = GridSelectionType.Single;
-                this.finder.hostComponent.contextualActionPosition = ContextualActionPosition.TOP;
-                this.finder.hostComponent.actions = [
+                this.hostComponent.selectionType = GridSelectionType.Single;
+                this.hostComponent.contextualActionPosition = ContextualActionPosition.TOP;
+                this.hostComponent.actions = [
                     {
                         textKey: 'contextual.action',
                         handler: () => null,
@@ -889,7 +927,7 @@ describe('DatagridComponent', () => {
                 ];
                 this.finder.detectChanges();
                 // This is because contextual actions requires entities to be selected
-                this.clrGridWidget.selectRow(0);
+                this.clrGridWidget.getRowInput(0).click();
                 this.finder.detectChanges();
                 expect(this.component.shouldShowActionBarOnTop).toBeTruthy();
             });
@@ -897,31 +935,32 @@ describe('DatagridComponent', () => {
 
         describe('@Input() header', () => {
             it('shows the header if set and allows it to be changed', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.header = 'Some Header!';
+                this.hostComponent.header = 'Some Header!';
                 this.finder.detectChanges();
-                expect(this.vcdDatagrid.gridHeader).toEqual('Some Header!');
-                this.finder.hostComponent.header = 'Some Other Header!';
+                expect(this.vcdDatagrid.getHeader().text()).toEqual('Some Header!');
+                this.hostComponent.header = 'Some Other Header!';
                 this.finder.detectChanges();
-                expect(this.vcdDatagrid.gridHeader).toEqual('Some Other Header!');
+                expect(this.vcdDatagrid.getHeader().text()).toEqual('Some Other Header!');
             });
 
             it('does not show a header when none is set', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.header = undefined;
+                this.hostComponent.header = undefined;
                 this.finder.detectChanges();
-                expect(this.vcdDatagrid.gridHeader).toEqual('');
+                expect(this.vcdDatagrid.getHeader().length()).toEqual(0);
             });
         });
 
         describe('GridColumn', () => {
             it('enables only sorting when queryFieldName is given but no filter is provided', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [{ displayName: 'Name', renderer: 'name', queryFieldName: 'name' }];
+                this.hostComponent.columns = [{ displayName: 'Name', renderer: 'name', queryFieldName: 'name' }];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.component.columns.first.sortable).toEqual(true);
-                expect(this.clrGridWidget.component.columns.first.customFilter).toEqual(false);
+                const el = this.clrGridWidget.unwrap().elements[0].componentInstance;
+                expect(el.columns.first.sortable).toEqual(true);
+                expect(el.columns.first.customFilter).toEqual(false);
             });
             // tslint:disable-next-line:max-line-length
             it('enables only filtering when queryFieldName, filter are provided and sortable is set to false', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Name',
                         renderer: 'name',
@@ -931,12 +970,13 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.component.columns.first.sortable).toEqual(false);
-                expect(this.clrGridWidget.component.columns.first.customFilter).toEqual(true);
+                const el = this.clrGridWidget.unwrap().elements[0].componentInstance;
+                expect(el.columns.first.sortable).toEqual(false);
+                expect(el.columns.first.customFilter).toEqual(true);
             });
             // tslint:disable-next-line:max-line-length
             it('enables both filtering and sorting when queryFieldName, filter are provided and sortable is not set to false', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Name',
                         renderer: 'name',
@@ -945,16 +985,17 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.component.columns.first.sortable).toEqual(true);
-                expect(this.clrGridWidget.component.columns.first.customFilter).toEqual(true);
+                const el = this.clrGridWidget.unwrap().elements[0].componentInstance;
+                expect(el.columns.first.sortable).toEqual(true);
+                expect(el.columns.first.customFilter).toEqual(true);
             });
         });
 
         describe('columnsUpdated event', () => {
             it('is fired when columns is set', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                const spy = spyOn(this.finder.hostComponent.grid.columnsUpdated, 'emit').and.callThrough();
-                this.finder.hostComponent.columns = [
+                const spy = spyOn(this.hostComponent.grid.columnsUpdated, 'emit').and.callThrough();
+                this.hostComponent.columns = [
                     {
                         displayName: 'Column',
                         renderer: 'name',
@@ -965,14 +1006,14 @@ describe('DatagridComponent', () => {
             });
             it('is not fired when addColumn or removeColumn is called', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                const spy = spyOn(this.finder.hostComponent.grid.columnsUpdated, 'emit').and.callThrough();
-                this.finder.hostComponent.grid.addColumn({
+                const spy = spyOn(this.hostComponent.grid.columnsUpdated, 'emit').and.callThrough();
+                this.hostComponent.grid.addColumn({
                     displayName: 'Column2',
                     renderer: 'name2',
                 });
                 this.finder.detectChanges();
                 expect(spy).not.toHaveBeenCalled();
-                this.finder.hostComponent.grid.removeColumn({
+                this.hostComponent.grid.removeColumn({
                     displayName: 'Column2',
                     renderer: 'name2',
                 });
@@ -983,7 +1024,7 @@ describe('DatagridComponent', () => {
 
         describe('addColumn', () => {
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Column',
                         renderer: 'name',
@@ -992,32 +1033,32 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
             it('adds the passed in column to list of existing grid columns', function (this: HasFinderAndGrid): void {
-                expect(this.finder.hostComponent.grid.columns.length).toBe(1);
-                this.finder.hostComponent.grid.addColumn({
+                expect(this.hostComponent.grid.columns.length).toBe(1);
+                this.hostComponent.grid.addColumn({
                     displayName: 'Column2',
                     renderer: 'name2',
                 });
                 this.finder.detectChanges();
-                expect(this.finder.hostComponent.grid.columns.length).toBe(2);
-                expect(this.finder.hostComponent.grid.columns[1].displayName).toBe('Column2');
+                expect(this.hostComponent.grid.columns.length).toBe(2);
+                expect(this.hostComponent.grid.columns[1].displayName).toBe('Column2');
             });
             it(
                 'updates a existing column if a column exists with same display name as the column passed ' + 'in',
                 function (this: HasFinderAndGrid): void {
-                    expect(this.finder.hostComponent.grid.columns[0].renderer).toBe('name');
-                    this.finder.hostComponent.grid.addColumn({
+                    expect(this.hostComponent.grid.columns[0].renderer).toBe('name');
+                    this.hostComponent.grid.addColumn({
                         displayName: 'Column',
                         renderer: 'updated-name',
                     });
                     this.finder.detectChanges();
-                    expect(this.finder.hostComponent.grid.columns[0].renderer).toBe('updated-name');
+                    expect(this.hostComponent.grid.columns[0].renderer).toBe('updated-name');
                 }
             );
         });
 
         describe('removeColumn', () => {
             beforeEach(function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Column',
                         renderer: 'name',
@@ -1026,24 +1067,24 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
             it('removes the column from list of existing grid columns', function (this: HasFinderAndGrid): void {
-                expect(this.finder.hostComponent.grid.columns.length).toBe(1);
-                this.finder.hostComponent.grid.removeColumn({
+                expect(this.hostComponent.grid.columns.length).toBe(1);
+                this.hostComponent.grid.removeColumn({
                     displayName: 'Column',
                     renderer: 'name',
                 });
                 this.finder.detectChanges();
-                expect(this.finder.hostComponent.grid.columns.length).toBe(0);
+                expect(this.hostComponent.grid.columns.length).toBe(0);
             });
             it(
                 'does not do anything if there is no column with same display name as the column passed ' + 'in',
                 function (this: HasFinderAndGrid): void {
-                    expect(this.finder.hostComponent.grid.columns.length).toBe(1);
-                    this.finder.hostComponent.grid.removeColumn({
+                    expect(this.hostComponent.grid.columns.length).toBe(1);
+                    this.hostComponent.grid.removeColumn({
                         displayName: 'Non-existing-Column',
                         renderer: 'name',
                     });
                     this.finder.detectChanges();
-                    expect(this.finder.hostComponent.grid.columns.length).toBe(1);
+                    expect(this.hostComponent.grid.columns.length).toBe(1);
                 }
             );
         });
@@ -1070,29 +1111,34 @@ describe('DatagridComponent', () => {
     describe('Column Renderers', () => {
         describe('Default renderer', () => {
             it('uses property path from  "renderer" property of column config ', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [{ displayName: '', renderer: 'details.gender' }];
+                this.hostComponent.columns = [{ displayName: '', renderer: 'details.gender' }];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getCellText(0, 0)).toEqual(mockData[0].details.gender);
-                expect(this.clrGridWidget.getRowValues(0)).toEqual([mockData[0].details.gender]);
+                expect(this.clrGridWidget.getCell(0, 0).text()).toEqual(mockData[0].details.gender);
+                expect(
+                    this.clrGridWidget
+                        .getRowCell(0)
+                        .toArray()
+                        .map((cell: TestElement) => cell.text())
+                ).toEqual([mockData[0].details.gender]);
             });
         });
 
         describe('Function renderer', () => {
             it('renders the string returned from the renderer function', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Function Renderer',
                         renderer: (record) => `${record.city}, ${record.state}`,
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getCellText(0, 0)).toEqual(`${mockData[0].city}, ${mockData[0].state}`);
+                expect(this.clrGridWidget.getCell(0, 0).text()).toEqual(`${mockData[0].city}, ${mockData[0].state}`);
             });
         });
 
         describe('Component renderer', () => {
             it('renders the passed in component using config from RendererSpec', function (this: HasFinderAndGrid): void {
-                this.finder.hostComponent.columns = [
+                this.hostComponent.columns = [
                     {
                         displayName: 'Component Renderer',
                         renderer: ColumnComponentRendererSpec({
@@ -1104,7 +1150,7 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.vcdDatagrid.getBoldText(0, 0)).toBe(mockData[0].name);
+                expect(this.clrGridWidget.getCellStrong(0, 0).text()).toBe(mockData[0].name);
             });
         });
     });

--- a/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.spec.ts
+++ b/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.spec.ts
@@ -8,7 +8,7 @@ import {
     createDatagridFilterTestHelperWithFinder,
     FilterTestHostComponent,
 } from '../../utils/test/datagrid/filter-utils';
-import { WidgetFinder } from '../../utils/test/widget-object';
+import { AngularWidgetObjectFinder } from '../../utils/test/widget-object/angular-widget-finder';
 import { Bytes } from '../../utils/unit/unit';
 import { DatagridFilter } from './datagrid-filter';
 import {
@@ -22,7 +22,7 @@ interface HasDgNumericFilter {
 }
 
 interface HasFinderAndFilter {
-    finder: WidgetFinder;
+    finder: AngularWidgetObjectFinder;
     filter: DatagridFilter<[number, number], DatagridNumericFilterConfig>;
 }
 

--- a/projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts
+++ b/projects/components/src/datagrid/renderers/bold-text-renderer.wo.ts
@@ -3,23 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Type } from '@angular/core';
-import { VcdDatagridWidgetObject } from '../../utils/test/datagrid/vcd-datagrid.wo';
 import { WidgetObject } from '../../utils/test/widget-object';
 import { BoldTextRendererComponent } from './bold-text-renderer.component';
-
-/**
- * Mixin that allows {@link ClrDatagridWidgetObject} to read information from {@link BoldTextRendererComponent}
- */
-// tslint:disable-next-line:typedef
-export function WithGridBoldRenderer<TBase extends Type<VcdDatagridWidgetObject<unknown>>>(Base: TBase) {
-    return class extends Base {
-        getBoldText(row: number, column: number): string {
-            const cellElement = this.clrDatagrid.getCell(row, column);
-            return this.getNodeText(this.findElement('strong', cellElement));
-        }
-    };
-}
 
 /**
  * Widget Object for the bold text renderer.

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -26,38 +26,99 @@ const Css = {
     RADIO_WRAPPER: 'clr-radio-wrapper',
     FILTER: 'clr-dg-filter',
     FILTER_TOGGLE: '.datagrid-filter-toggle',
+    SPINNER: 'clr-spinner',
 };
 
 /**
  * Widget Object for a Clarity DataGrid
  */
 export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
-    static tagName = `clr-datagrid`;
+    static tagName = 'clr-datagrid';
 
     /**
      * Gives the placeholder present on the datagrid
      */
-    getPlaceHolder = this.locatorForChild(Css.PLACEHOLDER);
+    getPlaceHolder = this.locatorForCssSelectors(Css.PLACEHOLDER);
 
     /**
      * The header of the detail pane
      */
-    getDetailPaneHeader = this.locatorForChild(Css.DETAIL_PANE_HEADER);
+    getDetailPaneHeader = this.locatorForCssSelectors(Css.DETAIL_PANE_HEADER);
 
     /**
      * Gives the pagination description text
      */
-    getPaginationDescription = this.locatorForChild(Css.PAGINATION_DESCRIPTION);
+    getPaginationDescription = this.locatorForCssSelectors(Css.PAGINATION_DESCRIPTION);
 
     /**
      * Gives the text next to the pagination selector
      */
-    getPaginationSizeSelector = this.locatorForChild(Css.PAGE_SIZE);
+    getPaginationSizeSelector = this.locatorForCssSelectors(Css.PAGE_SIZE);
 
     /**
      * Returns the next page button
      */
-    getNextButton = this.locatorForChild(Css.PAGINATION_NEXT);
+    getNextButton = this.locatorForCssSelectors(Css.PAGINATION_NEXT);
+
+    /**
+     * Returns all the rows
+     */
+    getRows = this.locatorForCssSelectors(Css.ROW);
+
+    /**
+     * Returns all the columns
+     */
+    getColumns = this.locatorForCssSelectors(Css.COLUMN);
+
+    /**
+     * Returns an array of headers
+     */
+    getColumnHeaders = this.locatorForCssSelectors(Css.COLUMN_TITLE);
+
+    /**
+     * Returns an array of columns that are hidden
+     */
+    getHiddenColumnHeaders = this.locatorForCssSelectors(Css.HIDDEN_COLUMN);
+
+    /**
+     * Returns the elements within all the detail pane open
+     */
+    getDetailRows = this.locatorForCssSelectors(Css.DETAIL_ROW);
+
+    /**
+     * Returns the elements within all the detail pane open
+     */
+    getDetailPanes = this.locatorForCssSelectors(Css.DETAIL_PANE);
+
+    /**
+     * Returns all the detail buttons
+     */
+    getDetailRowButtons = this.locatorForCssSelectors(Css.DETAIL_ROW_BUTTON);
+
+    /**
+     * Returns all the detail pane buttons
+     */
+    getDetailPaneButtons = this.locatorForCssSelectors(Css.DETAIL_PANE_BUTTON);
+
+    /**
+     * Gives a list of displayed action buttons at the top of the grid
+     */
+    getTopPositionedButtons = this.locatorForCssSelectors(Css.TOP_POSITIONED_BUTTON);
+
+    /**
+     * Find a clr-checkbox-wrapper
+     */
+    getCheckboxWrapper = this.locatorForCssSelectors(Css.CHECKBOX_WRAPPER);
+
+    /**
+     * Find a clr-radio-wrapper
+     */
+    getRadioWrapper = this.locatorForCssSelectors(Css.RADIO_WRAPPER);
+
+    /**
+     * Find a clr-spinner element
+     */
+    getSpinner = this.locatorForCssSelectors(Css.SPINNER);
 
     /**
      * Helper function to retrieve a row
@@ -91,7 +152,7 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * @param col 0-based index of column
      */
     getCellLink(row: number, col: number): T {
-        return this._getCell(row, col).get(`a`).unwrap();
+        return this._getCell(row, col).get('a').unwrap();
     }
 
     /**
@@ -104,13 +165,6 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     }
 
     /**
-     * Returns all the rows
-     */
-    getRows(): T {
-        return this.locatorDriver.get(Css.ROW).unwrap();
-    }
-
-    /**
      * Return a row by index
      * @param row 0-based index of row
      */
@@ -119,18 +173,12 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     }
 
     /**
-     * Returns all the columns
-     */
-    getColumns(): T {
-        return this.locatorDriver.get(Css.COLUMN).unwrap();
-    }
-
-    /**
      * Return a column by index
      * @param col 0-based index of column
      */
     getColumn(col: number): T {
-        return this.locatorDriver.get(`${Css.COLUMN}:nth-of-type(${col + 1})`).unwrap();
+        // return this.locatorDriver.get(`${Css.COLUMN}:nth-of-type(${col + 1})`).unwrap();
+        return this.locatorForCssSelectors(`${Css.COLUMN}:nth-of-type(${col + 1})`)();
     }
 
     /**
@@ -138,7 +186,7 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * @param row 0-based index of row
      */
     getRowInput(row: number): T {
-        return this._getRow(row).get(`input`).unwrap();
+        return this._getRow(row).get('input').unwrap();
     }
 
     /**
@@ -153,7 +201,8 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * Returns the button on the top of the grid with the given buttonClass
      */
     getTopButton(btnClass: string): T {
-        return this.locatorDriver.get(`button.${btnClass}`).unwrap();
+        // return this.locatorDriver.get(`button.${btnClass}`).unwrap();
+        return this.locatorForCssSelectors(`button.${btnClass}`)();
     }
 
     /**
@@ -164,60 +213,12 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     }
 
     /**
-     * Returns an array of headers
-     */
-    getColumnHeaders(): T {
-        return this.locatorDriver.get(Css.COLUMN_TITLE).unwrap();
-    }
-
-    /**
      * Returns a header
      * @param col 0-based index of header
      */
     getColumnHeader(col: number): T {
-        return this.locatorDriver.get(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`).unwrap();
-    }
-
-    /**
-     * Returns an array of columns that are hidden
-     */
-    getHiddenColumnHeaders(): T {
-        return this.locatorDriver.get(Css.HIDDEN_COLUMN).unwrap();
-    }
-
-    /**
-     * Returns the elements within all the detail pane open
-     */
-    getDetailRows(): T {
-        return this.locatorDriver.get(Css.DETAIL_ROW).unwrap();
-    }
-
-    /**
-     * Returns the elements within all the detail pane open
-     */
-    getDetailPanes(): T {
-        return this.locatorDriver.get(Css.DETAIL_PANE).unwrap();
-    }
-
-    /**
-     * Returns all the detail buttons
-     */
-    getDetailRowButtons(): T {
-        return this.locatorDriver.get(Css.DETAIL_ROW_BUTTON).unwrap();
-    }
-
-    /**
-     * Returns all the detail pane buttons
-     */
-    getDetailPaneButtons(): T {
-        return this.locatorDriver.get(Css.DETAIL_PANE_BUTTON).unwrap();
-    }
-
-    /**
-     * Gives a list of displayed action buttons at the top of the grid
-     */
-    getTopPositionedButtons(): T {
-        return this.locatorDriver.get(Css.TOP_POSITIONED_BUTTON).unwrap();
+        // return this.locatorDriver.get(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`).unwrap();
+        return this.locatorForCssSelectors(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`)();
     }
 
     /**
@@ -235,24 +236,7 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
         return this.locatorDriver.get(Css.COLUMN).get(Css.FILTER).get(Css.FILTER_TOGGLE).unwrap();
     }
 
-    /**
-     * Find a clr-checkbox-wrapper
-     */
-    getCheckboxWrapper(): T {
-        return this.locatorDriver.get(Css.CHECKBOX_WRAPPER).unwrap();
-    }
-
-    /**
-     * Find a clr-radio-wrapper
-     */
-    getRadioWrapper(): T {
-        return this.locatorDriver.get(Css.RADIO_WRAPPER).unwrap();
-    }
-
-    /**
-     * Unwrap the clr-datagrid
-     */
-    unwrap(): T {
+    get component(): T {
         return this.locatorDriver.unwrap();
     }
 }

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -236,7 +236,7 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
         return this.locatorDriver.get(Css.COLUMN).get(Css.FILTER).get(Css.FILTER_TOGGLE).unwrap();
     }
 
-    get component(): T {
+    get clrDatagrid(): T {
         return this.locatorDriver.unwrap();
     }
 }

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -3,343 +3,256 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { GridSelectionType } from './../../../datagrid/datagrid.component';
+import { BaseWidgetObject, LocatorDriver } from '../widget-object/widget-object';
 
-import { DebugElement, Type } from '@angular/core';
-import { By } from '@angular/platform-browser';
-import { ClrDatagrid } from '@clr/angular';
-import { DatagridFilter } from '../../../datagrid/filters/datagrid-filter';
-import { ShowClippedTextDirective } from '../../../lib/directives/show-clipped-text.directive';
-import { WidgetObject } from '../widget-object';
-
-const ROW_TAG = 'clr-dg-row';
-const CELL_TAG = 'clr-dg-cell';
-const COLUMN_SELECTOR = 'clr-dg-column';
-const COLUMN_CSS_SELECTOR = '.datagrid-column-title';
-const FILTER_SELECTOR = 'clr-dg-filter';
+const Css = {
+    ROW: 'clr-dg-row',
+    COLUMN: 'clr-dg-column',
+    CELL: 'clr-dg-cell',
+    PLACEHOLDER: 'clr-dg-placeholder',
+    COLUMN_TITLE: '.datagrid-column-title',
+    HIDDEN_COLUMN: 'clr-dg-column.datagrid-hidden-column',
+    DETAIL_ROW: 'clr-dg-row-detail',
+    DETAIL_PANE: '.datagrid-detail-pane-content',
+    DETAIL_PANE_HEADER: '.datagrid-detail-header-title',
+    DETAIL_ROW_BUTTON: '.datagrid-expandable-caret-button',
+    DETAIL_PANE_BUTTON: '.datagrid-detail-caret-button',
+    PAGINATION_DESCRIPTION: '.pagination-description',
+    PAGE_SIZE: 'clr-dg-page-size',
+    PAGINATION_NEXT: '.pagination-next',
+    TOP_POSITIONED_BUTTON: 'clr-dg-action-bar button',
+    ROW_BUTTON_CONTAINER: '.action-button-cell',
+    CHECKBOX_WRAPPER: 'clr-checkbox-wrapper',
+    RADIO_WRAPPER: 'clr-radio-wrapper',
+    FILTER: 'clr-dg-filter',
+    FILTER_TOGGLE: '.datagrid-filter-toggle',
+};
 
 /**
  * Widget Object for a Clarity DataGrid
  */
-export class ClrDatagridWidgetObject extends WidgetObject<ClrDatagrid> {
+export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     static tagName = `clr-datagrid`;
 
     /**
-     * Retrieves the text content of a cell
-     * @param row 0-based index of row
-     * @param column 0-based index of column
+     * Gives the placeholder present on the datagrid
      */
-    getCellText(row: number, column: number): string {
-        return this.getNodeText(this.getCell(row, column));
-    }
+    getPlaceHolder = this.locatorForChild(Css.PLACEHOLDER);
 
     /**
-     * Gives the text content of all the cells in a row.
-     * @param rowIndex 0-based index of row
+     * The header of the detail pane
      */
-    getRowValues(rowIndex: number): string[] {
-        return this.getTexts(`${ROW_TAG}:nth-of-type(${rowIndex + 1}) ${CELL_TAG}`);
-    }
+    getDetailPaneHeader = this.locatorForChild(Css.DETAIL_PANE_HEADER);
 
     /**
-     * Gives the linked text in the given cell represented by the {@param rowIndex} and {@param columnIndex} if present.
+     * Gives the pagination description text
      */
-    getCellLink(rowIndex: number, columnIndex: number): string[] {
-        return this.getCell(rowIndex, columnIndex)
-            .nativeElement.querySelector('a')
-            .getAttribute('href');
-    }
+    getPaginationDescription = this.locatorForChild(Css.PAGINATION_DESCRIPTION);
 
     /**
-     * Retrieves if the cell will clip text
-     * @param column 0-based index of column
+     * Gives the text next to the pagination selector
      */
-    columnClippedTextDirective(column: number): ShowClippedTextDirective {
-        const res = this.getCell(0, column);
-        return res.injector.get(ShowClippedTextDirective);
-    }
+    getPaginationSizeSelector = this.locatorForChild(Css.PAGE_SIZE);
 
     /**
-     * Returns the number of visible columns
+     * Returns the next page button
      */
-    get columnCount(): number {
-        return this.component.columns ? this.component.columns.length : this.columns.length;
-    }
+    getNextButton = this.locatorForChild(Css.PAGINATION_NEXT);
 
     /**
-     * Returns the text for a header
-     * @param columnIndex 0-based index of header to retrieve
-     */
-    getColumnHeader(columnIndex: number): string {
-        return this.getText(`${COLUMN_CSS_SELECTOR}:nth-of-type(${columnIndex + 1})`);
-    }
-
-    /**
-     * Returns an array of the texts for columns, in DOM order
-     */
-    get columnHeaders(): string[] {
-        return this.getTexts(COLUMN_CSS_SELECTOR);
-    }
-
-    /**
-     * Returns an array of the texts for columns that are hidden.
-     */
-    get hiddenColumnHeaders(): string[] {
-        return this.getTexts('clr-dg-column.datagrid-hidden-column');
-    }
-
-    /**
-     * Returns the number of rows currently displayed
-     */
-    get rowCount(): number {
-        return this.rows.length;
-    }
-
-    /**
-     * Says if this datagrid is loading.
-     */
-    get loading(): boolean {
-        return this.component.loading;
-    }
-
-    /**
-     * Gives the placeholder present on the datagrid.
-     */
-    get placeholder(): string {
-        return this.getText('clr-dg-placeholder');
-    }
-
-    /**
-     * Returns whether or not the column with the given index is displayed by the CSS.
-     */
-    isColumnDisplayed(index: number): boolean {
-        return this.findElements(COLUMN_SELECTOR)[index].classes['datagrid-hidden-column'] !== true;
-    }
-
-    /**
-     * Returns the classes of the column with the given index.
-     */
-    getColumnClasses(index: number): string[] {
-        return Object.keys(this.findElements(COLUMN_SELECTOR)[index].classes);
-    }
-
-    /*
-     * Returns the CSS class of the Clarity datagrid.
-     */
-    get gridCssClass(): string[] {
-        return Object.keys(this.root.classes);
-    }
-
-    /**
-     * Returns the CSS class names of the given Clarity datarow.
-     */
-    getRowsCssClass(index: number): string[] {
-        return Object.keys(this.rows[index].classes);
-    }
-
-    /**
-     * Returns the native element contents within all the detail pane open.
-     */
-    getAllDetailRowContents(): string[] {
-        return this.findElements('clr-dg-row-detail').map(detail => detail.nativeElement);
-    }
-
-    /**
-     * Returns the native element contents within all the detail pane open.
-     */
-    getAllDetailPaneContents(): string[] {
-        return this.findElements('.datagrid-detail-pane-content').map(detail => detail.nativeElement);
-    }
-
-    /**
-     * Returns the header of the detail pane.
-     */
-    getDetailPaneHeader(): string {
-        return this.getText('.datagrid-detail-header-title');
-    }
-
-    /**
-     * Clicks the given detail row button.
-     */
-    clickDetailRowButton(row: number): void {
-        this.detailRowButtons[row].nativeElement.click();
-    }
-
-    /**
-     * Clicks the given detail pane button.
-     */
-    clickDetailPaneButton(row: number): void {
-        this.detailPaneButtons[row].nativeElement.click();
-    }
-
-    /**
-     * Sorts the column at the given index.
-     */
-    sortColumn(index: number): void {
-        this.columns[index].nativeElement.click();
-    }
-
-    /**
-     * Returns the selection type of the grid.
-     */
-    getSelectionType(): GridSelectionType {
-        if (this.findElements('clr-checkbox-wrapper').length !== 0) {
-            return GridSelectionType.Multi;
-        } else if (this.findElements('clr-radio-wrapper').length !== 0) {
-            return GridSelectionType.Single;
-        } else {
-            return GridSelectionType.None;
-        }
-    }
-
-    /**
-     * Clicks the selection icon on the given row.
-     */
-    selectRow(row: number): void {
-        this.click(`input`, this.rows[row]);
-    }
-
-    /**
-     * Gives the pagination description text.
-     */
-    getPaginationDescription(): string {
-        return this.findElement('.pagination-description').nativeElement.textContent;
-    }
-
-    /**
-     * Gives the text next to the pagination selector.
-     * Gives empty string if the size dropdown is not in the page.
-     */
-    getPaginationSizeSelectorText(): string {
-        const sizer = this.findElement('clr-dg-page-size');
-        return sizer ? sizer.nativeElement.textContent : '';
-    }
-
-    /**
-     * Clicks the next page button.
-     */
-    nextPage(): void {
-        this.click('.pagination-next');
-    }
-
-    /**
-     * Gives a list of the labels of the displayed action buttons at the top of the grid.
-     */
-    getTopPositionedButtons(): string[] {
-        return this.findElements('clr-dg-action-bar button').map(button => button.nativeElement.textContent);
-    }
-
-    /**
-     * Gives the class of the cell that holds the row buttons.
-     */
-    getRowButtonContainerClass(rowIndex: number): string[] {
-        return Object.keys(this.findElement(`.action-button-cell`, this.rows[rowIndex]).classes);
-    }
-
-    /**
-     * Gives the text of the button with the given buttonClass on the top of the datagrid.
-     */
-    getTopButtonText(buttonClass: string): string {
-        return this.getText(`button.${buttonClass}`);
-    }
-
-    /**
-     * Gives the text of the button with the given buttonClass at a row of the datagrid.
+     * Helper function to retrieve a row
      * @param row 0-based index of row
      */
-    getRowButtonText(buttonClass: string, row: number): string {
-        return this.getText(`button.${buttonClass}`, this.rows[row]);
+    private _getRow(row: number): LocatorDriver<T> {
+        return this.locatorDriver.get(`${Css.ROW}:nth-of-type(${row + 1})`);
     }
 
     /**
-     * Says if the button on the top of the grid with the given buttonClass is enabled.
+     * Helper function to retrieve a cell
+     * @param row 0-based index of row
+     * @param col 0-based index of column
      */
-    isTopButtonEnabled(buttonClass: string): boolean {
-        return !this.findElement(`button.${buttonClass}`).nativeElement.disabled;
+    private _getCell(row: number, col: number): LocatorDriver<T> {
+        return this._getRow(row).get(`${Css.CELL}:nth-of-type(${col + 1})`);
     }
 
     /**
-     * Says if the button at a row in the datagrid with the given buttonClass is enabled.
+     * Retrieves the cell
+     * @param row 0-based index of row
+     * @param col 0-based index of column
+     */
+    getCell(row: number, col: number): T {
+        return this._getCell(row, col).unwrap();
+    }
+
+    /**
+     * Gives the linked tag in the given cell
+     * @param row 0-based index of row
+     * @param col 0-based index of column
+     */
+    getCellLink(row: number, col: number): T {
+        return this._getCell(row, col).get(`a`).unwrap();
+    }
+
+    /**
+     * Gives the `strong` tag in the given cell
+     * @param row 0-based index of row
+     * @param col 0-based index of column
+     */
+    getCellStrong(row: number, col: number): T {
+        return this._getCell(row, col).get('strong').unwrap();
+    }
+
+    /**
+     * Returns all the rows
+     */
+    getRows(): T {
+        return this.locatorDriver.get(Css.ROW).unwrap();
+    }
+
+    /**
+     * Return a row by index
      * @param row 0-based index of row
      */
-    isRowButtonEnabled(buttonClass: string, row: number): boolean {
-        return !this.findElement(`button.${buttonClass}`, this.rows[row]).nativeElement.disabled;
+    getRow(row: number): T {
+        return this._getRow(row).unwrap();
     }
 
     /**
-     * Presses the button with the given buttonClass on the top of the datagrid.
+     * Returns all the columns
      */
-    pressTopButton(buttonClass: string): void {
-        this.click(`button.${buttonClass}`);
+    getColumns(): T {
+        return this.locatorDriver.get(Css.COLUMN).unwrap();
     }
 
     /**
-     * Presses the button with the given buttonClass on a row of the datagrid.
+     * Return a column by index
+     * @param col 0-based index of column
+     */
+    getColumn(col: number): T {
+        return this.locatorDriver.get(`${Css.COLUMN}:nth-of-type(${col + 1})`).unwrap();
+    }
+
+    /**
+     * Returns input element in the given row
      * @param row 0-based index of row
      */
-    pressRowButton(buttonClass: string, row: number): void {
-        this.click(`button.${buttonClass}`, this.rows[row]);
+    getRowInput(row: number): T {
+        return this._getRow(row).get(`input`).unwrap();
     }
 
     /**
-     * Gives the height CSS of this clr-datagrid.
-     */
-    get gridHeight(): string {
-        return this.root.parent.nativeElement.style.getPropertyValue('--datagrid-height');
-    }
-
-    /**
-     * Gives the height of the grids container.
-     */
-    get gridContainerClasses(): string[] {
-        return Object.keys(this.root.parent.classes);
-    }
-
-    /**
-     * Can be used by subclasses to create methods that assert about HTML in custom rendered columns. Note that
-     * subclasses should not return the DebugElement, they should return a string from a section of the HTML.
-     *
+     * Returns all the cell elements in the given row
      * @param row 0-based index of row
-     * @param column 0-based index of column
-     *
-     * Because the custom renderer widget object requires getting the {@link DebugElement} of a cell,
-     * but doesn't directly extend {@link ClrDatagridWidgetObject}, this method needs to be public.
-     * This will be fixed in {@link https://jira.eng.vmware.com/browse/VDUCC-127}.
      */
-    getCell(row: number, column: number): DebugElement {
-        return this.findElement(`${ROW_TAG}:nth-of-type(${row + 1}) ${CELL_TAG}:nth-of-type(${column + 1})`);
-    }
-
-    private get rows(): DebugElement[] {
-        return this.findElements(ROW_TAG);
-    }
-
-    private get columns(): DebugElement[] {
-        return this.findElements(COLUMN_CSS_SELECTOR);
-    }
-
-    private get detailRowButtons(): DebugElement[] {
-        return this.findElements('.datagrid-expandable-caret-button');
-    }
-
-    private get detailPaneButtons(): DebugElement[] {
-        return this.findElements('.datagrid-detail-caret-button');
-    }
-
-    private openFilter(): void {
-        const clrDgColumn = this.findElements(COLUMN_SELECTOR)[0];
-        const filterDebugEl = this.findElement(FILTER_SELECTOR, clrDgColumn);
-        this.click('.datagrid-filter-toggle', filterDebugEl);
-        this.detectChanges();
+    getRowCell(row: number): T {
+        return this._getRow(row).get(Css.CELL).unwrap();
     }
 
     /**
-     * Used by the {@link createDatagridFilterTestHelper} to query for a filter component. Opens filter of first
-     * column and returns the filter component.
-     * @param ctor The constructor of a grid filter component
+     * Returns the button on the top of the grid with the given buttonClass
      */
-    getFilter<V, C>(ctor: Type<DatagridFilter<V, C>>): DatagridFilter<V, C> {
-        this.openFilter();
-        return this.root.parent.parent.parent.query(By.directive(ctor)).componentInstance;
+    getTopButton(btnClass: string): T {
+        return this.locatorDriver.get(`button.${btnClass}`).unwrap();
+    }
+
+    /**
+     * Returns the button at a row with the given buttonClass
+     */
+    getRowButton(btnClass: string, row: number): T {
+        return this._getRow(row).get(`button.${btnClass}`).unwrap();
+    }
+
+    /**
+     * Returns an array of headers
+     */
+    getColumnHeaders(): T {
+        return this.locatorDriver.get(Css.COLUMN_TITLE).unwrap();
+    }
+
+    /**
+     * Returns a header
+     * @param col 0-based index of header
+     */
+    getColumnHeader(col: number): T {
+        return this.locatorDriver.get(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`).unwrap();
+    }
+
+    /**
+     * Returns an array of columns that are hidden
+     */
+    getHiddenColumnHeaders(): T {
+        return this.locatorDriver.get(Css.HIDDEN_COLUMN).unwrap();
+    }
+
+    /**
+     * Returns the elements within all the detail pane open
+     */
+    getDetailRows(): T {
+        return this.locatorDriver.get(Css.DETAIL_ROW).unwrap();
+    }
+
+    /**
+     * Returns the elements within all the detail pane open
+     */
+    getDetailPanes(): T {
+        return this.locatorDriver.get(Css.DETAIL_PANE).unwrap();
+    }
+
+    /**
+     * Returns all the detail buttons
+     */
+    getDetailRowButtons(): T {
+        return this.locatorDriver.get(Css.DETAIL_ROW_BUTTON).unwrap();
+    }
+
+    /**
+     * Returns all the detail pane buttons
+     */
+    getDetailPaneButtons(): T {
+        return this.locatorDriver.get(Css.DETAIL_PANE_BUTTON).unwrap();
+    }
+
+    /**
+     * Gives a list of displayed action buttons at the top of the grid
+     */
+    getTopPositionedButtons(): T {
+        return this.locatorDriver.get(Css.TOP_POSITIONED_BUTTON).unwrap();
+    }
+
+    /**
+     * Returns a row button
+     * @param row 0-based index
+     */
+    getRowButtonContainer(row: number): T {
+        return this._getRow(row).get(Css.ROW_BUTTON_CONTAINER).unwrap();
+    }
+
+    /**
+     * Returns filter toggle
+     */
+    getFilterToggle(): T {
+        return this.locatorDriver.get(Css.COLUMN).get(Css.FILTER).get(Css.FILTER_TOGGLE).unwrap();
+    }
+
+    /**
+     * Find a clr-checkbox-wrapper
+     */
+    getCheckboxWrapper(): T {
+        return this.locatorDriver.get(Css.CHECKBOX_WRAPPER).unwrap();
+    }
+
+    /**
+     * Find a clr-radio-wrapper
+     */
+    getRadioWrapper(): T {
+        return this.locatorDriver.get(Css.RADIO_WRAPPER).unwrap();
+    }
+
+    /**
+     * Unwrap the clr-datagrid
+     */
+    unwrap(): T {
+        return this.locatorDriver.unwrap();
     }
 }

--- a/projects/components/src/utils/test/datagrid/filter-utils.ts
+++ b/projects/components/src/utils/test/datagrid/filter-utils.ts
@@ -75,9 +75,9 @@ export function createDatagridFilterTestHelper<V, C>(
     const grid = finder.find(ClrDatagridWidgetObject);
 
     wf.hostComponent.setFilter(filterType, wf, config || ({} as C));
-    grid.component.fixture.detectChanges();
+    grid.clrDatagrid.fixture.detectChanges();
     grid.getFilterToggle().click();
-    return getFilter(grid.component, filterType);
+    return getFilter(grid.clrDatagrid, filterType);
 }
 
 /**
@@ -94,12 +94,12 @@ export function createDatagridFilterTestHelperWithFinder<V, C>(
     const finder = new AngularWidgetObjectFinder(FilterTestHostComponent);
     const grid = finder.find(ClrDatagridWidgetObject);
     wf.hostComponent.setFilter(filterType, wf, config || ({} as C));
-    grid.component.fixture.detectChanges();
+    grid.clrDatagrid.fixture.detectChanges();
     grid.getFilterToggle().click();
 
     return {
         finder: wf,
-        filter: getFilter(grid.component, filterType),
+        filter: getFilter(grid.clrDatagrid, filterType),
     };
 }
 

--- a/projects/components/src/utils/test/datagrid/filter-utils.ts
+++ b/projects/components/src/utils/test/datagrid/filter-utils.ts
@@ -75,9 +75,9 @@ export function createDatagridFilterTestHelper<V, C>(
     const grid = finder.find(ClrDatagridWidgetObject);
 
     wf.hostComponent.setFilter(filterType, wf, config || ({} as C));
-    grid.unwrap().fixture.detectChanges();
+    grid.component.fixture.detectChanges();
     grid.getFilterToggle().click();
-    return getFilter(grid.unwrap(), filterType);
+    return getFilter(grid.component, filterType);
 }
 
 /**
@@ -94,12 +94,12 @@ export function createDatagridFilterTestHelperWithFinder<V, C>(
     const finder = new AngularWidgetObjectFinder(FilterTestHostComponent);
     const grid = finder.find(ClrDatagridWidgetObject);
     wf.hostComponent.setFilter(filterType, wf, config || ({} as C));
-    grid.unwrap().fixture.detectChanges();
+    grid.component.fixture.detectChanges();
     grid.getFilterToggle().click();
 
     return {
         finder: wf,
-        filter: getFilter(grid.unwrap(), filterType),
+        filter: getFilter(grid.component, filterType),
     };
 }
 

--- a/projects/components/src/utils/test/datagrid/filter-utils.ts
+++ b/projects/components/src/utils/test/datagrid/filter-utils.ts
@@ -16,13 +16,12 @@ import {
 } from '../../../datagrid';
 import { MockRecord } from '../../../datagrid/mock-data';
 import { IdGenerator } from '../../id-generator/id-generator';
-import { WidgetFinder } from '../widget-object';
 import { AngularWidgetObjectFinder } from '../widget-object/angular-widget-finder';
 import { TestElement } from '../widget-object/angular-widget-object';
 import { ClrDatagridWidgetObject } from './datagrid.wo';
 
 function getFilter<V, C>(element: TestElement, filterType: Type<DatagridFilter<V, C>>): DatagridFilter<V, C> {
-    return element.elements[0].parent.parent.parent.query(By.directive(filterType)).componentInstance;
+    return element.parents('body').queryDirective(filterType);
 }
 
 /**
@@ -69,12 +68,10 @@ export function createDatagridFilterTestHelper<V, C>(
     configureTestingModule();
 
     // Add the filter to grid column
-    const wf = new WidgetFinder(FilterTestHostComponent);
-
     const finder = new AngularWidgetObjectFinder(FilterTestHostComponent);
     const grid = finder.find(ClrDatagridWidgetObject);
 
-    wf.hostComponent.setFilter(filterType, wf, config || ({} as C));
+    finder.hostComponent.setFilter(filterType, finder, config || ({} as C));
     grid.clrDatagrid.fixture.detectChanges();
     grid.getFilterToggle().click();
     return getFilter(grid.clrDatagrid, filterType);
@@ -86,19 +83,18 @@ export function createDatagridFilterTestHelper<V, C>(
 export function createDatagridFilterTestHelperWithFinder<V, C>(
     filterType: Type<DatagridFilter<V, C>>,
     config?: C
-): { finder: WidgetFinder; filter: DatagridFilter<V, C> } {
+): { finder: AngularWidgetObjectFinder; filter: DatagridFilter<V, C> } {
     configureTestingModule();
 
     // Add the filter to grid column
-    const wf = new WidgetFinder(FilterTestHostComponent);
     const finder = new AngularWidgetObjectFinder(FilterTestHostComponent);
     const grid = finder.find(ClrDatagridWidgetObject);
-    wf.hostComponent.setFilter(filterType, wf, config || ({} as C));
+    finder.hostComponent.setFilter(filterType, finder, config || ({} as C));
     grid.clrDatagrid.fixture.detectChanges();
     grid.getFilterToggle().click();
 
     return {
-        finder: wf,
+        finder,
         filter: getFilter(grid.clrDatagrid, filterType),
     };
 }
@@ -131,11 +127,7 @@ export class FilterTestHostComponent {
     /**
      * Creates the filterRendererSpec and adds it to the grid column above
      */
-    setFilter<V, C>(
-        filterType: Type<DatagridFilter<V, C>>,
-        finder: WidgetFinder<FilterTestHostComponent>,
-        config: C
-    ): void {
+    setFilter<V, C>(filterType: Type<DatagridFilter<V, C>>, finder: AngularWidgetObjectFinder, config: C): void {
         this.column.filter = FilterComponentRendererSpec({ type: filterType, config });
         finder.detectChanges();
     }

--- a/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
@@ -15,7 +15,7 @@ export class VcdDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * Gives the header above the grid.
      */
-    getHeader = this.locatorForChild('h3');
+    getHeader = this.locatorForCssSelectors('h3');
 
     /**
      * Gives the widget object for this `clr-datagrid`.
@@ -28,7 +28,7 @@ export class VcdDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * Unwraps the `vcd-datagrid`
      */
-    unwrap(): T {
+    get component(): T {
         return this.locatorDriver.unwrap();
     }
 }

--- a/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
@@ -3,28 +3,32 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { WidgetObject } from '../widget-object';
-import { DatagridComponent } from './../../../datagrid/datagrid.component';
+import { BaseWidgetObject } from '../widget-object/widget-object';
 import { ClrDatagridWidgetObject } from './datagrid.wo';
 
 /**
  * Widget Object for our VCD DataGrid
  */
-export class VcdDatagridWidgetObject<R> extends WidgetObject<DatagridComponent<R>> {
+export class VcdDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     static tagName = `vcd-datagrid`;
 
     /**
      * Gives the header above the grid.
      */
-    get gridHeader(): string {
-        return this.getText('h3');
+    getHeader = this.locatorForChild('h3');
+
+    /**
+     * Gives the widget object for this `clr-datagrid`.
+     */
+    findClrDatagrid(): ClrDatagridWidgetObject<T> {
+        // @ts-ignore
+        return this.locatorDriver.findWidget(ClrDatagridWidgetObject);
     }
 
     /**
-     * Gives the widget object for this clr datagrid.
+     * Unwraps the `vcd-datagrid`
      */
-    get clrDatagrid(): ClrDatagridWidgetObject {
-        const constElement = this.findElement(ClrDatagridWidgetObject.tagName);
-        return new ClrDatagridWidgetObject(this.fixture, constElement, constElement.componentInstance);
+    unwrap(): T {
+        return this.locatorDriver.unwrap();
     }
 }

--- a/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
@@ -28,7 +28,7 @@ export class VcdDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * Unwraps the `vcd-datagrid`
      */
-    get component(): T {
+    get vcdDatagrid(): T {
         return this.locatorDriver.unwrap();
     }
 }

--- a/projects/components/src/utils/test/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object.ts
@@ -176,8 +176,9 @@ export interface FindParams<T> {
 }
 
 /**
- * Finds instances that implement {@link FindableWidget}
- * H is the host component's type
+ * @deprecated Finds instances that implement {@link FindableWidget}
+ * H is the host component's type. This finder is only for old unit tests.
+ * Please use AngularWidgetObjectFinder instead.
  */
 export class WidgetFinder<H = unknown> {
     /**

--- a/projects/components/src/utils/test/widget-object/angular-widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-object.spec.ts
@@ -47,11 +47,11 @@ class HeaderWidgetObject<T> extends BaseWidgetObject<T> {
 class ClickTrackerWidgetObject<T> extends BaseWidgetObject<T> {
     static tagName = 'vcd-click-tracker';
 
-    getClickCount = this.locatorForChild('.click-count');
+    getClickCount = this.locatorForCssSelectors('.click-count');
 
-    getHeaderText = this.locatorForChild('h1');
+    getHeaderText = this.locatorForCssSelectors('h1');
 
-    getTrackerElement = this.locatorForChild('p');
+    getTrackerElement = this.locatorForCssSelectors('p');
 
     findHeaderWidget(): HeaderWidgetObject<T> {
         return this.locatorDriver.findWidget(HeaderWidgetObject);

--- a/projects/components/src/utils/test/widget-object/angular-widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-object.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { DebugElement, Type } from '@angular/core';
+import { DebugElement, Injector, Type } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AngularWidgetObjectFinder } from './angular-widget-finder';
@@ -187,10 +187,25 @@ export class TestElement implements Iterable<TestElement> {
     }
 
     /**
-     * Returns the parent of first element
+     * Returns style property value of the first element
+     * @param key specified CSS property
      */
-    parent(): TestElement {
-        return new TestElement([this.elements[0].parent], this.fixture);
+    getStylePropertyValue(key: string): string {
+        return this.elements[0].nativeElement.style.getPropertyValue(key);
+    }
+
+    /**
+     * Returns componentInstance of the first element
+     */
+    getComponentInstance(): any {
+        return this.elements[0].componentInstance;
+    }
+
+    /**
+     * Returns injector of the first element
+     */
+    getInjector(): Injector {
+        return this.elements[0].injector;
     }
 
     /**

--- a/projects/components/src/utils/test/widget-object/angular-widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-object.ts
@@ -209,6 +209,31 @@ export class TestElement implements Iterable<TestElement> {
     }
 
     /**
+     * Finds the first parent element that matches the CSS selector
+     */
+    private findParents(debugEl: DebugElement, cssSelector: string): DebugElement {
+        if (!debugEl) {
+            return null;
+        }
+        return debugEl.nativeElement.matches(cssSelector) ? debugEl : this.findParents(debugEl.parent, cssSelector);
+    }
+
+    /**
+     * Returns the first parent element that matches css selector
+     */
+    parents(cssSelector: string): TestElement {
+        const result = this.findParents(this.elements[0].parent, cssSelector);
+        return new TestElement(result ? [result] : [], this.fixture);
+    }
+
+    /**
+     * Returns componentInstance after query directive
+     */
+    queryDirective(type: Type<any>): any {
+        return this.elements[0].query(By.directive(type)).componentInstance;
+    }
+
+    /**
      * Allows a TestElement to be used in a `for ... of ...` loop.
      */
     [Symbol.iterator](): Iterator<TestElement, any, undefined> {

--- a/projects/components/src/utils/test/widget-object/angular-widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-object.ts
@@ -163,6 +163,37 @@ export class TestElement implements Iterable<TestElement> {
     }
 
     /**
+     * Send a keyboard event of type {@param eventType} with properties {@param eventProperties} on this element.
+     * Setting the event properties is done with `Object.defineProperty` on the created event. This allows setting
+     * properties like `which` that is deprecated and cannot be set with the native approach of creating keyboard event.
+     * @param eventType The keyboard event type like 'keyup', 'keydown', 'keypress'
+     * @param eventProperties properties of the event like `code`, `key` etc.
+     */
+    sendKeyboardEvent(eventType: string, eventProperties: { [name: string]: unknown }): void {
+        const element = this.elements[0].nativeElement as HTMLElement;
+        const event = new KeyboardEvent(eventType, { bubbles: true });
+        Object.keys(eventProperties).forEach((key) => {
+            Object.defineProperty(event, key, { value: eventProperties[key] });
+        });
+        element.dispatchEvent(event);
+        this.detectChanges();
+    }
+
+    /**
+     * Returns classes of first element as a string array
+     */
+    classes(): string[] {
+        return Object.keys(this.elements[0].classes);
+    }
+
+    /**
+     * Returns the parent of first element
+     */
+    parent(): TestElement {
+        return new TestElement([this.elements[0].parent], this.fixture);
+    }
+
+    /**
      * Allows a TestElement to be used in a `for ... of ...` loop.
      */
     [Symbol.iterator](): Iterator<TestElement, any, undefined> {

--- a/projects/components/src/utils/test/widget-object/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/widget-object.ts
@@ -35,14 +35,14 @@ export class BaseWidgetObject<T> {
     /**
      * Returns an element locator that will find a child with the given cssSelector when called.
      */
-    protected locatorForChild? = (cssSelector: string): ElementLocator<T> => {
+    protected locatorForCssSelectors? = (cssSelector: string): ElementLocator<T> => {
         return (options?: unknown) => this.locatorDriver.get(cssSelector, options).unwrap();
     };
 
     /**
      * Returns an element locator that will find a parent with the given cssSelector when called.
      */
-    protected locatorForParent? = (cssSelector: string): ElementLocator<T> => {
+    protected locatorForAncestors? = (cssSelector: string): ElementLocator<T> => {
         return (options?: unknown) => this.locatorDriver.parents(cssSelector, options).unwrap();
     };
 


### PR DESCRIPTION
## Description
 - Rewrote `VcdDatagridWidget` and `ClrDatagridWidget` using new Widget Object pattern.
 - Rewrote datagrid component unit tests using new `ClrDatagridWidget`.
 - Rewrote helper method `createDatagridFilterTestHelper` and `createDatagridFilterTestHelperWithFinder` using new Widget Object.
 - Added convenience methods `sendKeyboardEvent`, `classes`, and `parent` to `TestElement`.
 - Removed `WithGridBoldRenderer`. The `getBoldText` is implemented in `ClrDatagridWidget.getCellStrong`.

## Test done:
Ran unit tests and assured that all the tests passed.

Signed-off-by: yumengwu <yumengwu95@gmail.com>