### PR TITLE
Make sure writeValue for number-with-unit is not called before ngOnInit

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-a11y.7] - 2020-12-2
+### Fixed
+- Values were not being written at times on `vcd-number-with-unit`. Make sure `writeValue` does not fully run before 
+  `ngOnInit` to make sure `@Input` parameters have been set
+
 ## [1.0.0-a11y.6] - 2020-12-2
 ### Fixed
 - Underlying page scrolling when navigating the action menu using arrow keys.

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-a11y.6",
+    "version": "1.0.0-a11y.7",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -192,6 +192,11 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
     lastRealValue: number = null;
 
     /**
+     * Should this functionality be provided at the base class?
+     */
+    private ngOnInitCalled = false;
+
+    /**
      * Set the unit in the dropdown.
      * @param value Should be one of the value that you pass in {@link #unitOptions} to select the Unit.
      */
@@ -210,7 +215,11 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
     }
 
     ngOnInit(): void {
+        this.ngOnInitCalled = true;
+
         defaultValidatorForControl(this.formControl, () => this.validateNumber());
+
+        this.writeValue(this.initialValue as number);
 
         this.recalculateUnitMinMax();
     }
@@ -282,6 +291,13 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
     }
 
     writeValue(value: number): void {
+        // This gets called before ngOnInit. Store the value and we'll call it
+        // again from ngOnInit so that `@Input` parameters will be set
+        if (!this.ngOnInitCalled) {
+            this.initialValue = value;
+            return;
+        }
+
         if (value === null) {
             if (this.showUnlimitedOption) {
                 // Set Unlimited checkbox to false because the form control was reset
@@ -314,6 +330,10 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
     }
 
     private computeBestUnitAndValue(value: number): void {
+        // Nothing to do when setting to unlimited
+        if (this.isUnlimitedValue(value)) {
+            return;
+        }
         if (this.unitOptions.length === 0) {
             this.bestValue = value;
             this.bestUnit = NoUnit.INSTANCE;


### PR DESCRIPTION
This was causing problems revealed by unit tests because writeValue can depend on @Input values
which are not set before ngOnInit


## Testing Done
Ran unit tests for ui-components and for VCD's internal vcd_ui project

Signed-off-by: Juan Mendes <jmendes@vmware.com>