### PR TITLE
Adds error icon to vcd-form-select

### DIFF
--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -13,6 +13,7 @@
                         {{ option.isTranslatable ? (option.display | translate) : option.display }}
                     </option>
                 </select>
+                <clr-icon *ngIf="showErrors" class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
             </div>
 
             <ng-content select="aside"></ng-content>

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, ViewChild } from '@angular/core';
+import { Component, DebugElement, Type, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { SelectOption } from '../../common/interfaces/select-option';
 import { WidgetFinder, WidgetObject } from '../../utils/test/widget-object';
@@ -15,6 +15,15 @@ export class VcdFormSelectWidgetObject extends WidgetObject<FormSelectComponent>
 
     private get selectElement(): HTMLSelectElement {
         return this.findElement('select').nativeElement;
+    }
+
+    get clrIcon(): HTMLElement {
+        const clrIconDebugEl = this.findElement('clr-icon');
+        return clrIconDebugEl ? clrIconDebugEl.nativeElement : undefined;
+    }
+
+    findElement(selector: string | Type<unknown>, parent: DebugElement = this.root): DebugElement {
+        return super.findElement(selector, parent);
     }
 
     get value(): string {
@@ -81,6 +90,20 @@ describe('FormSelectComponent', () => {
             expect(selectInput.value).toEqual(hostComponent.options[1].value as string);
             hostComponent.formGroup.get('selectInput').setValue(hostComponent.options[2].value);
             expect(selectInput.value).toEqual(hostComponent.options[2].value as string);
+        });
+    });
+
+    describe('validation', () => {
+        it('should not show error icon before user selects value', () => {
+            expect(selectInput.clrIcon).toBeUndefined();
+        });
+        it('shows error icon when a invalid value is selected', () => {
+            selectInput.select(0);
+            expect(selectInput.clrIcon).toBeDefined();
+        });
+        it('does not show error icon when a valid value is selected', () => {
+            selectInput.select(1);
+            expect(selectInput.clrIcon).toBeUndefined();
         });
     });
 });

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -19,7 +19,7 @@ export class VcdFormSelectWidgetObject extends WidgetObject<FormSelectComponent>
 
     get clrIcon(): string {
         const clrIconDebugEl = this.findElement('clr-icon');
-        return clrIconDebugEl ? clrIconDebugEl.nativeElement.getAttribute('shape') : undefined;
+        return clrIconDebugEl?.nativeElement.getAttribute('shape') || '';
     }
 
     get value(): string {

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -17,7 +17,10 @@ export class VcdFormSelectWidgetObject extends WidgetObject<FormSelectComponent>
         return this.findElement('select').nativeElement;
     }
 
-    get clrIcon(): string {
+    /**
+     * Returns the 'shape' attribute if defined, returns empty string if undefined
+     */
+    get clrIconShape(): string {
         const clrIconDebugEl = this.findElement('clr-icon');
         return clrIconDebugEl?.nativeElement.getAttribute('shape') || '';
     }
@@ -91,15 +94,15 @@ describe('FormSelectComponent', () => {
 
     describe('validation', () => {
         it('does not show error icon before user selects value', () => {
-            expect(selectInput.clrIcon).toBeUndefined();
+            expect(selectInput.clrIconShape).toEqual('');
         });
         it('shows error icon when a invalid value is selected', () => {
             selectInput.select(0);
-            expect(selectInput.clrIcon).toEqual('exclamation-circle');
+            expect(selectInput.clrIconShape).toEqual('exclamation-circle');
         });
         it('does not show error icon when a valid value is selected', () => {
             selectInput.select(1);
-            expect(selectInput.clrIcon).toBeUndefined();
+            expect(selectInput.clrIconShape).toEqual('');
         });
     });
 });

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -17,13 +17,9 @@ export class VcdFormSelectWidgetObject extends WidgetObject<FormSelectComponent>
         return this.findElement('select').nativeElement;
     }
 
-    get clrIcon(): HTMLElement {
+    get clrIcon(): string {
         const clrIconDebugEl = this.findElement('clr-icon');
-        return clrIconDebugEl ? clrIconDebugEl.nativeElement : undefined;
-    }
-
-    findElement(selector: string | Type<unknown>, parent: DebugElement = this.root): DebugElement {
-        return super.findElement(selector, parent);
+        return clrIconDebugEl ? clrIconDebugEl.nativeElement.getAttribute('shape') : undefined;
     }
 
     get value(): string {
@@ -94,12 +90,12 @@ describe('FormSelectComponent', () => {
     });
 
     describe('validation', () => {
-        it('should not show error icon before user selects value', () => {
+        it('does not show error icon before user selects value', () => {
             expect(selectInput.clrIcon).toBeUndefined();
         });
         it('shows error icon when a invalid value is selected', () => {
             selectInput.select(0);
-            expect(selectInput.clrIcon).toBeDefined();
+            expect(selectInput.clrIcon).toEqual('exclamation-circle');
         });
         it('does not show error icon when a valid value is selected', () => {
             selectInput.select(1);

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, DebugElement, Type, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { SelectOption } from '../../common/interfaces/select-option';
 import { WidgetFinder, WidgetObject } from '../../utils/test/widget-object';

--- a/projects/examples/src/app/home/home.component.spec.ts
+++ b/projects/examples/src/app/home/home.component.spec.ts
@@ -7,7 +7,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
 
-xdescribe('HomeComponent', () => {
+describe('HomeComponent', () => {
     let component: HomeComponent;
     let fixture: ComponentFixture<HomeComponent>;
 

--- a/projects/examples/src/app/home/home.component.spec.ts
+++ b/projects/examples/src/app/home/home.component.spec.ts
@@ -7,7 +7,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
 
-describe('HomeComponent', () => {
+xdescribe('HomeComponent', () => {
     let component: HomeComponent;
     let fixture: ComponentFixture<HomeComponent>;
 


### PR DESCRIPTION
## Testing Done

* Go to http://localhost:4200/formSelect/example
* Verify that error icon does not appear when user arrives on the page
* Verify that error icon does not appear when user selects an option from the drop-down
* Verify that error icon DOES appear when user fails to select an option from the drop-down

## Unit Tests Added

* Test to verify no icon shows when page loads
* Test to verify icon shows when user selects invalid option
* Test to verify no icon shows when user selects valid option

### Before
<img width="597" alt="Screen Shot 2020-11-24 at 1 19 35 PM" src="https://user-images.githubusercontent.com/73592887/100156295-a1c51b00-2e76-11eb-98f2-a1b85f1f77f3.png">

### After - with error
<img width="765" alt="Screen Shot 2020-11-24 at 4 47 43 PM" src="https://user-images.githubusercontent.com/73592887/100156326-ac7fb000-2e76-11eb-8475-2555fac20c33.png">

### After - without error
![image](https://user-images.githubusercontent.com/73592887/100156380-c620f780-2e76-11eb-9335-a4166d1d16ae.png)


Signed-off-by: Ria Mahoney <mpatrice@vmware.com>