### PR TITLE
Update responsive input to increase label's width when container's width is small

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,24 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Fixed `vcd-number-with-unit` styling errors where the container grew too much and resulted in poor appearance.
 - Fixed a bug where `vcd-number-with-unit` did not select a default unit.
+### Changed
+- Update `ResponsiveInputDirective` to add Clarity grid classes based on the host element's width.
 
 ## [1.0.0-a11y.7] - 2020-12-2
 ### Fixed
-- Values were not being written at times on `vcd-number-with-unit`. Make sure `writeValue` does not fully run before 
+- Values were not being written at times on `vcd-number-with-unit`. Make sure `writeValue` does not fully run before
   `ngOnInit` to make sure `@Input` parameters have been set
 
 ## [1.0.0-a11y.6] - 2020-12-2
 ### Fixed
 - Underlying page scrolling when navigating the action menu using arrow keys.
 - Space/Enter keys not closing the action menu after a action menu item is activated.
-- Esc key not closing the action menu it is pressed on. 
+- Esc key not closing the action menu it is pressed on.
 - Not being able to navigate using arrow keys on action menu with separators
 
 ## [1.0.0-a11y.5] - 2020-12-2
 
 ### Fixed
 - Display error messages for invalid input on form controls accepting numbers.
-  
+
 ### Added
 - Enabled hints for vcd-form-checkbox
 - Fixed previous bad vcdResponsiveInput commits. Module was incorrectly setup and vcdResponsiveInput had

--- a/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
+++ b/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
@@ -3,29 +3,45 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { AfterViewInit, Directive, ElementRef, HostBinding } from '@angular/core';
+import { AfterViewChecked, Directive, ElementRef, HostBinding } from '@angular/core';
+
+declare type ColSize = '2' | '4' | '8' | '10';
 
 /**
- * Adds Clarity grid classes to form controls so that labels and inputs are on separate lines and to control the label width
- * for large screens.
+ * Adds Clarity grid classes to form controls based on the host's width so that labels and inputs are on separate
+ * lines and to control the label width for large screens.
  *
  * Centralizes CSS classes to be used to enforce a common look and feel throughout the application
  */
 @Directive({
     selector: '.clr-form-control[vcdResponsiveInput]',
 })
-export class ResponsiveInputDirective implements AfterViewInit {
+export class ResponsiveInputDirective implements AfterViewChecked {
+    private elementWidth = 0;
+
+    private breakPoint = 768;
+
     @HostBinding('class.clr-row') public clrGridRow = true;
     constructor(private el: ElementRef<HTMLElement>) {}
 
-    ngAfterViewInit(): void {
-        this.applyClasses('label', '2');
-        this.applyClasses('container', '10');
+    ngAfterViewChecked(): void {
+        if (this.elementWidth !== 0) {
+            return;
+        }
+        const newElementWidth = this.el.nativeElement.offsetWidth;
+        if (newElementWidth) {
+            this.elementWidth = newElementWidth;
+            const [labelWidth, containerWidth]: ColSize[] =
+                this.elementWidth < this.breakPoint ? ['4', '8'] : ['2', '10'];
+            this.applyClasses('label', labelWidth);
+            this.applyClasses('container', containerWidth);
+        }
     }
 
-    private applyClasses(className: 'label' | 'container', mdSize: '2' | '10'): void {
+    private applyClasses(className: 'label' | 'container', mdSize: ColSize): void {
         const el = this.el.nativeElement.querySelector(`:scope > .clr-control-${className}`);
         if (el) {
+            el.classList.remove('clr-col-12', 'clr-col-md-2', 'clr-col-md-4', 'clr-col-md-8', 'clr-col-md-10');
             el.classList.add('clr-col-12', `clr-col-md-${mdSize}`);
         }
     }


### PR DESCRIPTION
## Why this change is made
The reason for this issue is, in a responsive input, default clr grid classes for label and container are `clr-col-md-2` and `clr-col-md-10`, which are fine for most places. But when width for the host element row is small, there is no enough space for label.
This PR updates `ResponsiveInput` to add grid classes based on host element's width.

When host's width is less than 768px:
<img width="585" alt="Screen Shot 2020-12-09 at 10 45 26 AM" src="https://user-images.githubusercontent.com/49406822/101652018-b6271d00-3a0b-11eb-951f-58e389a7782b.png">

When host's width is bigger than 768px:
<img width="1020" alt="Screen Shot 2020-12-09 at 10 46 16 AM" src="https://user-images.githubusercontent.com/49406822/101652084-ce973780-3a0b-11eb-8235-d0f049bcb6ac.png">


Signed-off-by: yumengwu <yumengwu95@gmail.com>