### PR TITLE
[master branch]Fix accessibility issues on Action menu component

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 [internal]: Update `ng-live-docs` to 0.0.8 to enable `@vmw/ng-live-docs:add-example` schematic.
 
+## [1.0.0-dev.50] - 2020-12-2
+### Fixed
+- Underlying page scrolling when navigating the action menu using arrow keys.
+- Space/Enter keys not closing the action menu after a action menu item is activated.
+- Esc key not closing the action menu it is pressed on. 
+- Not being able to navigate using arrow keys on action menu with separators
+
 ## [1.0.0-dev.49] - 2020-11-10
 1. BREAKING: Fixes an error in the type clash with Jasmine and Chai in the Widget Object
 2. Fix arrow navigation of disabled menu items.

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.49",
+    "version": "1.0.0-dev.50",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/dropdown/dropdown-focus-handler.service.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.service.ts
@@ -23,41 +23,47 @@ export class DropdownFocusHandlerService implements OnDestroy {
     }
 
     /**
-     * Moves the focus to HTML element in the given direction
+     * Moves the focus to HTML element in the given direction and returns true if the focus is moved and false otherwise
      */
-    moveFocus(direction: Direction): void {
+    moveFocus(direction: Direction): boolean {
+        let moved;
         switch (direction) {
             case Direction.DOWN:
-                this.moveFocusTo(this.currentFocusedItem.down);
+                moved = this.moveFocusTo(this.currentFocusedItem.down);
                 break;
             case Direction.LEFT:
-                this.moveFocusTo(this.currentFocusedItem.left);
+                moved = this.moveFocusTo(this.currentFocusedItem.left);
                 break;
             case Direction.UP:
-                this.moveFocusTo(this.currentFocusedItem.up);
+                moved = this.moveFocusTo(this.currentFocusedItem.up);
                 break;
             case Direction.RIGHT:
-                this.moveFocusTo(this.currentFocusedItem.right);
+                moved = this.moveFocusTo(this.currentFocusedItem.right);
                 break;
         }
+        return moved;
     }
 
     /**
-     * Calls the HTML focus method on the HTML element passed
+     * Calls the HTML focus method on the HTML element passed and removed focus on currently focused element.
+     * Returns true if the focus is moved and false otherwise.
      */
-    moveFocusTo(item: MenuItem): void {
+    moveFocusTo(item: MenuItem): boolean {
+        let moved = false;
         if (!item) {
-            return;
+            return moved;
         }
         if (this.currentFocusedItem) {
             // Sometimes, when navigating to a nested menu using right arrow, the nested menu trigger gets focused multiple times
             if (Object.is(this.currentFocusedItem.element, item.element)) {
-                return;
+                return moved;
             }
             this.currentFocusedItem.element.blur();
         }
         item.element.focus();
         this.currentFocusedItem = item;
+        moved = true;
+        return moved;
     }
 
     /**
@@ -66,28 +72,43 @@ export class DropdownFocusHandlerService implements OnDestroy {
      * automatically moves the focus to first item in the menu on the right side
      */
     listenToArrowKeys(menuContainer: HTMLElement): void {
+        // The following listeners return false when the focus is moved for the key pressed, in order to prevent the default behavior of
+        // that key. For example, to prevent scrolling of page underneath the dropdown when up and down arrow keys are pressed.
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowdown', (event: Event) => {
-                this.moveFocus(Direction.DOWN);
                 event.stopPropagation();
+                return !this.moveFocus(Direction.DOWN);
             })
         );
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowup', (event: Event) => {
-                this.moveFocus(Direction.UP);
                 event.stopPropagation();
+                return !this.moveFocus(Direction.UP);
             })
         );
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowleft', (event: Event) => {
                 if (!this.currentFocusedItem.left) {
-                    return;
+                    return true;
                 }
                 // Close the nested menu before moving focus to left side
-                this.currentFocusedItem.left.closeMenu(event);
-                this.moveFocus(Direction.LEFT);
+                this.currentFocusedItem.left.closeMenu();
                 event.stopPropagation();
+                return !this.moveFocus(Direction.LEFT);
             })
         );
+    }
+
+    /**
+     * Whenever escape is pressed on dropdown item, the menu has to be closed and the focus has to be moved to parent menu if any... Just
+     * like when left arrow key is pressed
+     */
+    escapePressed(): void {
+        if (!this.currentFocusedItem.left) {
+            return;
+        }
+        // Close the nested menu before moving focus to left side
+        this.currentFocusedItem.left.closeMenu();
+        this.moveFocus(Direction.LEFT);
     }
 }

--- a/projects/components/src/dropdown/dropdown-focus-handler.service.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.service.ts
@@ -49,21 +49,19 @@ export class DropdownFocusHandlerService implements OnDestroy {
      * Returns true if the focus is moved and false otherwise.
      */
     moveFocusTo(item: MenuItem): boolean {
-        let moved = false;
         if (!item) {
-            return moved;
+            return false;
         }
         if (this.currentFocusedItem) {
             // Sometimes, when navigating to a nested menu using right arrow, the nested menu trigger gets focused multiple times
             if (Object.is(this.currentFocusedItem.element, item.element)) {
-                return moved;
+                return false;
             }
             this.currentFocusedItem.element.blur();
         }
         item.element.focus();
         this.currentFocusedItem = item;
-        moved = true;
-        return moved;
+        return true;
     }
 
     /**
@@ -72,29 +70,31 @@ export class DropdownFocusHandlerService implements OnDestroy {
      * automatically moves the focus to first item in the menu on the right side
      */
     listenToArrowKeys(menuContainer: HTMLElement): void {
-        // The following listeners return false when the focus is moved for the key pressed, in order to prevent the default behavior of
-        // that key. For example, to prevent scrolling of page underneath the dropdown when up and down arrow keys are pressed.
+        // We call event.preventDefault below to prevent scrolling of page underneath the dropdown when arrow keys are pressed
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowdown', (event: Event) => {
                 event.stopPropagation();
-                return !this.moveFocus(Direction.DOWN);
+                this.moveFocus(Direction.DOWN);
+                event.preventDefault();
             })
         );
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowup', (event: Event) => {
                 event.stopPropagation();
-                return !this.moveFocus(Direction.UP);
+                this.moveFocus(Direction.UP);
+                event.preventDefault();
             })
         );
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowleft', (event: Event) => {
                 if (!this.currentFocusedItem.left) {
-                    return true;
+                    return;
                 }
                 // Close the nested menu before moving focus to left side
                 this.currentFocusedItem.left.closeMenu();
                 event.stopPropagation();
-                return !this.moveFocus(Direction.LEFT);
+                this.moveFocus(Direction.LEFT);
+                event.preventDefault();
             })
         );
     }

--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -1,4 +1,4 @@
-<clr-dropdown [clrCloseMenuOnItemClick]="false" vcdDynamicDropdown class="nested-dropdown">
+<clr-dropdown vcdDynamicDropdown class="nested-dropdown">
     <button
         [ngClass]="[
             dropdownTriggerBtnTxt ? 'btn btn-link' : '',
@@ -8,6 +8,9 @@
         clrDropdownTrigger
         [vcdShowClippedText]="clipTextConfig"
         [disabled]="isDropdownDisabled"
+        (keydown.enter)="onDropdownTriggerActivated($event)"
+        (keydown.space)="onDropdownTriggerActivated($event)"
+        (keydown.escape)="onDropdownEscPressed($event)"
     >
         <ng-container *ngIf="dropdownTriggerBtnTxt">
             {{ dropdownTriggerBtnTxt }}
@@ -51,8 +54,9 @@
                         [ngClass]="[item.class ? item.class : '', shouldShowIcon ? 'btn-icon' : '', 'btn', 'btn-link']"
                         clrDropdownItem
                         (click)="onItemClicked(item)"
-                        (keydown.space)="onDropdownItemActivated($event)"
                         (keydown.enter)="onDropdownItemActivated($event)"
+                        (keydown.space)="onDropdownItemActivated($event)"
+                        (keydown.escape)="onDropdownEscPressed($event)"
                         [clrDisabled]="isItemDisabled(item)"
                     >
                         <ng-container *ngIf="shouldShowText">{{

--- a/projects/components/src/dropdown/dropdown.component.spec.ts
+++ b/projects/components/src/dropdown/dropdown.component.spec.ts
@@ -49,7 +49,7 @@ class VcdDropdownWidgetObject extends WidgetObject<DropdownComponent> {
 describe('DropdownComponent', () => {
     describe('shouldRenderAsSeparator', () => {
         beforeEach(function (this: HasVcdDropdown): void {
-            this.dropdownComponent = new DropdownComponent(null);
+            this.dropdownComponent = new DropdownComponent(null, null);
         });
         it('returns false when separator is the first item in the list', function (this: HasVcdDropdown): void {
             this.dropdownComponent.items = [

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -312,6 +312,8 @@ export class DropdownComponent implements AfterViewInit {
      */
     onDropdownItemActivated(event: Event): void {
         event.stopPropagation();
+        // We need to dispatch a click event instead of just calling the click handler because, Clarity listens to a
+        // click event to close the menu after an item is activated
         event.target.dispatchEvent(new Event('click'));
     }
 

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -15,6 +15,7 @@ import {
     Provider,
     QueryList,
     Renderer2,
+    Self,
     SkipSelf,
     TrackByFunction,
     ViewChild,
@@ -82,7 +83,10 @@ export class DropdownComponent implements AfterViewInit {
 
     @Output() dropdownMenuUpdated = new EventEmitter<{ menu: HTMLElement }>();
 
-    constructor(@Optional() @SkipSelf() private parentVcdDropdown: DropdownComponent) {}
+    constructor(
+        @Optional() @SkipSelf() private parentVcdDropdown: DropdownComponent,
+        private focusHandler: DropdownFocusHandlerService
+    ) {}
 
     @ViewChild(ClrDropdownMenu)
     set clrDropdownMenu(val: ClrDropdownMenu) {
@@ -183,7 +187,7 @@ export class DropdownComponent implements AfterViewInit {
     @Input() dropdownTriggerButtonClassName: string;
 
     /**
-     * To toggle open an close states when hovered over
+     * To toggle open and close states when hovered over
      */
     @ViewChild(ClrDropdown) clrDropdown: ClrDropdown;
 
@@ -307,10 +311,28 @@ export class DropdownComponent implements AfterViewInit {
      * @param event Space or Enter key press event
      */
     onDropdownItemActivated(event: Event): void {
-        if (!event) {
+        event.stopPropagation();
+        event.target.dispatchEvent(new Event('click'));
+    }
+
+    /**
+     * When space or enter is pressed on a nested trigger, the nested menu has to be opened. So, we trigger a mouseover event which opens
+     * the nested menu
+     * @param event Space or Enter key press event
+     */
+    onDropdownTriggerActivated(event: Event): void {
+        // For the root dropdown, it is already being handled by Clarity
+        if (!this.parentVcdDropdown) {
             return;
         }
-        (event.target as HTMLElement).click();
+        event.stopPropagation();
+        event.target.dispatchEvent(
+            new MouseEvent('mouseover', {
+                view: window,
+                bubbles: true,
+                cancelable: true,
+            })
+        );
     }
 
     /**
@@ -331,5 +353,15 @@ export class DropdownComponent implements AfterViewInit {
      */
     isItemDisabled(item: ActionItem<any, any>): boolean {
         return (CommonUtil.isFunction(item.disabled) ? item.disabled(this.selectedEntities) : item.disabled) as boolean;
+    }
+
+    /**
+     * When an esc key is pressed on a dropdown item, the behavior should be same as pressing left arrow key on the item. This is
+     * being handled here instead of inside the {@link DropdownFocusHandlerService} because, the escape event is being absorned by
+     * Claritys focus handling logic before it reaches the service.
+     */
+    onDropdownEscPressed(event: Event): void {
+        event.stopPropagation();
+        this.focusHandler.escapePressed();
     }
 }

--- a/projects/examples/src/app/components/action-menu/contextual-actions/action-menu-contextual-actions-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/contextual-actions/action-menu-contextual-actions-example.component.ts
@@ -19,12 +19,18 @@ export class ActionMenuContextualActionsExampleComponent {
                 {
                     textKey: 'Add',
                     isTranslatable: false,
+                    handler: () => {
+                        console.log('Add');
+                    },
                     icon: 'plus',
                 },
                 {
                     textKey: 'Delete featured',
                     actionType: ActionType.CONTEXTUAL_FEATURED,
                     isTranslatable: false,
+                    handler: () => {
+                        console.log('Delete featured');
+                    },
                     icon: 'trash',
                 },
             ],


### PR DESCRIPTION
## Why this change:
Fix the following a11y issues in the action menu component:
- Navigating using up & down arrows on the action menu pop-up is making the underlying page scroll. The underlying page should not scroll.
- Pressing the Space/Enter keys on nested menus is not closing the action menu. Pressing those keys from anywhere on the menu should activate the button and then close the menu.
- Pressing the Esc key on the menu should just close the menu.
- Navigation using arrow keys on a menu with separators is not working.

## Testing done:
Tested the action menu in VM and Vapp action menus:
![actionMenuA11yIssuesFix](https://user-images.githubusercontent.com/10735165/100672304-bbaba580-332f-11eb-8a87-c992792b16a0.gif)

In the examples app:
![actionMenuA11yIssuesFix-1](https://user-images.githubusercontent.com/10735165/100672485-02999b00-3330-11eb-81a4-62251dc367a3.gif)
