### PR TITLE
Fixes bugs with the number with unit input

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed `vcd-number-with-unit` styling errors where the container grew too much and resulted in poor appearance.
+- Fixed a bug where `vcd-number-with-unit` did not select a default unit.
 
 ## [1.0.0-a11y.7] - 2020-12-2
 ### Fixed

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
@@ -8,7 +8,7 @@ clr-signpost-content {
     }
 }
 
-.clr-input {
+.clr-control-container .clr-input {
     // We need this !important to override styles from clr-control-container
     width: 5rem !important;
     margin-right: 5px;
@@ -34,10 +34,10 @@ input[type='number'] {
     }
 }
 
-.clr-control-container {
+.clr-form-control .clr-control-container {
     // We need these !importants to override styles that come from the col classes.
-    width: auto !important;
-    flex: 0 1 auto !important;
+    width: auto;
+    flex: 0 1 auto;
 }
 
 .single-option {

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
@@ -9,7 +9,9 @@ clr-signpost-content {
 }
 
 .clr-input {
-    width: 5rem;
+    // We need this !important to override styles from clr-control-container
+    width: 5rem !important;
+    margin-right: 5px;
 }
 
 // To make the text input and the select align, it still doesn't at some zoom levels.
@@ -30,4 +32,14 @@ input[type='number'] {
     .clr-validate-icon {
         margin-left: 0;
     }
+}
+
+.clr-control-container {
+    // We need these !importants to override styles that come from the col classes.
+    width: auto !important;
+    flex: 0 1 auto !important;
+}
+
+.single-option {
+    flex: 0;
 }

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -142,7 +142,7 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
         });
 
         // TODO: write this test
-        it('sets a input unit if none is given', () => {});
+        it('sets a input unit if initial value is null', () => {});
     });
 
     describe('FormControl value', () => {

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -140,6 +140,9 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             numberWithUnitInput.textInputValue = '50';
             expect(numberWithUnitInput.formControl.value).toEqual(50);
         });
+
+        // TODO: write this test
+        it('sets a input unit if none is given', () => {});
     });
 
     describe('FormControl value', () => {

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -298,15 +298,6 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
             return;
         }
 
-        if (value === null) {
-            if (this.showUnlimitedOption) {
-                // Set Unlimited checkbox to false because the form control was reset
-                this.unlimitedControlValue = false;
-            }
-            this.textInputValue = '';
-            return;
-        }
-
         if (this.initialValueUnit) {
             this.bestUnit = this.initialValueUnit;
             this.bestValue = value ? this.inputValueUnit.getOutputValue(value, this.bestUnit) : null;
@@ -316,16 +307,29 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
             this.computeBestUnitAndValue(value as number);
         }
 
-        if (this.showUnlimitedOption) {
-            this.unlimitedControlValue = this.isUnlimitedValue(value);
-        }
-
         if (!this.isUnlimitedValue(value)) {
-            this.lastRealValue = this.bestValue;
-            this.textInputValue = this.bestValue.toString();
-            this.unitsControlValue = this.bestUnit.getMultiplier().toString();
+            if (this.bestValue) {
+                this.lastRealValue = this.bestValue;
+                this.textInputValue = this.bestValue.toString();
+            }
+            if (this.bestUnit) {
+                this.unitsControlValue = this.bestUnit.getMultiplier().toString();
+            }
         } else {
             this.textInputValue = '';
+        }
+
+        if (value === null) {
+            if (this.showUnlimitedOption) {
+                // Set Unlimited checkbox to false because the form control was reset
+                this.unlimitedControlValue = false;
+            }
+            this.textInputValue = '';
+            return;
+        }
+
+        if (this.showUnlimitedOption) {
+            this.unlimitedControlValue = this.isUnlimitedValue(value);
         }
     }
 

--- a/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
+++ b/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { AfterViewChecked, Directive, ElementRef, HostBinding } from '@angular/core';
-
-type colSize = string;
+import { AfterViewInit, Directive, ElementRef, HostBinding } from '@angular/core';
 
 /**
  * Adds Clarity grid classes to form controls so that labels and inputs are on separate lines and to control the label width
@@ -16,33 +14,19 @@ type colSize = string;
 @Directive({
     selector: '.clr-form-control[vcdResponsiveInput]',
 })
-export class ResponsiveInputDirective implements AfterViewChecked {
+export class ResponsiveInputDirective implements AfterViewInit {
     @HostBinding('class.clr-row') public clrGridRow = true;
     constructor(private el: ElementRef<HTMLElement>) {}
-    private elementWidth = 0;
 
-    ngAfterViewChecked(): void {
-        const newElementWidth = this.el.nativeElement.offsetWidth;
-        if (newElementWidth !== this.elementWidth) {
-            this.elementWidth = newElementWidth;
-            const [labelWidth, containerWidth]: colSize[] = this.elementWidth < 768 ? ['4', '8'] : ['2', '10'];
-            this.applyClasses('label', labelWidth);
-            this.applyClasses('container', containerWidth);
-        }
+    ngAfterViewInit(): void {
+        this.applyClasses('label', '2');
+        this.applyClasses('container', '10');
     }
 
-    private applyClasses(className: 'label' | 'container', mdSize: colSize): void {
+    private applyClasses(className: 'label' | 'container', mdSize: '2' | '10'): void {
         const el = this.el.nativeElement.querySelector(`:scope > .clr-control-${className}`);
         if (el) {
-            el.classList.add('clr-col-12');
-            const removeList: string[] = [];
-            el.classList.forEach((css: string) => {
-                if (css.includes('clr-col-md-')) {
-                    removeList.push(css);
-                }
-            });
-            el.classList.remove(...removeList);
-            el.classList.add(`clr-col-md-${mdSize}`);
+            el.classList.add('clr-col-12', `clr-col-md-${mdSize}`);
         }
     }
 }

--- a/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
+++ b/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { AfterViewInit, Directive, ElementRef, HostBinding } from '@angular/core';
+import { AfterViewChecked, Directive, ElementRef, HostBinding } from '@angular/core';
+
+type colSize = string;
 
 /**
  * Adds Clarity grid classes to form controls so that labels and inputs are on separate lines and to control the label width
@@ -14,19 +16,33 @@ import { AfterViewInit, Directive, ElementRef, HostBinding } from '@angular/core
 @Directive({
     selector: '.clr-form-control[vcdResponsiveInput]',
 })
-export class ResponsiveInputDirective implements AfterViewInit {
+export class ResponsiveInputDirective implements AfterViewChecked {
     @HostBinding('class.clr-row') public clrGridRow = true;
     constructor(private el: ElementRef<HTMLElement>) {}
+    private elementWidth = 0;
 
-    ngAfterViewInit(): void {
-        this.applyClasses('label', '2');
-        this.applyClasses('container', '10');
+    ngAfterViewChecked(): void {
+        const newElementWidth = this.el.nativeElement.offsetWidth;
+        if (newElementWidth !== this.elementWidth) {
+            this.elementWidth = newElementWidth;
+            const [labelWidth, containerWidth]: colSize[] = this.elementWidth < 768 ? ['4', '8'] : ['2', '10'];
+            this.applyClasses('label', labelWidth);
+            this.applyClasses('container', containerWidth);
+        }
     }
 
-    private applyClasses(className: 'label' | 'container', mdSize: '2' | '10'): void {
+    private applyClasses(className: 'label' | 'container', mdSize: colSize): void {
         const el = this.el.nativeElement.querySelector(`:scope > .clr-control-${className}`);
         if (el) {
-            el.classList.add('clr-col-12', `clr-col-md-${mdSize}`);
+            el.classList.add('clr-col-12');
+            const removeList: string[] = [];
+            el.classList.forEach((css: string) => {
+                if (css.includes('clr-col-md-')) {
+                    removeList.push(css);
+                }
+            });
+            el.classList.remove(...removeList);
+            el.classList.add(`clr-col-md-${mdSize}`);
         }
     }
 }


### PR DESCRIPTION
# Description
Fixes three bugs with the number with unit input:
1. The selector was growing to fill remaining space, so the dropdown appeared strange.
2. The dropdown was not being populated in certain cases on loading.
3. The input had a variable width and was changing based on what unit you selected. 

# Testing

Loaded into VCD-UI and tested the following:

# Named Disks
1. Navigate to named disks
2. Click new
3. Observe correct appearance and correct default unit value
4. Change unit, observe appearance is still correct

![image](https://user-images.githubusercontent.com/7528512/101661362-305c9f00-3a16-11eb-9a04-6098d7fd58da.png)

# VM Sizing Policies Edit Form
1. Navigate to VM sizing policies
2. Observe arrow is with the unit selector

![image](https://user-images.githubusercontent.com/7528512/101661990-f0e28280-3a16-11eb-8047-14e70d8a3ed7.png)

# VM Memory Edit Form
1. Navigate to a VM memory page
2. Click edit
3. Observe dropdown arrow is with the unit selector.

![image](https://user-images.githubusercontent.com/7528512/101661424-42d6d880-3a16-11eb-85f7-f1b106bdad8f.png)

# Disk Add VM Screen
1. Navigate to any VM
2. Go to add a disk
3. Observe correct units appear in bus size dropdown

![image](https://user-images.githubusercontent.com/7528512/101661534-639f2e00-3a16-11eb-8907-af44a6eb5d38.png)

