### PR TITLE
Using datagridSelection getter to emit datagrid selection changes

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -7,13 +7,13 @@
     [clrDgLoading]="isLoading"
     [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent-grid']"
     (clrDgRefresh)="gridStateChanged($event)"
-    (clrDgSelectedChange)="datagridSelectionChange.emit($event)"
-    (clrDgSingleSelectedChange)="datagridSelectionChange.emit([$event])"
+    (clrDgSelectedChange)="datagridSelectionChange.emit(datagridSelection)"
+    (clrDgSingleSelectedChange)="datagridSelectionChange.emit(datagridSelection)"
 >
     <clr-dg-placeholder>{{ emptyGridPlaceholder }}</clr-dg-placeholder>
     <clr-dg-action-bar class="top-action-bar" *ngIf="shouldShowActionBarOnTop">
         <!--- We need to instantiate the action bar as its own component to separate its provider chain
-        such that the clr-dg-row doesn't get its trackBy. 
+        such that the clr-dg-row doesn't get its trackBy.
         This is due to a bug in Clarity: https://github.com/vmware/clarity/issues/3936 -->
         <ng-container *ngTemplateOutlet="actionBar"> </ng-container>
     </clr-dg-action-bar>

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -8,7 +8,6 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LoadingListener } from '@clr/angular';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
-import { Mock } from 'protractor/built/driverProviders';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { ActivityPromiseResolver } from '../common/activity-reporter/activity-promise-resolver';
@@ -248,6 +247,12 @@ describe('DatagridComponent', () => {
                     this.clrGridWidget.getRowInput(1).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                 });
+
+                it('returns an empty array when there is no initial selection', function (this: HasFinderAndGrid): void {
+                    this.hostComponent.selectionType = GridSelectionType.Single;
+                    this.finder.detectChanges();
+                    expect(this.hostComponent.datagridSelection).toEqual([]);
+                });
             });
 
             describe('@Output() selectionChanged', () => {
@@ -269,6 +274,28 @@ describe('DatagridComponent', () => {
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
                     this.clrGridWidget.getRowInput(1).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[1]]);
+                });
+
+                it('emits empty array when single selection is cleared', function (this: HasFinderAndGrid): void {
+                    this.hostComponent.selectionType = GridSelectionType.Single;
+                    this.finder.detectChanges();
+                    spyOn(this.hostComponent, 'selectionChanged');
+                    this.clrGridWidget.getSingleSelectionRadioLabel(0).click();
+                    expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
+                    this.hostComponent.datagridSelection = [];
+                    this.finder.detectChanges();
+                    expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([]);
+                });
+
+                it('emits empty array when multiple selection is cleared', function (this: HasFinderAndGrid): void {
+                    this.hostComponent.selectionType = GridSelectionType.Multi;
+                    this.finder.detectChanges();
+                    spyOn(this.hostComponent, 'selectionChanged');
+                    this.clrGridWidget.getSingleSelectionRadioLabel(0).click();
+                    expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
+                    this.hostComponent.datagridSelection = [];
+                    this.finder.detectChanges();
+                    expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([]);
                 });
             });
 
@@ -1163,7 +1190,7 @@ describe('DatagridComponent', () => {
                 [clrDatagridCssClass]="clrDatagridCssClass"
                 [clrDatarowCssClassGetter]="clrDatarowCssClassGetter"
                 [selectionType]="selectionType"
-                (selectionChanged)="selectionChanged($event)"
+                (datagridSelectionChange)="selectionChanged($event)"
                 [paginationDropdownText]="paginationText"
                 [pagination]="pagination"
                 [actions]="actions"

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -21,7 +21,9 @@ const Css = {
     PAGE_SIZE: 'clr-dg-page-size',
     PAGINATION_NEXT: '.pagination-next',
     TOP_POSITIONED_BUTTON: 'clr-dg-action-bar button',
+    // Do not use this. This is specific to VCD datagrid.
     ROW_BUTTON_CONTAINER: '.action-button-cell',
+    ROW_ACTION_CONTAINER: '.datagrid-select label',
     CHECKBOX_WRAPPER: 'clr-checkbox-wrapper',
     RADIO_WRAPPER: 'clr-radio-wrapper',
     FILTER: 'clr-dg-filter',
@@ -184,6 +186,7 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * Returns input element in the given row
      * @param row 0-based index of row
+     * @deprecated It doesn't make sense to grab a random input out of a row.
      */
     getRowInput(row: number): T {
         return this._getRow(row).get('input').unwrap();
@@ -227,6 +230,10 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      */
     getRowButtonContainer(row: number): T {
         return this._getRow(row).get(Css.ROW_BUTTON_CONTAINER).unwrap();
+    }
+
+    getSingleSelectionRadioLabel(row: number): T {
+        return this._getRow(row).get(Css.ROW_ACTION_CONTAINER).unwrap();
     }
 
     /**


### PR DESCRIPTION
## Description
*  The problem appeared to be that this.datagrid.selection.currentSingle was set to undefined instead of an empty array when the user clears their selection.
* The template was getting datagridSelection from Clarity $event but it should have come from the getter.
* [$event] is an array of undefined. 
* Now if this.datagrid.selection.currentSingle is undefined, the logic in the getter handles for that and returns the empty array.

## Testing Done
* Added unit test to verify that when the selection is cleared an empty array is emitted.
* Added unit test to verify that when the selection is cleared the getter for the current selection returns an empty array.

Fixes: #233 

Signed-off-by: Ria Mahoney <mpatrice@vmware.com>