### PR TITLE
[a11y branch]Fix accessibility issues on Action menu component

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-a11y.6] - 2020-12-2
+### Fixed
+- Underlying page scrolling when navigating the action menu using arrow keys.
+- Space/Enter keys not closing the action menu after a action menu item is activated.
+- Esc key not closing the action menu it is pressed on. 
+- Not being able to navigate using arrow keys on action menu with separators
+
 ## [1.0.0-a11y.5] - 2020-12-2
 
 ### Fixed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-a11y.5",
+    "version": "1.0.0-a11y.6",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.html
+++ b/projects/components/src/action-menu/action-menu.component.html
@@ -11,6 +11,7 @@
         </ng-container>
 
         <vcd-dropdown
+            vcdDropdownFocusHandler
             class="inline-action-dropdown"
             *ngIf="shouldDisplayContextualActionsDropdownInline"
             [items]="contextualActions"
@@ -33,6 +34,7 @@
 </div>
 
 <vcd-dropdown
+    vcdDropdownFocusHandler
     *ngIf="shouldDisplayStaticAndStaticFeaturedActionsDropdown"
     [items]="staticDropdownActions"
     [trackByFunction]="actionsTrackBy"
@@ -46,6 +48,7 @@
 ></vcd-dropdown>
 
 <vcd-dropdown
+    vcdDropdownFocusHandler
     *ngIf="shouldDisplayContextualActionsDropdown"
     [items]="contextualActions"
     [trackByFunction]="actionsTrackBy"

--- a/projects/components/src/dropdown/dropdown-focus-handler.directive.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.directive.ts
@@ -1,0 +1,227 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { AfterViewInit, Directive, Host, OnDestroy, Optional, Renderer2, SkipSelf } from '@angular/core';
+import { SubscriptionTracker } from '../common/subscription';
+import { DropdownFocusHandlerService } from './dropdown-focus-handler.service';
+import { DropdownComponent } from './dropdown.component';
+
+/**
+ * Html node names of different menu items other than separators, that can be part of a {@link DropdownComponent}s html
+ */
+enum DropdownMenuItemType {
+    /**
+     * Menu item that results in executing of an action when clicked
+     */
+    BUTTON = 'BUTTON',
+    /**
+     * Activating this would open a nested menu
+     */
+    NESTED_DROPDOWN_TRIGGER = 'VCD-DROPDOWN',
+}
+
+/**
+ * Arrow keys directions
+ */
+export enum Direction {
+    UP = 'up',
+    DOWN = 'down',
+    LEFT = 'left',
+    RIGHT = 'right',
+}
+
+/**
+ * Object wrapping the focusable HTML elements of dropdown menu with the neighbors in 4 directions of each menu item.
+ */
+export interface MenuItem {
+    /**
+     * The HTML element of this dropdown menu item
+     */
+    element: HTMLElement;
+    /**
+     * Neighboring menu items in all the 4 directions
+     */
+    up?: MenuItem;
+    down?: MenuItem;
+    left?: MenuItem;
+    right?: MenuItem;
+    /**
+     * Call back to close the menu for which this menu item can be a trigger. called from {@link DropdownFocusHandlerService}
+     */
+    closeMenu?: () => void;
+}
+
+/**
+ * Added on to vcd-dropdown component to vertically link menu items of the dropdown on which this directive is added. It also, then links
+ * the vertically linked menu items horizontally to their menu trigger. It then uses the {@link DropdownFocusHandlerService} to move the
+ * DOM focus between the menu items.
+ *
+ * @Example:
+ * <vcd-dropdown
+ *        vcdDropdownFocusHandler
+ *        [items]="contextualActions"
+ *        [onItemClickedCb]="runActionHandler.bind(this)"
+ *        [isItemDisabledCb]="isActionDisabled.bind(this)"
+ * ></vcd-dropdown>
+ */
+@Directive({
+    selector: 'vcd-dropdown[vcdDropdownFocusHandler]',
+})
+export class DropdownFocusHandlerDirective implements AfterViewInit, OnDestroy {
+    constructor(
+        @Optional() @SkipSelf() private parentVcdDropdown: DropdownComponent,
+        @Optional() @SkipSelf() private parentFocusHandler: DropdownFocusHandlerDirective,
+        @Host() private hostVcdDropdown: DropdownComponent,
+        private focusHandlerService: DropdownFocusHandlerService,
+        private renderer: Renderer2
+    ) {}
+
+    /**
+     * List of focusable menu items with their neighbors in 4 directions.
+     */
+    menuItems: MenuItem[];
+    /**
+     * The menu item which can toggle this menu. This can be the root dropdown trigger or nested menu trigger
+     */
+    private menuTrigger: MenuItem;
+    private dropdownTriggerEl: HTMLElement;
+    private clrDropdownMenuEl: HTMLElement;
+    private isRootDropdown = !this.parentVcdDropdown;
+    private timeoutId: number;
+    private subscriptionTracker = new SubscriptionTracker(this);
+    private unlistenRightArrowKeyPress: (...argArray: any[]) => any;
+
+    /**
+     * After a dropdown menu is opened, it creates {@link MenuItem} for each of the menu items along with their trigger menu item and links
+     * them. It also then moves the focus to first item in the opened menu list.
+     */
+    ngAfterViewInit(): void {
+        this.dropdownTriggerEl = this.hostVcdDropdown._dropdownTriggerEl;
+        this.listenToRightArrowKeyPressOnNestedTrigger();
+
+        this.subscriptionTracker.subscribe(this.hostVcdDropdown.dropdownMenuUpdated, (dropdown) => {
+            if (!dropdown) {
+                this.reset();
+                return;
+            }
+            this.clrDropdownMenuEl = dropdown.menu;
+            // We have to wait till the dropdown is opened for getting the menus trigger because, in case of a nested menu, the trigger is
+            // obtained from parent menus menuItems and they are not initialized even if we wait till the ngAfterViewInit hook
+            this.menuTrigger = this.isRootDropdown ? this.rootMenuTrigger : this.nestedMenuTrigger;
+            this.registerRootMenuContainer();
+            this.linkMenuItems();
+            this.moveFocusToFirstItem();
+        });
+    }
+
+    /**
+     * Sometimes when the right arrow key is pressed on a nested menu trigger, the event is propagating to sibling nested menu triggers and
+     * the event handlers attached to the menu triggers by clarity to toggle the menus are being invoked. Because of this, pressing right
+     * arrow on a nested menu is opening other sibling menus as well
+     */
+    private listenToRightArrowKeyPressOnNestedTrigger(): void {
+        if (this.isRootDropdown) {
+            return;
+        }
+        this.unlistenRightArrowKeyPress = this.renderer.listen(
+            this.dropdownTriggerEl,
+            'keydown.arrowright',
+            (event: Event) => event.stopPropagation()
+        );
+    }
+
+    private reset(): void {
+        if (this.isRootDropdown) {
+            this.focusHandlerService.unlistenFuncs.forEach((unlisten) => unlisten());
+        }
+        this.menuTrigger = null;
+        this.menuItems = null;
+    }
+
+    ngOnDestroy(): void {
+        if (this.unlistenRightArrowKeyPress) {
+            this.unlistenRightArrowKeyPress();
+        }
+    }
+
+    private registerRootMenuContainer(): void {
+        if (this.isRootDropdown) {
+            const rootMenuContainer = this.clrDropdownMenuEl;
+            this.focusHandlerService.listenToArrowKeys(rootMenuContainer);
+        }
+    }
+
+    private moveFocusToFirstItem(): void {
+        this.focusHandlerService.moveFocusTo(this.menuTrigger);
+        // After the menu is opened, the ClrDropdownMenu wouldn't be attached to the DOM until the next change detection cycle.
+        // So setTimeout is the only way to wait for the ClrDropdownMenu to be ready to move focus to first item.
+        this.timeoutId = window.setTimeout(() => {
+            if (this.parentVcdDropdown) {
+                this.focusHandlerService.moveFocus(Direction.RIGHT);
+            } else {
+                this.focusHandlerService.moveFocus(Direction.DOWN);
+            }
+            window.clearTimeout(this.timeoutId);
+        });
+    }
+
+    private linkMenuItems(): void {
+        const menuChildren: Element[] = Array.from(this.clrDropdownMenuEl.children);
+        this.menuItems = menuChildren
+            .filter(
+                (child) =>
+                    child.nodeName === DropdownMenuItemType.BUTTON ||
+                    child.nodeName === DropdownMenuItemType.NESTED_DROPDOWN_TRIGGER
+            )
+            .map((child) => ({
+                element: (child.matches('button')
+                    ? child
+                    : child.querySelector('clr-dropdown > button')) as HTMLElement,
+                left: this.menuTrigger,
+            }));
+        this.linkVertical();
+        // Lint to menu trigger
+        if (this.isRootDropdown) {
+            this.menuTrigger.down = this.menuItems[0];
+        } else {
+            // If there is a parent dropdown, We have to link these menu items to their trigger in the parent dropdown
+            this.menuTrigger.right = this.menuItems[0];
+        }
+    }
+
+    private get rootMenuTrigger(): MenuItem {
+        return {
+            element: this.dropdownTriggerEl,
+            closeMenu: () => {
+                this.hostVcdDropdown.clrDropdown.toggleService.open = false;
+            },
+        };
+    }
+
+    private get nestedMenuTrigger(): MenuItem {
+        const menuTrigger = this.parentFocusHandler.menuItems.find((item) => {
+            return Object.is(item.element.innerText, this.dropdownTriggerEl.innerText);
+        });
+        menuTrigger.closeMenu = () => {
+            this.hostVcdDropdown.clrDropdown.toggleService.open = false;
+        };
+        return menuTrigger;
+    }
+
+    private linkVertical(): void {
+        this.menuItems.forEach((menuItem: MenuItem, index: number) => {
+            if (index > 0) {
+                menuItem.up = this.menuItems[index - 1];
+            }
+            if (index < this.menuItems.length - 1) {
+                menuItem.down = this.menuItems[index + 1];
+            }
+        });
+        if (this.menuItems.length > 1) {
+            this.menuItems[0].up = this.menuItems[this.menuItems.length - 1];
+            this.menuItems[this.menuItems.length - 1].down = this.menuItems[0];
+        }
+    }
+}

--- a/projects/components/src/dropdown/dropdown-focus-handler.service.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.service.ts
@@ -1,0 +1,114 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Injectable, OnDestroy, Renderer2 } from '@angular/core';
+import { Direction, MenuItem } from './dropdown-focus-handler.directive';
+
+/**
+ * Provided at the injector level of root {@link DropdownComponent}. The same service object is used for all the nested menus along
+ * with the root menu. This is responsible for listening to arrow key presses within the root dropdown menu container and updating the
+ * focused item on the DOM across all the nested and root menus.
+ */
+@Injectable()
+export class DropdownFocusHandlerService implements OnDestroy {
+    currentFocusedItem: MenuItem;
+    unlistenFuncs: (() => void)[] = [];
+
+    constructor(private renderer: Renderer2) {}
+
+    ngOnDestroy(): void {
+        this.unlistenFuncs.forEach((unlisten) => unlisten());
+    }
+
+    /**
+     * Moves the focus to HTML element in the given direction and returns true if the focus is moved and false otherwise
+     */
+    moveFocus(direction: Direction): boolean {
+        let moved;
+        switch (direction) {
+            case Direction.DOWN:
+                moved = this.moveFocusTo(this.currentFocusedItem.down);
+                break;
+            case Direction.LEFT:
+                moved = this.moveFocusTo(this.currentFocusedItem.left);
+                break;
+            case Direction.UP:
+                moved = this.moveFocusTo(this.currentFocusedItem.up);
+                break;
+            case Direction.RIGHT:
+                moved = this.moveFocusTo(this.currentFocusedItem.right);
+                break;
+        }
+        return moved;
+    }
+
+    /**
+     * Calls the HTML focus method on the HTML element passed and removed focus on currently focused element.
+     * Returns true if the focus is moved and false otherwise.
+     */
+    moveFocusTo(item: MenuItem): boolean {
+        let moved = false;
+        if (!item) {
+            return moved;
+        }
+        if (this.currentFocusedItem) {
+            // Sometimes, when navigating to a nested menu using right arrow, the nested menu trigger gets focused multiple times
+            if (Object.is(this.currentFocusedItem.element, item.element)) {
+                return moved;
+            }
+            this.currentFocusedItem.element.blur();
+        }
+        item.element.focus();
+        this.currentFocusedItem = item;
+        moved = true;
+        return moved;
+    }
+
+    /**
+     * Attaches arrow key event listeners to the root menu container in all direction except right. This is because, when a right arrow is
+     * pressed, Clarity opens the nested dropdown menu and the logic inside {@link DropdownFocusHandlerDirective.ngAfterViewInit}
+     * automatically moves the focus to first item in the menu on the right side
+     */
+    listenToArrowKeys(menuContainer: HTMLElement): void {
+        // The following listeners return false when the focus is moved for the key pressed, in order to prevent the default behavior of
+        // that key. For example, to prevent scrolling of page underneath the dropdown when up and down arrow keys are pressed.
+        this.unlistenFuncs.push(
+            this.renderer.listen(menuContainer, 'keydown.arrowdown', (event: Event) => {
+                event.stopPropagation();
+                return !this.moveFocus(Direction.DOWN);
+            })
+        );
+        this.unlistenFuncs.push(
+            this.renderer.listen(menuContainer, 'keydown.arrowup', (event: Event) => {
+                event.stopPropagation();
+                return !this.moveFocus(Direction.UP);
+            })
+        );
+        this.unlistenFuncs.push(
+            this.renderer.listen(menuContainer, 'keydown.arrowleft', (event: Event) => {
+                if (!this.currentFocusedItem.left) {
+                    return true;
+                }
+                // Close the nested menu before moving focus to left side
+                this.currentFocusedItem.left.closeMenu();
+                event.stopPropagation();
+                return !this.moveFocus(Direction.LEFT);
+            })
+        );
+    }
+
+    /**
+     * Whenever escape is pressed on dropdown item, the menu has to be closed and the focus has to be moved to parent menu if any... Just
+     * like when left arrow key is pressed
+     */
+    escapePressed(): void {
+        if (!this.currentFocusedItem.left) {
+            return;
+        }
+        // Close the nested menu before moving focus to left side
+        this.currentFocusedItem.left.closeMenu();
+        this.moveFocus(Direction.LEFT);
+    }
+}

--- a/projects/components/src/dropdown/dropdown-focus-handler.service.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.service.ts
@@ -49,21 +49,19 @@ export class DropdownFocusHandlerService implements OnDestroy {
      * Returns true if the focus is moved and false otherwise.
      */
     moveFocusTo(item: MenuItem): boolean {
-        let moved = false;
         if (!item) {
-            return moved;
+            return false;
         }
         if (this.currentFocusedItem) {
             // Sometimes, when navigating to a nested menu using right arrow, the nested menu trigger gets focused multiple times
             if (Object.is(this.currentFocusedItem.element, item.element)) {
-                return moved;
+                return false;
             }
             this.currentFocusedItem.element.blur();
         }
         item.element.focus();
         this.currentFocusedItem = item;
-        moved = true;
-        return moved;
+        return true;
     }
 
     /**
@@ -72,29 +70,31 @@ export class DropdownFocusHandlerService implements OnDestroy {
      * automatically moves the focus to first item in the menu on the right side
      */
     listenToArrowKeys(menuContainer: HTMLElement): void {
-        // The following listeners return false when the focus is moved for the key pressed, in order to prevent the default behavior of
-        // that key. For example, to prevent scrolling of page underneath the dropdown when up and down arrow keys are pressed.
+        // We call event.preventDefault below to prevent scrolling of page underneath the dropdown when arrow keys are pressed
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowdown', (event: Event) => {
                 event.stopPropagation();
-                return !this.moveFocus(Direction.DOWN);
+                this.moveFocus(Direction.DOWN);
+                event.preventDefault();
             })
         );
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowup', (event: Event) => {
                 event.stopPropagation();
-                return !this.moveFocus(Direction.UP);
+                this.moveFocus(Direction.UP);
+                event.preventDefault();
             })
         );
         this.unlistenFuncs.push(
             this.renderer.listen(menuContainer, 'keydown.arrowleft', (event: Event) => {
                 if (!this.currentFocusedItem.left) {
-                    return true;
+                    return;
                 }
                 // Close the nested menu before moving focus to left side
                 this.currentFocusedItem.left.closeMenu();
                 event.stopPropagation();
-                return !this.moveFocus(Direction.LEFT);
+                this.moveFocus(Direction.LEFT);
+                event.preventDefault();
             })
         );
     }

--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -8,6 +8,9 @@
         clrDropdownTrigger
         [vcdShowClippedText]="clipTextConfig"
         [disabled]="isDropdownDisabled"
+        (keydown.enter)="onDropdownTriggerActivated($event)"
+        (keydown.space)="onDropdownTriggerActivated($event)"
+        (keydown.escape)="onDropdownEscPressed($event)"
     >
         <ng-container *ngIf="dropdownTriggerBtnTxt">
             {{ dropdownTriggerBtnTxt }}
@@ -32,6 +35,7 @@
 
                 <ng-container *ngIf="!item.isSeparator && item.children && item.children.length">
                     <vcd-dropdown
+                        vcdDropdownFocusHandler
                         [items]="item.children"
                         [selectedEntities]="selectedEntities"
                         [dropdownTriggerBtnTxt]="
@@ -50,6 +54,9 @@
                         [ngClass]="[item.class ? item.class : '', shouldShowIcon ? 'btn-icon' : '', 'btn', 'btn-link']"
                         clrDropdownItem
                         (click)="onItemClicked(item)"
+                        (keydown.enter)="onDropdownItemActivated($event)"
+                        (keydown.space)="onDropdownItemActivated($event)"
+                        (keydown.escape)="onDropdownEscPressed($event)"
                         [clrDisabled]="isItemDisabled(item)"
                     >
                         <ng-container *ngIf="shouldShowText">{{

--- a/projects/components/src/dropdown/dropdown.component.spec.ts
+++ b/projects/components/src/dropdown/dropdown.component.spec.ts
@@ -49,7 +49,7 @@ class VcdDropdownWidgetObject extends WidgetObject<DropdownComponent> {
 describe('DropdownComponent', () => {
     describe('shouldRenderAsSeparator', () => {
         beforeEach(function (this: HasVcdDropdown): void {
-            this.dropdownComponent = new DropdownComponent(null);
+            this.dropdownComponent = new DropdownComponent(null, null);
         });
         it('returns false when separator is the first item in the list', function (this: HasVcdDropdown): void {
             this.dropdownComponent.items = [
@@ -245,6 +245,7 @@ describe('DropdownComponent', () => {
 @Component({
     template: `
         <vcd-dropdown
+            vcdDropdownFocusHandler
             [items]="items"
             [dropdownTriggerBtnTxt]="'Dropdown'"
             [dropdownTriggerButtonClassName]="primaryDropdownClassName"

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -312,6 +312,8 @@ export class DropdownComponent implements AfterViewInit {
      */
     onDropdownItemActivated(event: Event): void {
         event.stopPropagation();
+        // We need to dispatch a click event instead of just calling the click handler because, Clarity listens to a
+        // click event to close the menu after an item is activated
         event.target.dispatchEvent(new Event('click'));
     }
 

--- a/projects/components/src/dropdown/dropdown.module.ts
+++ b/projects/components/src/dropdown/dropdown.module.ts
@@ -9,12 +9,13 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
 import { ShowClippedTextDirectiveModule } from '../lib/directives/show-clipped-text.directive.module';
+import { DropdownFocusHandlerDirective } from './dropdown-focus-handler.directive';
 import { DropdownComponent } from './dropdown.component';
 import { DynamicDropdownPositionDirective } from './dynamic-dropdown-position.directive';
 
 @NgModule({
-    declarations: [DropdownComponent, DynamicDropdownPositionDirective],
+    declarations: [DropdownComponent, DynamicDropdownPositionDirective, DropdownFocusHandlerDirective],
     imports: [CommonModule, ReactiveFormsModule, ClarityModule, I18nModule, ShowClippedTextDirectiveModule],
-    exports: [DropdownComponent, DynamicDropdownPositionDirective],
+    exports: [DropdownComponent, DynamicDropdownPositionDirective, DropdownFocusHandlerDirective],
 })
 export class DropdownModule {}


### PR DESCRIPTION
# Note:
This Pull request is similar to the PR created to merge into the master branch at https://github.com/vmware/vmware-cloud-director-ui-components/pull/264. However, This PR is created separately because the accessibility fixes(`DropdownFocusHandlerDirective`, `DropdownFocusHandlerService`) that are already checked into the `master` branch didn't make it into the `a11y` branch and hence this PR contains duplicate changes.
Please review the changes at https://github.com/vmware/vmware-cloud-director-ui-components/pull/264 to approve this PR.

## Why this change:
Fix the following a11y issues in the action menu component:
- Navigating using up & down arrows on the action menu pop-up is making the underlying page scroll. The underlying page should not scroll.
- Pressing the Space/Enter keys on nested menus is not closing the action menu. Pressing those keys from anywhere on the menu should activate the button and then close the menu.
- Pressing the Esc key on the menu should just close the menu.
- Navigation using arrow keys on a menu with separators is not working.

## Testing done:
Tested the action menu in VM and Vapp action menus:
![actionMenuA11yIssuesFix](https://user-images.githubusercontent.com/10735165/100672304-bbaba580-332f-11eb-8a87-c992792b16a0.gif)

In the examples app:
![actionMenuA11yIssuesFix-1](https://user-images.githubusercontent.com/10735165/100672485-02999b00-3330-11eb-81a4-62251dc367a3.gif)
