### PR TITLE
[a11y] Show validation errors when users type invalid numbers

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Display error messages for invalid input on form controls accepting numbers. Includes refactoringh
 ### Added
 - Enabled hints for vcd-form-checkbox
 - Fixed previous bad vcdResponsiveInput commits. Module was incorrectly setup and vcdResponsiveInput had

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -66,9 +66,9 @@ vcd.cc.cpu.speed.unit.YHz={0} YHz
 
 # Validation error strings
 vcd.cc.warning.numRange=Only numbers in the range of {1} to {2} are allowed
-
 vcd.cc.numeric.filter.from=From:
 vcd.cc.numeric.filter.to=To:
+vcd.cc.bad.input=Invalid number
 
 vcd.cc.datagrid.actions=Actions
 

--- a/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.spec.ts
+++ b/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.spec.ts
@@ -35,22 +35,22 @@ describe('Datagrid numeric filter', () => {
     });
 
     describe('set unitOptions', () => {
-        beforeEach(function(this: HasDgNumericFilter): void {
+        beforeEach(function (this: HasDgNumericFilter): void {
             this.filter = createDatagridFilterTestHelper(DatagridNumericFilterComponent, {
                 unitOptions: [...Bytes.types],
             });
         });
-        it('sets the unit options with value given', function(this: HasDgNumericFilter): void {
+        it('sets the unit options with value given', function (this: HasDgNumericFilter): void {
             expect((this.filter as DatagridNumericFilterComponent).unitOptions).toEqual([...Bytes.types]);
         });
 
-        it('sets the base unit with value of first option when no base unit is set', function(this: HasDgNumericFilter): void {
+        it('sets the base unit with value of first option when no base unit is set', function (this: HasDgNumericFilter): void {
             expect((this.filter as DatagridNumericFilterComponent).unit).toEqual([...Bytes.types][0]);
         });
     });
 
     describe('unit', () => {
-        it('sets the base unit with value given in config', function(this: HasDgNumericFilter): void {
+        it('sets the base unit with value given in config', function (this: HasDgNumericFilter): void {
             this.filter = createDatagridFilterTestHelper(DatagridNumericFilterComponent, {
                 unitOptions: [...Bytes.types],
                 unit: Bytes.GB,
@@ -58,7 +58,7 @@ describe('Datagrid numeric filter', () => {
             expect((this.filter as DatagridNumericFilterComponent).unit).toEqual(Bytes.GB);
         });
 
-        it('sets the base unit with value of first option when null is passed in the config', function(this: HasDgNumericFilter): void {
+        it('sets the base unit with value of first option when null is passed in the config', function (this: HasDgNumericFilter): void {
             this.filter = createDatagridFilterTestHelper(DatagridNumericFilterComponent, {
                 unitOptions: [...Bytes.types],
                 unit: null,
@@ -68,25 +68,25 @@ describe('Datagrid numeric filter', () => {
     });
 
     describe('setValue', () => {
-        beforeEach(function(this: HasDgNumericFilter): void {
+        beforeEach(function (this: HasDgNumericFilter): void {
             this.filter = createDatagridFilterTestHelper(DatagridNumericFilterComponent);
         });
-        it('sets from and to when both are defined', function(this: HasDgNumericFilter): void {
+        it('sets from and to when both are defined', function (this: HasDgNumericFilter): void {
             this.filter.setValue([1, 2]);
             expect(this.filter.formGroup.get('from').value).toEqual(1);
             expect(this.filter.formGroup.get('to').value).toEqual(2);
         });
-        it('sets only from when to is null', function(this: HasDgNumericFilter): void {
+        it('sets only from when to is null', function (this: HasDgNumericFilter): void {
             this.filter.setValue([1, null]);
             expect(this.filter.formGroup.get('from').value).toEqual(1);
             expect(this.filter.formGroup.get('to').value).toEqual(null);
         });
-        it('sets only to when from is null', function(this: HasDgNumericFilter): void {
+        it('sets only to when from is null', function (this: HasDgNumericFilter): void {
             this.filter.setValue([null, 2]);
             expect(this.filter.formGroup.get('from').value).toEqual(null);
             expect(this.filter.formGroup.get('to').value).toEqual(2);
         });
-        it('does not set when undefined or null is passed', function(this: HasDgNumericFilter): void {
+        it('does not set when undefined or null is passed', function (this: HasDgNumericFilter): void {
             this.filter.setValue(undefined);
             expect(this.filter.formGroup.get('from').value).toEqual(null);
             expect(this.filter.formGroup.get('to').value).toEqual(null);
@@ -99,28 +99,28 @@ describe('Datagrid numeric filter', () => {
     describe('getValue', () => {
         const queryFieldName = FilterTestHostComponent.filterColumn.queryFieldName;
         describe('without units', () => {
-            beforeEach(function(this: HasDgNumericFilter): void {
+            beforeEach(function (this: HasDgNumericFilter): void {
                 this.filter = createDatagridFilterTestHelper(DatagridNumericFilterComponent);
             });
-            it('returns a FIQL string with gt as operator when only from is set', function(this: HasDgNumericFilter): void {
+            it('returns a FIQL string with gt as operator when only from is set', function (this: HasDgNumericFilter): void {
                 this.filter.setValue([1, null]);
                 expect(this.filter.getValue()).toEqual(`${queryFieldName}=gt=1`);
             });
-            it('returns a FIQL string with both ge and le as operators when both limits are set', function(this: HasDgNumericFilter): void {
+            it('returns FIQL string with both ge and le as operators when both limits are set', function (this: HasDgNumericFilter): void {
                 this.filter.setValue([1, 10]);
                 expect(this.filter.getValue()).toEqual(`(${queryFieldName}=ge=1;${queryFieldName}=le=10)`);
             });
-            it('returns a FIQL string with lt as operator when only to is set', function(this: HasDgNumericFilter): void {
+            it('returns a FIQL string with lt as operator when only to is set', function (this: HasDgNumericFilter): void {
                 this.filter.setValue([null, 10]);
                 expect(this.filter.getValue()).toEqual(`${queryFieldName}=lt=10`);
             });
-            it('returns a FIQL string with both ge and le as operators when both limits are 0', function(this: HasDgNumericFilter): void {
+            it('returns a FIQL string with both ge and le as operators when both limits are 0', function (this: HasDgNumericFilter): void {
                 this.filter.setValue([0, 0]);
                 expect(this.filter.getValue()).toEqual(`(${queryFieldName}=ge=0;${queryFieldName}=le=0)`);
             });
         });
         describe('with units', () => {
-            beforeEach(function(this: HasFinderAndFilter): void {
+            beforeEach(function (this: HasFinderAndFilter): void {
                 const finderAndFilter = createDatagridFilterTestHelperWithFinder(DatagridNumericFilterComponent, {
                     unitOptions: [...Bytes.types],
                     unit: Bytes.MB,
@@ -128,34 +128,36 @@ describe('Datagrid numeric filter', () => {
                 this.finder = finderAndFilter.finder;
                 this.filter = finderAndFilter.filter;
             });
-            it('returns a FIQL string with values converted to base unit of MB from selected unit of ' + 'GB', function(
-                this: HasFinderAndFilter
-            ): void {
-                const [fromValInGb, toValInGb] = [1, 10];
-                const [fromValInMb, toValInMb] = [1024, 10240];
-                this.filter.setValue([fromValInGb, toValInGb]);
-                (this.filter as DatagridNumericFilterComponent).fromInput.selectedUnit = Bytes.GB.getMultiplier();
-                (this.filter as DatagridNumericFilterComponent).toInput.selectedUnit = Bytes.GB.getMultiplier();
-                expect(this.filter.getValue()).toEqual(
-                    `(${queryFieldName}=ge=${fromValInMb};${queryFieldName}=le=${toValInMb})`
-                );
-            });
+            it(
+                'returns a FIQL string with values converted to base unit of MB from selected unit of ' + 'GB',
+                function (this: HasFinderAndFilter): void {
+                    const [fromValInGb, toValInGb] = [1, 10];
+                    const [fromValInMb, toValInMb] = [1024, 10240];
+                    this.filter.setValue([fromValInGb, toValInGb]);
+                    const filter = this.filter as DatagridNumericFilterComponent;
+                    filter.fromInput.onUnitChange(Bytes.GB.getMultiplier().toString());
+                    filter.toInput.onUnitChange(Bytes.GB.getMultiplier().toString());
+                    expect(this.filter.getValue()).toEqual(
+                        `(${queryFieldName}=ge=${fromValInMb};${queryFieldName}=le=${toValInMb})`
+                    );
+                }
+            );
         });
     });
 
     describe('isActive', () => {
-        beforeEach(function(this: HasDgNumericFilter): void {
+        beforeEach(function (this: HasDgNumericFilter): void {
             this.filter = createDatagridFilterTestHelper(DatagridNumericFilterComponent);
         });
-        it('returns false when formGroup is undefined', function(this: HasDgNumericFilter): void {
+        it('returns false when formGroup is undefined', function (this: HasDgNumericFilter): void {
             this.filter.formGroup = null;
             expect(this.filter.isActive()).toEqual(false);
         });
-        it('returns false when both from and to inputs are null', function(this: HasDgNumericFilter): void {
+        it('returns false when both from and to inputs are null', function (this: HasDgNumericFilter): void {
             this.filter.setValue([null, null]);
             expect(this.filter.isActive()).toEqual(false);
         });
-        it('returns true when either from or to or both inputs are defined', function(this: HasDgNumericFilter): void {
+        it('returns true when either from or to or both inputs are defined', function (this: HasDgNumericFilter): void {
             this.filter.setValue([1, null]);
             expect(this.filter.isActive()).toEqual(true);
             this.filter.setValue([null, 1]);
@@ -163,7 +165,7 @@ describe('Datagrid numeric filter', () => {
             this.filter.setValue([1, 2]);
             expect(this.filter.isActive()).toEqual(true);
         });
-        it('does not return false when inputs are 0', function(this: HasDgNumericFilter): void {
+        it('does not return false when inputs are 0', function (this: HasDgNumericFilter): void {
             this.filter.setValue([0, null]);
             expect(this.filter.isActive()).toEqual(true);
             this.filter.setValue([null, 0]);

--- a/projects/components/src/form/form-input/form-input.component.ts
+++ b/projects/components/src/form/form-input/form-input.component.ts
@@ -14,8 +14,8 @@ import {
     Self,
     ViewChild,
 } from '@angular/core';
-import { NgControl } from '@angular/forms';
-import { BaseFormControl } from '../base-form-control';
+import { AbstractControl, FormControl, NgControl, ValidationErrors } from '@angular/forms';
+import { BaseFormControl, defaultValidatorForControl } from '../base-form-control';
 
 /**
  * A {@link FormControl} that contains an input that supports string, number and datetime-local input types
@@ -122,6 +122,9 @@ export class FormInputComponent extends BaseFormControl implements AfterViewInit
         // The textInput view child element is only defined after this life cycle hook. So, the writeValue is called
         // here.
         this.writeValue(this.initialValue);
+        if (this.type === 'number') {
+            defaultValidatorForControl(this.formControl, () => this.validateNumber());
+        }
     }
 
     inputChanged(): void {
@@ -154,6 +157,13 @@ export class FormInputComponent extends BaseFormControl implements AfterViewInit
         }
         this.textInput.nativeElement.focus();
         this.textInput.nativeElement.select();
+    }
+
+    /**
+     * Default validator that looks at the input's [validity](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
+     */
+    validateNumber(): ValidationErrors {
+        return this.textInput?.nativeElement.validity.badInput ? { 'vcd.cc.bad.input': true } : null;
     }
 }
 

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -1,61 +1,82 @@
 <div class="clr-form-control" vcdResponsiveInput *ngIf="isReadOnly">
     <label class="clr-control-label">{{ label }}</label>
-    <span class="clr-control-container readonly-text">{{ this.displayValue }}</span>
+    <span class="clr-control-container readonly-text">{{ displayValue || '-' }}</span>
 </div>
-<div *ngIf="!isReadOnly" class="input-number-with-unit">
-    <vcd-form-input
-        #limitedInput
-        [formControl]="formGroup.controls.limited"
-        [placeholder]="placeholder"
-        type="number"
-        [size]="size"
-        [min]="unitMin"
-        [max]="unitMax"
-        [maxlength]="maxlength"
-        [showAsterisk]="showAsterisk"
-        [label]="label"
-        [description]="description"
-    >
-        <aside [ngSwitch]="unitOptions.length">
-            <ng-container *ngSwitchCase="0">
-                <!-- Do not display unit -->
-            </ng-container>
-            <ng-container *ngSwitchCase="1">
-                <div class="single-option">{{ unitOptions[0].getUnitNameTranslationKey() | translate }}</div>
-            </ng-container>
-            <vcd-form-select
-                class="combo-options"
-                *ngSwitchDefault
-                #unitDropdown
-                [options]="comboOptions"
-                [formControl]="formGroup.controls.comboUnitOptions"
-            >
-            </vcd-form-select>
-            <clr-signpost *ngIf="hint">
-                <clr-signpost-content [clrPosition]="hintPosition" *clrIfOpen>
-                    <p>{{ hint }}</p>
-                </clr-signpost-content>
-            </clr-signpost>
-        </aside>
-    </vcd-form-input>
-    <div class="clr-form-control errors" vcdResponsiveInput *ngIf="showErrors">
-        <!-- Label is here to take up space so that the error aligns with the right side only -->
-        <label class="clr-control-label"></label>
-        <div class="clr-error">
-            <span class="clr-subtext">
+
+<div *ngIf="!isReadOnly">
+    <div class="clr-form-control" vcdResponsiveInput>
+        <label *ngIf="label" class="clr-control-label" [for]="id" [ngClass]="{ 'required-field': showAsterisk }">{{
+            label
+        }}</label>
+        <div class="clr-control-container" [ngClass]="{ 'clr-error': showErrors }">
+            <div class="clr-input-wrapper">
+                <input
+                    [id]="id"
+                    class="clr-input"
+                    type="number"
+                    [min]="unitMin"
+                    [max]="unitMax"
+                    #textInput
+                    (ngModelChange)="onTextInputChange($event)"
+                    [ngModel]="textInputValue"
+                    [attr.disabled]="shouldDisableNumberAndUnitControls"
+                    [attr.placeholder]="placeholder"
+                    [attr.size]="size"
+                    [attr.aria-required]="showAsterisk"
+                    [attr.aria-describedby]="showErrors ? errorsId : descriptionId"
+                />
+                <ng-container [ngSwitch]="unitOptions.length">
+                    <ng-container *ngSwitchCase="0">
+                        <!-- Do not display unit -->
+                    </ng-container>
+                    <div class="single-option" *ngSwitchCase="1">
+                        {{ unitOptions[0].getUnitNameTranslationKey() | translate }}
+                    </div>
+
+                    <div class="clr-select-wrapper" *ngSwitchDefault>
+                        <select
+                            [id]="id + 'unit'"
+                            (ngModelChange)="onUnitChange($event)"
+                            [ngModel]="unitsControlValue"
+                            [attr.disabled]="shouldDisableNumberAndUnitControls"
+                        >
+                            <option *ngFor="let option of comboOptions" [value]="option.value">
+                                {{ option.isTranslatable ? (option.display | translate) : option.display }}
+                            </option>
+                        </select>
+                    </div>
+                </ng-container>
+                <clr-icon *ngIf="showErrors" class="clr-validate-icon" shape="exclamation-circle"></clr-icon>
+                <clr-signpost *ngIf="hint">
+                    <clr-signpost-content [clrPosition]="hintPosition" *clrIfOpen>
+                        {{ hint }}
+                    </clr-signpost-content>
+                </clr-signpost>
+            </div>
+            <div class="clr-subtext" *ngIf="showErrors" [id]="errorsId">
                 <div *ngFor="let error of errors | keyvalue">
                     <div>{{ error.key | translate: getErrorTranslationParams(error.value) }}</div>
                 </div>
-            </span>
+            </div>
+            <div class="clr-subtext" *ngIf="!showErrors && description" [id]="descriptionId">
+                {{ description }}
+            </div>
+
+            <div
+                *ngIf="showUnlimitedOption"
+                class="clr-checkbox-wrapper"
+                [ngClass]="{ 'clr-form-control-disabled': disabled }"
+            >
+                <input
+                    type="checkbox"
+                    class="clr-checkbox"
+                    [attr.disabled]="disabled || null"
+                    [id]="id + 'checkbox'"
+                    (ngModelChange)="onUnlimitedCheckboxChange($event)"
+                    [ngModel]="unlimitedControlValue"
+                />
+                <label class="clr-control-label" [for]="id + 'checkbox'">{{ 'vcd.cc.unlimited' | translate }}</label>
+            </div>
         </div>
     </div>
-
-    <footer *ngIf="showUnlimitedOption">
-        <!-- Setting [label] to space ensures the label is created hence the checkbox aligned properly -->
-        <vcd-form-checkbox
-            [label]="' '"
-            [text]="'vcd.cc.unlimited' | translate"
-            [formControl]="formGroup.controls.unlimited"
-        ></vcd-form-checkbox>
-    </footer>
 </div>

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
@@ -1,86 +1,33 @@
-single-option {
-    margin-left: 4px;
-    margin-top: 12px;
-}
-
-:host {
-    display: block;
-}
-
-aside > * {
-    display: inline-block;
-}
-
-/* Undo the nowrap added by .clr-input-container */
 clr-signpost-content {
+    // Undo the nowrap added by .clr-input-container
     white-space: normal;
+    // To make the icon line up nicer
+    ::ng-deep button {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
 }
 
-:host ::ng-deep {
-    .clr-control-container {
-        flex: 0 1 auto;
+.clr-input {
+    width: 5rem;
+}
+
+// To make the text input and the select align, it still doesn't at some zoom levels.
+input[type='number'] {
+    margin-top: 1px;
+}
+
+.clr-input-wrapper {
+    align-items: center;
+    display: flex;
+}
+
+.clr-error {
+    // When there's an error, the arrow in the dropdown is offset, undo it
+    .clr-select-wrapper::after {
+        right: 0.3rem;
     }
-
-    .input-number-with-unit {
-        .clr-subtext:empty {
-            display: none;
-        }
-
-        .clr-form-control.errors {
-            margin-top: 0;
-
-            label {
-                margin: 0;
-            }
-        }
-
-        clr-signpost {
-            button {
-                height: 1.3rem;
-                clr-icon {
-                    vertical-align: baseline;
-                    transform: none;
-                }
-            }
-        }
-
-        vcd-form-input {
-            input {
-                width: 5rem;
-            }
-        }
-
-        .clr-control-label {
-            + .clr-control-container {
-                width: auto;
-                .clr-input-wrapper {
-                    display: flex;
-                    .clr-input {
-                        margin-right: 0;
-                    }
-                }
-            }
-        }
-
-        aside {
-            display: flex;
-            flex: 0 1 auto;
-            min-width: 50px;
-            margin-top: -1px !important;
-            margin-left: 5px;
-            vcd-form-select {
-                .clr-form-control {
-                    margin-top: 0;
-                }
-            }
-        }
-
-        footer {
-            vcd-form-checkbox {
-                .clr-form-control {
-                    margin-top: 0;
-                }
-            }
-        }
+    .clr-validate-icon {
+        margin-left: 0;
     }
 }

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -89,28 +89,29 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
 
     describe('showUnlimitedOption', () => {
         it('shows the unlimited checkbox by default', () => {
-            expect(numberWithUnitInput.unlimitedFormControl).toBeTruthy();
+            expect(numberWithUnitInput.isShowingUnlimitedCheckbox).toBe(true);
         });
 
         it('disables the value and unit fields when unlimited checkbox is checked', () => {
-            numberWithUnitInput.unlimitedFormControl.setValue(true);
-            numberWithUnitInput.detectChanges();
-            expect(numberWithUnitInput.valueFormControl.disabled).toBeTruthy('Value field should have been disabled');
-            expect(numberWithUnitInput.unitFormControl.disabled).toBeTruthy('Unit field should have been disabled');
+            // Turn unlimited on
+            numberWithUnitInput.clickUnlimitedCheckbox();
+            expect(numberWithUnitInput.isInputFieldDisabled).toBeTruthy('Value field should have been disabled');
+            expect(numberWithUnitInput.isUnitDropdownDisabled).toBeTruthy('Unit field should have been disabled');
         });
 
         it('sets the focus on the input element when unlimited checkbox is unchecked', () => {
-            numberWithUnitInput.unlimitedFormControl.setValue(true);
-            numberWithUnitInput.detectChanges();
-            expect(numberWithUnitInput.isInputValueFucused()).toBe(false, 'Input element should not be on focus');
-            numberWithUnitInput.unlimitedFormControl.setValue(false);
-            expect(numberWithUnitInput.isInputValueFucused()).toBe(true, 'Input element should be on focus');
+            // Turn unlimited on
+            numberWithUnitInput.clickUnlimitedCheckbox();
+            expect(numberWithUnitInput.isInputValueFocused).toBe(false, 'Input element should not have focus');
+            // Turn it back off
+            numberWithUnitInput.clickUnlimitedCheckbox();
+            expect(numberWithUnitInput.isInputValueFocused).toBe(true, 'Input element should have focus');
         });
     });
 
     describe('unitOptions', () => {
         it('displays unit options', () => {
-            expect(numberWithUnitInput.unitFormControl).toBeTruthy();
+            expect(numberWithUnitInput.isShowingUnitDropdown).toBe(true);
         });
 
         it('selects GHz for a unit', () => {
@@ -127,8 +128,7 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
                 ts.translate(percentUnit.getUnitNameTranslationKey(), [])
             );
             expect(numberWithUnitInput.isUnitDropDownDisplayed).toBe(false);
-            numberWithUnitInput.valueFormControl.setValue(50);
-            numberWithUnitInput.detectChanges();
+            numberWithUnitInput.textInputValue = '50';
             expect(numberWithUnitInput.formControl.value).toEqual(0.5);
         });
 
@@ -137,8 +137,7 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             numberWithUnitInput.setUnitOptionsToNone();
             expect(numberWithUnitInput.singleUnitDisplayText).toBe('');
             expect(numberWithUnitInput.isUnitDropDownDisplayed).toBe(false);
-            numberWithUnitInput.valueFormControl.setValue(50);
-            numberWithUnitInput.detectChanges();
+            numberWithUnitInput.textInputValue = '50';
             expect(numberWithUnitInput.formControl.value).toEqual(50);
         });
     });
@@ -148,20 +147,19 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             numberWithUnitInput.setInputValueUnit(Hertz.Mhz);
             numberWithUnitInput.selectUnit(Hertz.Ghz);
             numberWithUnitInput.detectChanges();
-            expect(numberWithUnitInput.unlimitedFormControl.value).toBe(false);
+            expect(numberWithUnitInput.component.unlimitedControlValue).toBe(false);
             expect(numberWithUnitInput.formControl.value).toEqual(null);
         });
 
         it('has a value set in inputValueUnit Unit', () => {
             numberWithUnitInput.setInputValueUnit(Hertz.Mhz);
             numberWithUnitInput.selectUnit(Hertz.Ghz);
-            numberWithUnitInput.valueFormControl.setValue(10);
-            numberWithUnitInput.detectChanges();
+            numberWithUnitInput.textInputValue = '10';
             expect(numberWithUnitInput.formControl.value).toEqual(1000 * 10);
         });
 
         it('has a value of UNLIMITED when unlimited checkbox is checked', () => {
-            numberWithUnitInput.unlimitedFormControl.setValue(true);
+            numberWithUnitInput.clickUnlimitedCheckbox();
             numberWithUnitInput.detectChanges();
             expect(numberWithUnitInput.formControl.value).toEqual(UNLIMITED);
         });
@@ -171,15 +169,15 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
                 woConstructor: NumberWithUnitFormInputWidgetObject,
                 className: 'initially-unlimited',
             });
-            expect(numberWithUnitInputInitializedUnlimited.valueFormControl.enabled).toEqual(false);
-            expect(numberWithUnitInputInitializedUnlimited.unitFormControl.enabled).toEqual(false);
+            expect(numberWithUnitInputInitializedUnlimited.isInputFieldDisabled).toEqual(true);
+            expect(numberWithUnitInputInitializedUnlimited.isUnitDropdownDisabled).toEqual(true);
         });
 
         it('disables text input when set to unlimited programmatically', () => {
             numberWithUnitInput.formControl.setValue(UNLIMITED);
             numberWithUnitInput.detectChanges();
-            expect(numberWithUnitInput.valueFormControl.enabled).toEqual(false);
-            expect(numberWithUnitInput.unitFormControl.enabled).toEqual(false);
+            expect(numberWithUnitInput.isInputFieldDisabled).toEqual(true);
+            expect(numberWithUnitInput.isUnitDropdownDisabled).toEqual(true);
         });
     });
 
@@ -187,8 +185,7 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
         it('is in GHz when input value is greater than 1000 Mhz', () => {
             numberWithUnitInput.setInputValueUnit(Hertz.Mhz);
             numberWithUnitInput.selectUnit(Hertz.Mhz);
-            numberWithUnitInput.valueFormControl.setValue(2000);
-            numberWithUnitInput.detectChanges();
+            numberWithUnitInput.textInputValue = '2000';
             expect(numberWithUnitInput.displayValue).toEqual(
                 ts.translate(Hertz.Ghz.getValueWithUnitTranslationKey(), [2])
             );
@@ -223,8 +220,7 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
         it('sets value in GHz units to FormControl Value for input selected unit is MHz', () => {
             numberWithUnitInput.setInputValueUnit(Hertz.Ghz);
             numberWithUnitInput.selectUnit(Hertz.Mhz);
-            numberWithUnitInput.valueFormControl.setValue(2000);
-            numberWithUnitInput.detectChanges();
+            numberWithUnitInput.textInputValue = '2000';
             expect(numberWithUnitInput.formControl.value).toEqual(2000 / 1000);
         });
 
@@ -232,8 +228,7 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             numberWithUnitInput.setUnitOptionsToPercent();
             numberWithUnitInput.setInputValueUnit(Percent.ZERO_TO_1);
             numberWithUnitInput.selectUnit(Percent.ZERO_TO_100);
-            numberWithUnitInput.valueFormControl.setValue(98);
-            numberWithUnitInput.detectChanges();
+            numberWithUnitInput.textInputValue = '98';
             expect(numberWithUnitInput.formControl.value).toEqual(98 / 100);
         });
     });
@@ -245,12 +240,12 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             () => {
                 numberWithUnitInput.formControl.disable();
                 numberWithUnitInput.detectChanges();
-                expect(numberWithUnitInput.valueFormControl.disabled).toBe(true);
-                expect(numberWithUnitInput.unitFormControl.disabled).toBe(true);
+                expect(numberWithUnitInput.isInputFieldDisabled).toBe(true);
+                expect(numberWithUnitInput.isUnitDropdownDisabled).toBe(true);
                 numberWithUnitInput.formControl.enable();
                 numberWithUnitInput.detectChanges();
-                expect(numberWithUnitInput.valueFormControl.enabled).toBe(true);
-                expect(numberWithUnitInput.unitFormControl.enabled).toBe(true);
+                expect(numberWithUnitInput.isInputFieldDisabled).toBe(false);
+                expect(numberWithUnitInput.isUnitDropdownDisabled).toBe(false);
             }
         );
     });

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.widget-object.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.widget-object.ts
@@ -29,47 +29,66 @@ export class NumberWithUnitFormInputWidgetObject extends WidgetObject<NumberWith
         return this.getText('.readonly-text');
     }
 
-    get unlimitedFormControl(): AbstractControl {
-        return this.component.formGroup.get('unlimited');
-    }
-
-    get valueFormControl(): AbstractControl {
-        return this.component.formGroup.get('limited');
-    }
-
-    get unitFormControl(): AbstractControl {
-        return this.component.formGroup.get('comboUnitOptions');
-    }
-
-    selectUnit(unit: Unit): void {
-        this.component.selectedUnit = unit.getMultiplier();
-    }
-
     setInputValueUnit(unit: Unit): void {
         this.component.inputValueUnit = unit;
     }
 
-    isInputValueFucused(): boolean {
+    selectUnit(unit: Unit): void {
+        this.component.onUnitChange(unit.getMultiplier().toString());
+    }
+
+    get isShowingUnlimitedCheckbox(): boolean {
+        return !!this.unlimitedCheckbox;
+    }
+
+    private get unlimitedCheckbox(): HTMLElement {
+        return this.getNativeElement('.clr-checkbox-wrapper label');
+    }
+
+    clickUnlimitedCheckbox(): void {
+        this.component.onUnlimitedCheckboxChange(!this.component.unlimitedControlValue);
+        this.detectChanges();
+    }
+
+    private get unitDropdown(): HTMLSelectElement {
+        return this.getNativeElement('select') as HTMLSelectElement;
+    }
+
+    set textInputValue(num: string) {
+        this.component.onTextInputChange(num);
+        this.detectChanges();
+    }
+
+    get isShowingUnitDropdown(): boolean {
+        return !!this.unitDropdown;
+    }
+
+    get isUnitDropdownDisabled(): boolean {
+        return this.unitDropdown?.disabled;
+    }
+
+    private get inputElement(): HTMLInputElement {
+        return this.getNativeElement('input[type=number]') as HTMLInputElement;
+    }
+
+    get isInputValueFocused(): boolean {
         return document.activeElement === this.inputElement;
     }
 
-    get selectedUnit(): number {
-        return this.component.formGroup.get('comboUnitOptions').value;
+    get isInputFieldDisabled(): boolean {
+        return this.inputElement.disabled;
     }
 
     get selectedUnitDisplayValue(): string {
-        return (
-            this.component.unitOptions
-                // tslint:disable-next-line:triple-equals
-                .find((item) => item.getMultiplier() == this.selectedUnit)
-                .getUnitName()
-        );
+        return this.component.unitOptions
+            .find((item) => item.getMultiplier() === Number(this.component.unitsControlValue))
+            .getUnitName();
     }
 
     setUnitOptionsToPercent(): void {
         this.component.unitOptions = [Percent.ZERO_TO_100];
         this.component.inputValueUnit = Percent.ZERO_TO_1;
-        this.unitFormControl.setValue(this.component.unitOptions[0].getMultiplier());
+        this.component.unitsControlValue = this.component.unitOptions[0].getMultiplier().toString();
         this.fixture.detectChanges();
     }
 
@@ -79,7 +98,7 @@ export class NumberWithUnitFormInputWidgetObject extends WidgetObject<NumberWith
     }
 
     getNativeElement(cssSelector: string): HTMLElement {
-        return this.findElement(cssSelector) && this.findElement(cssSelector).nativeElement;
+        return this.findElement(cssSelector)?.nativeElement;
     }
 
     get isUnitDropDownDisplayed(): boolean {
@@ -90,11 +109,6 @@ export class NumberWithUnitFormInputWidgetObject extends WidgetObject<NumberWith
      * Returns an empty string if there is no HTML for single unit
      */
     get singleUnitDisplayText(): string {
-        const element = this.getNativeElement('.single-option');
-        return element ? element.innerHTML : '';
-    }
-
-    private get inputElement(): HTMLInputElement {
-        return this.getNativeElement('vcd-form-input input') as HTMLInputElement;
+        return this.getText('.single-option');
     }
 }

--- a/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.html
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.html
@@ -29,7 +29,7 @@ The "Warn Level" percent example also disables the "unlimited" functionality.
             [isReadOnly]="formGroup.controls.readonly.value"
         >
         </vcd-number-with-unit-form-input>
-        <div class="value-container" *ngIf="!formGroup.controls.readonly.value">
+        <div *ngIf="!formGroup.controls.readonly.value">
             <strong>Value:</strong>
             {{ formGroup.get('noUnit').value }}
         </div>

--- a/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.scss
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.scss
@@ -1,3 +1,0 @@
-.value-container {
-    margin-top: -1.2rem;
-}

--- a/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.ts
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input-unitless.example.component.ts
@@ -42,8 +42,8 @@ export class NumberWithUnitFormInputUnitlessExampleComponent implements OnDestro
             readonly: new FormControl(false),
             disabled: new FormControl(false),
             validatorShowPercent: new FormControl(true),
-            noUnit: new FormControl(null, [Validators.required, noUnitValidator]),
-            percentUnit: new FormControl(null, [percentValidatorShowPercent]),
+            noUnit: new FormControl(5, [Validators.required, noUnitValidator]),
+            percentUnit: new FormControl(50, [percentValidatorShowPercent]),
         });
         this.subscriptionTracker.subscribe(this.formGroup.controls.disabled.valueChanges, (value) => {
             if (value) {

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.html
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.html
@@ -36,10 +36,12 @@ type of units.
             [max]="maxMemoryAllowedMB"
             [initialValueUnit]="Bytes.MB"
             [isReadOnly]="formGroup.controls.readonly.value"
-            [description]="'Description below control'"
+            [description]="
+                'This control has its inputValueUnit set to MB. That is why the initial displayed value is not 2GB'
+            "
         >
         </vcd-number-with-unit-form-input>
-        <div class="value-container" *ngIf="!formGroup.controls.readonly.value">
+        <div *ngIf="!formGroup.controls.readonly.value">
             <strong>Selected Memory:</strong>
             {{ formGroup.get('memory').value + ' ' + memoryFormControlValueUnit.getUnitName() }}
         </div>
@@ -55,7 +57,7 @@ type of units.
             [isReadOnly]="formGroup.controls.readonly.value"
         >
         </vcd-number-with-unit-form-input>
-        <div class="value-container" *ngIf="!formGroup.controls.readonly.value">
+        <div *ngIf="!formGroup.controls.readonly.value">
             <strong>Selected Cpu speed:</strong>
             {{ formGroup.get('cpuLimit').value + ' ' + cpuSpeedFormControlValueUnit.getUnitName() }}
         </div>

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.scss
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.scss
@@ -1,3 +1,0 @@
-.value-container {
-    margin-top: -1.2rem;
-}

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.ts
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.ts
@@ -52,9 +52,10 @@ export class NumberWithUnitFormInputExampleComponent implements AfterViewInit, O
         this.formGroup = fb.group({
             readonly: new FormControl(false),
             disabled: new FormControl(false),
-            cpuLimit: new FormControl(1500, [cpuValidator]),
             memory: new FormControl(1024 * 2, [Validators.required, memoryValidator]),
+            cpuLimit: new FormControl(1500, [cpuValidator]),
         });
+
         this.subscriptionTracker.subscribe(this.formGroup.controls.disabled.valueChanges, (value) => {
             if (value) {
                 this.formGroup.controls.cpuLimit.disable();


### PR DESCRIPTION
## Problem 
This fixes an issue where the form control's value was null if the user input could not be parsed as a number. We did not display any validation error to the user explaining that the input is invalid.

## Solution
`form-input` uses an internal default validator that checks for HTML's [validity](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) for `badInput`

## Implementation
We also chose to reimplement the HTML for number-with-unit with raw clarity HTML instead of `vcd-form-*` implementations. Trying to combine the different fields to look correctly took a lot of CSS. This allowed us to use fewer CSS hacks and easier control over the HTML.

## Testing Done

### Form with unit example
* Displays "Invalid number" if user types `e`, `1e`, `-e` 
  * In Firefox, anything is allowed so typing abc also displays "Invalid number"
### Form with unit - unit-less example
* Type -1 into warn level
  * See message indicating that number must be 1-100
* Type `-1e`
  * See message saying "Invalid number"
* Toggle box that says "Validator shows *" 
  * Make sure message still says "Invalid number"
* Toggle unlimited checkbox
  * Make sure it remembers the previous value (since it hides it when unlimited is checked)  

### Form input
* Displays "Invalid number" if user types `e`, `1e`, `-e` 
  * In Firefox, anything is allowed so typing abc also displays "Invalid number"
* Make sure "Input is required" displays for empty required field

Signed-off-by: Juan Mendes <jmendes@vmware.com>