### PR TITLE
[a11y] Fix no alternative text on input error icons

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Accessibility: Added blank alternative text to all svgs inside clr-icon elements
 
 ## [1.0.0-a11y.7] - 2020-12-8
 ### Fixed 

--- a/projects/components/src/components.module.ts
+++ b/projects/components/src/components.module.ts
@@ -12,6 +12,7 @@ import { VcdDataExporterModule } from './data-exporter/data-exporter.module';
 import { VcdDatagridModule } from './datagrid/datagrid.module';
 import { DropdownModule } from './dropdown/dropdown.module';
 import { VcdFormModule } from './form/form.module';
+import { AlternativeTextModule } from './lib/directives/alternative-text/alternative-text.module';
 import { ResponsiveInputDirectiveModule } from './lib/directives/responsive-input/responsive-input.module';
 import { ShowClippedTextDirectiveModule } from './lib/directives/show-clipped-text.directive.module';
 import { QuickSearchModule } from './quick-search/quick-search.module';
@@ -29,6 +30,7 @@ import { QuickSearchModule } from './quick-search/quick-search.module';
         VcdActionMenuModule,
         DropdownModule,
         ResponsiveInputDirectiveModule,
+        AlternativeTextModule,
     ],
 })
 export class VcdComponentsModule {}

--- a/projects/components/src/form/form.module.ts
+++ b/projects/components/src/form/form.module.ts
@@ -8,6 +8,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
+import { AlternativeTextModule } from '../lib/directives/alternative-text/alternative-text.module';
 import { ResponsiveInputDirectiveModule } from '../lib/directives/responsive-input/responsive-input.module';
 import { UnitFormatter } from '../utils/unit/unit-formatter';
 import { FormCheckboxComponent } from './form-checkbox/form-checkbox.component';
@@ -25,6 +26,7 @@ const declarations = [FormInputComponent, FormSelectComponent, FormCheckboxCompo
         CommonModule,
         I18nModule,
         ResponsiveInputDirectiveModule,
+        AlternativeTextModule,
     ],
     declarations,
     providers: [UnitFormatter],

--- a/projects/components/src/lib/directives/alternative-text/alternative-text.directive.spec.ts
+++ b/projects/components/src/lib/directives/alternative-text/alternative-text.directive.spec.ts
@@ -1,0 +1,66 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ClarityModule } from '@clr/angular';
+import { WidgetObject } from '../../../utils/test';
+import { ALTERNATIVE_TEXT } from './alternative-text.directive';
+import { AlternativeTextModule } from './alternative-text.module';
+
+interface TestContext {
+    widget: ComponentTestWidget;
+    fixture: ComponentFixture<TestHostComponent>;
+}
+
+@Component({
+    template: `
+        <clr-icon shape="home" [vcdAlternativeText]="altText">
+            <svg></svg>
+        </clr-icon>
+        <clr-icon shape="check">
+            <svg></svg>
+        </clr-icon>
+        <clr-icon shape="times" [vcdAlternativeText]="'Times icon'">
+            <svg alt="pre-set text"></svg>
+        </clr-icon>
+    `,
+})
+export class TestHostComponent {
+    altText = 'Home';
+}
+
+class ComponentTestWidget extends WidgetObject<TestHostComponent> {
+    public getAlternativeText(shape: string): string {
+        return this.findElement(`clr-icon[shape="${shape}"] svg`).nativeElement.getAttribute(ALTERNATIVE_TEXT);
+    }
+}
+
+describe('AlternativeTextDirective', () => {
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [ClarityModule, AlternativeTextModule],
+            declarations: [TestHostComponent],
+        }).compileComponents();
+    });
+
+    beforeEach(function (this: TestContext): void {
+        this.fixture = TestBed.createComponent(TestHostComponent);
+        this.widget = new ComponentTestWidget(this.fixture);
+        this.widget.detectChanges();
+    });
+
+    it('sets the "alt" attribute', function (this: TestContext): void {
+        expect(this.widget.getAlternativeText('home')).toBe(this.widget.component.altText);
+    });
+
+    it('sets the "alt" attribute to blank when no value is set', function (this: TestContext): void {
+        expect(this.widget.getAlternativeText('check')).toBe('');
+    });
+
+    it('does not set the "alt" attribute when there is one already', function (this: TestContext): void {
+        expect(this.widget.getAlternativeText('times')).toBe('pre-set text');
+    });
+});

--- a/projects/components/src/lib/directives/alternative-text/alternative-text.directive.ts
+++ b/projects/components/src/lib/directives/alternative-text/alternative-text.directive.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { AfterViewInit, Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+
+export const ALTERNATIVE_TEXT = 'alt';
+
+/**
+ * Adds the 'alt' attribute to the injected svg in clr-icon elements.
+ */
+@Directive({
+    // tslint:disable-next-line: directive-selector
+    selector: 'clr-icon',
+})
+export class AlternativeTextDirective implements AfterViewInit {
+    @Input() vcdAlternativeText: string = '';
+
+    constructor(private el: ElementRef<HTMLElement>, private renderer: Renderer2) {}
+
+    ngAfterViewInit(): void {
+        const svgElement = this.el.nativeElement.querySelector('svg');
+        if (svgElement && !svgElement.getAttribute(ALTERNATIVE_TEXT)) {
+            this.renderer.setAttribute(svgElement, ALTERNATIVE_TEXT, this.vcdAlternativeText);
+        }
+    }
+}

--- a/projects/components/src/lib/directives/alternative-text/alternative-text.module.ts
+++ b/projects/components/src/lib/directives/alternative-text/alternative-text.module.ts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { NgModule } from '@angular/core';
+import { AlternativeTextDirective } from './alternative-text.directive';
+
+@NgModule({
+    declarations: [AlternativeTextDirective],
+    exports: [AlternativeTextDirective],
+})
+export class AlternativeTextModule {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
- Introduces alternative-text directive that sets the 'alt' attribute on the inner 'svg'

## What manual testing did you do?
- on the examples, inspected the error icon and verified that it has an empty 'alt' attribute

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
