### PR TITLE
Add de-bouncing logic to the quick search functionality

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-dev.54]
+### Changed
+- QuickSearchProvider now takes a boolean argument in its constructor to debounce calling the search functionality
+by 300 milliseconds 
+
 ## [1.0.0-dev.53] - 2020-12-16
 ### Fixed
 - Allows boolean to be set to disable an action item

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.53",
+    "version": "1.0.0-dev.54",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-search-provider/action-search.provider.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.ts
@@ -25,9 +25,10 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
         this.flatListOfAvailableActions = null;
     }
 
-    constructor(private ts: TranslationService) {
-        super();
+    constructor(private ts: TranslationService, public shouldDebounceInput = false) {
+        super(shouldDebounceInput);
     }
+
     private flatListOfAvailableActions: ActionItem<R, T>[];
 
     /**

--- a/projects/components/src/action-search-provider/action-search.provider.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.ts
@@ -25,7 +25,7 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
         this.flatListOfAvailableActions = null;
     }
 
-    constructor(private ts: TranslationService, public shouldDebounceInput = false) {
+    constructor(private ts: TranslationService, shouldDebounceInput = false) {
         super(shouldDebounceInput);
     }
 

--- a/projects/components/src/quick-search/quick-search.component.ts
+++ b/projects/components/src/quick-search/quick-search.component.ts
@@ -198,6 +198,10 @@ export class QuickSearchComponent {
                     return;
                 }
             }
+            // This code will get called for each of the key strokes that gets typed during the buffer time. This means if there were 10
+            // characters typed during the de-bouncing time, this code will be called 10 times after the promise is resolved from a provider
+            // search function. However, we don't currently see any problem with that because the following code just re assigns variables
+            // with same values
             searchSection.result = searchResult;
             searchSection.isLoading = false;
             if (!this.selectedItem) {

--- a/projects/components/src/quick-search/quick-search.provider.ts
+++ b/projects/components/src/quick-search/quick-search.provider.ts
@@ -30,11 +30,6 @@ export interface QuickSearchProvider {
     data: unknown;
 
     /**
-     * Indicates if a provider has to wait for {@link PROVIDER_SEARCH_DEBOUNCE_TIME} milliseconds
-     */
-    shouldDebounceInput: boolean;
-
-    /**
      * Returns an array or a promise of array of items that comply with the search criteria.
      * @param criteria The search string provided by the user when typing in the Quick Search Component
      */
@@ -45,9 +40,11 @@ export abstract class QuickSearchProviderDefaults implements QuickSearchProvider
     sectionName = '';
     order = -1;
     data: unknown;
-    abstract shouldDebounceInput: boolean;
     abstract search(criteria: string): QuickSearchResultsType;
 
+    /**
+     * @param shouldDebounceInput Indicates if a provider has to wait for {@link PROVIDER_SEARCH_DEBOUNCE_TIME} milliseconds
+     */
     constructor(shouldDebounceInput: boolean) {
         if (shouldDebounceInput) {
             // The return type is being ignored because, createBufferedPromise function returns a function that returns a Promise which

--- a/projects/components/src/quick-search/quick-search.provider.ts
+++ b/projects/components/src/quick-search/quick-search.provider.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { CommonUtil } from '../utils';
 import { QuickSearchResultsType } from './quick-search-result';
+
+export const PROVIDER_SEARCH_DEBOUNCE_TIME = 300;
 
 /**
  * The interface a search providers should implement in order to register itself with the {@link QuickSearchService}
@@ -27,6 +30,11 @@ export interface QuickSearchProvider {
     data: unknown;
 
     /**
+     * Indicates if a provider has to wait for {@link PROVIDER_SEARCH_DEBOUNCE_TIME} milliseconds
+     */
+    shouldDebounceInput: boolean;
+
+    /**
      * Returns an array or a promise of array of items that comply with the search criteria.
      * @param criteria The search string provided by the user when typing in the Quick Search Component
      */
@@ -37,5 +45,17 @@ export abstract class QuickSearchProviderDefaults implements QuickSearchProvider
     sectionName = '';
     order = -1;
     data: unknown;
+    abstract shouldDebounceInput: boolean;
     abstract search(criteria: string): QuickSearchResultsType;
+
+    constructor(shouldDebounceInput: boolean) {
+        if (shouldDebounceInput) {
+            // The return type is being ignored because, createBufferedPromise function returns a function that returns a Promise which
+            // in turn wraps the return value of search function and TS compiler is not accepting () => Promise<QuickSearchResultsType>
+            // as () => QuickSearchResultsType. However, this is not a problem because, QuickSearchResultsType can be of type
+            // Promise<QuickSearchResults> and Promise<Promise<QuickSearchResults>> can be assigned to Promise<QuickSearchResults>
+            // @ts-ignore
+            this.search = CommonUtil.createBufferedPromise(this.search, this, PROVIDER_SEARCH_DEBOUNCE_TIME);
+        }
+    }
 }

--- a/projects/components/src/quick-search/quick-search.service.spec.ts
+++ b/projects/components/src/quick-search/quick-search.service.spec.ts
@@ -8,8 +8,10 @@ import { QuickSearchProvider } from './quick-search.provider';
 import { QuickSearchService } from './quick-search.service';
 
 class SimpleSearchProvider implements QuickSearchProvider {
-    data: unknown;
     constructor(public sectionName: string = '', public order: number = -1) {}
+    data: unknown;
+
+    shouldDebounceInput: boolean;
     search(criteria: string): QuickSearchResultsType {
         return { items: [] };
     }

--- a/projects/components/src/utils/common-util.spec.ts
+++ b/projects/components/src/utils/common-util.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, tick } from '@angular/core/testing';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { CommonUtil } from './common-util';
 
 describe('CommonUtil', () => {
@@ -18,27 +18,22 @@ describe('CommonUtil', () => {
     });
 
     describe('createBufferedPromise', () => {
-        it(
-            'returns a function that returns a promise which resolves with the output of function passed after a buffer amount of' +
-                'milliseconds',
-            fakeAsync(() => {
-                const bufferedFuncOutput = `output of function passed to createBufferedPromise`;
-                const spiedObject = {
-                    functionToBeBuffered: () => bufferedFuncOutput,
-                };
-                const spy = spyOn(spiedObject, 'functionToBeBuffered').and.callThrough();
-                const bufferTime = 400;
-                const bufferedPromise = CommonUtil.createBufferedPromise(
-                    spiedObject.functionToBeBuffered,
-                    null,
-                    bufferTime
-                );
-                bufferedPromise();
-                tick(399);
-                expect(spy).not.toHaveBeenCalled();
-                tick(1);
-                expect(spy).toHaveBeenCalled();
-            })
-        );
+        it('returns a function that when called does not call the passed in function until x ms have elapsed', fakeAsync(() => {
+            const spiedObject = {
+                functionToBeBuffered: () => `output of function passed to createBufferedPromise`,
+            };
+            const spy = spyOn(spiedObject, 'functionToBeBuffered').and.callThrough();
+            const bufferTime = 400;
+            const bufferedPromise = CommonUtil.createBufferedPromise(
+                spiedObject.functionToBeBuffered,
+                null,
+                bufferTime
+            );
+            bufferedPromise();
+            tick(399);
+            expect(spy).not.toHaveBeenCalled();
+            tick(1);
+            expect(spy).toHaveBeenCalled();
+        }));
     });
 });

--- a/projects/components/src/utils/common-util.spec.ts
+++ b/projects/components/src/utils/common-util.spec.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import { discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, tick } from '@angular/core/testing';
 import { CommonUtil } from './common-util';
 
 describe('CommonUtil', () => {
@@ -14,5 +15,23 @@ describe('CommonUtil', () => {
     });
     it('can round to 0 when no number is given', () => {
         expect(CommonUtil.roundTo(null)).toEqual(0);
+    });
+
+    describe('createBufferedPromise', () => {
+        it(
+            'returns a function that returns a promise which resolves with the output of function passed after a buffer amount of' +
+                'milliseconds',
+            async () => {
+                const bufferedFuncOutput = `output of function passed to createBufferedPromise`;
+                const functionToBeBuffered = () => bufferedFuncOutput;
+                const bufferTime = 400;
+                const bufferedPromise = CommonUtil.createBufferedPromise(functionToBeBuffered, null, bufferTime);
+                let result;
+                setTimeout(() => expect(result).toBeUndefined(), 399);
+                setTimeout(() => expect(result).toBeDefined(), 401);
+                result = await bufferedPromise();
+                expect(result).toEqual(bufferedFuncOutput);
+            }
+        );
     });
 });

--- a/projects/components/src/utils/common-util.spec.ts
+++ b/projects/components/src/utils/common-util.spec.ts
@@ -21,17 +21,24 @@ describe('CommonUtil', () => {
         it(
             'returns a function that returns a promise which resolves with the output of function passed after a buffer amount of' +
                 'milliseconds',
-            async () => {
+            fakeAsync(() => {
                 const bufferedFuncOutput = `output of function passed to createBufferedPromise`;
-                const functionToBeBuffered = () => bufferedFuncOutput;
+                const spiedObject = {
+                    functionToBeBuffered: () => bufferedFuncOutput,
+                };
+                const spy = spyOn(spiedObject, 'functionToBeBuffered').and.callThrough();
                 const bufferTime = 400;
-                const bufferedPromise = CommonUtil.createBufferedPromise(functionToBeBuffered, null, bufferTime);
-                let result;
-                setTimeout(() => expect(result).toBeUndefined(), 399);
-                setTimeout(() => expect(result).toBeDefined(), 401);
-                result = await bufferedPromise();
-                expect(result).toEqual(bufferedFuncOutput);
-            }
+                const bufferedPromise = CommonUtil.createBufferedPromise(
+                    spiedObject.functionToBeBuffered,
+                    null,
+                    bufferTime
+                );
+                bufferedPromise();
+                tick(399);
+                expect(spy).not.toHaveBeenCalled();
+                tick(1);
+                expect(spy).toHaveBeenCalled();
+            })
         );
     });
 });

--- a/projects/components/src/utils/common-util.ts
+++ b/projects/components/src/utils/common-util.ts
@@ -22,4 +22,48 @@ export class CommonUtil {
     static isFunction(value: any): value is (...args: unknown[]) => unknown {
         return typeof value === 'function';
     }
+
+    /**
+     * Creates a function that when called, actually calls the function parameter `fn` after a certain amount of time,
+     * which is the value of `buffer` parameter. The created function then resolves the promise it returned and the same
+     * promise is reused for all the calls that get buffered
+     *
+     * @param fn - Function to be debounced
+     * @param scope - The function scope of the parameter `fn`
+     * @param buffer - How long since the last call to the debounced function to wait before calling `fn`
+     * @return A function that when called, will delay the calls to the `fn` that was passed in. That function will return
+     * the same promise each time a call is made and buffered. This means that callers need to be sure to ignore previous
+     * calls. This is not
+     */
+    static createBufferedPromise<T extends (...p: any) => any>(
+        fn: T,
+        scope: unknown,
+        buffer = 300
+    ): (...args: Parameters<T>) => Promise<ReturnType<T>> {
+        let timerId: any;
+        let pendingPromise: Promise<ReturnType<T>> = null;
+        // tslint:disable-next-line:ban-types
+        let resolver: Function;
+        // tslint:disable-next-line:only-arrow-functions
+        return function (): Promise<any> {
+            if (!pendingPromise) {
+                pendingPromise = new Promise((resolve) => {
+                    resolver = resolve;
+                });
+            }
+            const callArgs = Array.from(arguments);
+            if (timerId) {
+                clearTimeout(timerId);
+                timerId = null;
+            }
+
+            timerId = setTimeout(() => {
+                const retValue = fn.apply(scope, callArgs);
+                resolver(retValue);
+                pendingPromise = null;
+                timerId = null;
+            }, buffer);
+            return pendingPromise;
+        };
+    }
 }

--- a/projects/examples/src/app/components/action-menu/action-menu.examples.module.ts
+++ b/projects/examples/src/app/components/action-menu/action-menu.examples.module.ts
@@ -11,6 +11,8 @@ import { ActionMenuContextualActionsExampleComponent } from './contextual-action
 import { ActionMenuContextualActionsExampleModule } from './contextual-actions/action-menu-contextual-actions-example.module';
 import { ActionMenuHideDisableExampleComponent } from './hide-disable/action-menu-hide-disable-example.component';
 import { ActionMenuHideDisableExampleModule } from './hide-disable/action-menu-hide-disable.example.module';
+import { ActionMenuSearchDebounceExampleComponent } from './search-debounce/action-menu-search-debounce.example.component';
+import { ActionMenuSearchDebounceExampleModule } from './search-debounce/action-menu-search-debounce.example.module';
 // tslint:disable-next-line:max-line-length
 import { ActionMenuSearchPauseUnpauseExampleComponent } from './search-pause-unpause/action-menu-search-pause-and-unpause.example.component';
 import { ActionMenuSearchPauseAndUnpauseExampleModule } from './search-pause-unpause/action-menu-search-pause-and-unpause.example.module';
@@ -71,6 +73,12 @@ Documentation.registerDocumentationEntry({
             title: 'Action search pause and unpause',
             urlSegment: 'action-search-pause-unpause',
         },
+        {
+            component: ActionMenuSearchDebounceExampleComponent,
+            forComponent: null,
+            title: 'Debounced Action Search',
+            urlSegment: 'action-menu-search-debounce',
+        },
     ],
 });
 
@@ -83,6 +91,7 @@ Documentation.registerDocumentationEntry({
         ActionMenuStaticAndContextualActionsExampleModule,
         ActionMenuHideDisableExampleModule,
         ActionMenuSearchExampleModule,
+        ActionMenuSearchDebounceExampleModule,
     ],
 })
 export class ActionMenuExamplesModule {}

--- a/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.html
+++ b/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.html
@@ -1,0 +1,16 @@
+<div>
+    <p>
+        Press 'command+.' on Mac OS or 'ctrl+.' on PC to open quick search and search through all the actions. Notice
+        that there is a spinner displayed initially for 300ms before displaying the action items. This is because the
+        action search provider is created to debounce the search using 2nd argument(boolean) passed to its constructor.
+    </p>
+    <vcd-action-menu
+        [actions]="actions"
+        [actionDisplayConfig]="actionDisplayConfig"
+        [selectedEntities]="selectedEntities"
+        [dropdownTriggerBtnText]="'vcd.cc.action.menu.actions'"
+    >
+    </vcd-action-menu>
+</div>
+
+<vcd-quick-search [(open)]="spotlightOpen" [placeholder]="'Search contextual actions'"></vcd-quick-search>

--- a/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.scss
+++ b/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.scss
@@ -1,0 +1,7 @@
+vcd-action-menu ::ng-deep .inline-actions-container {
+    & .inline-action-dropdown {
+        & ::ng-deep .nested-dropdown > .first-dropdown-toggle {
+            margin-top: 0 !important;
+        }
+    }
+}

--- a/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.ts
+++ b/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2020 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -28,15 +28,17 @@ interface HandlerData {
 }
 
 @Component({
-    selector: 'vcd-action-search-example',
-    templateUrl: 'action-menu-search-example.component.html',
-    styleUrls: ['action-menu-search-example.component.scss'],
+    selector: 'vcd-action-menu-search-debounce-example',
+    templateUrl: './action-menu-search-debounce.example.component.html',
+    styleUrls: ['./action-menu-search-debounce.example.component.scss'],
 })
-export class ActionMenuSearchExampleComponent<R extends Record, T extends HandlerData> implements OnInit, OnDestroy {
+export class ActionMenuSearchDebounceExampleComponent<R extends Record, T extends HandlerData>
+    implements OnInit, OnDestroy {
     constructor(private spotlightSearchService: QuickSearchService, private translationService: TranslationService) {}
 
     kbdShortcut = 'mod+.';
     spotlightOpen: boolean;
+    actionSearchProvider = new ActionSearchProvider(this.translationService, true);
 
     actions: ActionItem<R, T>[] = [
         {
@@ -66,35 +68,6 @@ export class ActionMenuSearchExampleComponent<R extends Record, T extends Handle
             handler: () => console.log('Contextual featured'),
             isTranslatable: false,
         },
-        {
-            textKey: 'power.actions',
-            children: [
-                {
-                    textKey: 'Start',
-                    handler: (rec: R[]) => {
-                        console.log('Starting ' + rec[0].value);
-                        rec[0].paused = false;
-                        this.selectedEntities = rec;
-                    },
-                    availability: (rec: R[]) => rec.length === 1 && rec[0].paused,
-                    actionType: ActionType.CONTEXTUAL_FEATURED,
-                    isTranslatable: false,
-                    class: 'start',
-                },
-                {
-                    textKey: 'Stop',
-                    handler: (rec: R[]) => {
-                        console.log('Stopping ' + (rec as R[])[0].value);
-                        rec[0].paused = true;
-                        this.selectedEntities = rec;
-                    },
-                    availability: (rec: R[]) => rec.length === 1 && !rec[0].paused,
-                    actionType: ActionType.CONTEXTUAL_FEATURED,
-                    isTranslatable: false,
-                    class: 'stop',
-                },
-            ],
-        },
     ];
 
     actionDisplayConfig: ActionDisplayConfig = {
@@ -115,8 +88,6 @@ export class ActionMenuSearchExampleComponent<R extends Record, T extends Handle
     }
 
     private actionProviderName = 'actionMenuExampleComponent';
-
-    actionSearchProvider = new ActionSearchProvider(this.translationService);
 
     ngOnInit(): void {
         const mousetrap = new Mousetrap();

--- a/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.module.ts
+++ b/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.module.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { VcdComponentsModule } from '@vcd/ui-components';
+import { ActionMenuSearchDebounceExampleComponent } from './action-menu-search-debounce.example.component';
+
+@NgModule({
+    declarations: [ActionMenuSearchDebounceExampleComponent],
+    imports: [CommonModule, VcdComponentsModule],
+    exports: [ActionMenuSearchDebounceExampleComponent],
+    entryComponents: [ActionMenuSearchDebounceExampleComponent],
+})
+export class ActionMenuSearchDebounceExampleModule {}

--- a/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
@@ -116,7 +116,7 @@ export class ActionMenuSearchExampleComponent<R extends Record, T extends Handle
 
     private actionProviderName = 'actionMenuExampleComponent';
 
-    actionSearchProvider = new ActionSearchProvider(this.translationService);
+    actionSearchProvider = new ActionSearchProvider(this.translationService, true);
 
     ngOnInit(): void {
         const mousetrap = new Mousetrap();

--- a/projects/examples/src/components/quick-search/quick-search-content-projection.example.component.ts
+++ b/projects/examples/src/components/quick-search/quick-search-content-projection.example.component.ts
@@ -60,8 +60,8 @@ export class SimpleSearchProvider extends QuickSearchProviderDefaults {
 
     private actions: QuickSearchResultItem[];
 
-    constructor() {
-        super();
+    constructor(public shouldDebounceInput = false) {
+        super(shouldDebounceInput);
         // Build actions
         this.actions = [...Array(200)].map((_, i) => {
             const action = `Action - ${i + 1}`;

--- a/projects/examples/src/components/quick-search/quick-search-sync-async.example.component.ts
+++ b/projects/examples/src/components/quick-search/quick-search-sync-async.example.component.ts
@@ -74,8 +74,8 @@ export class ActionsSearchProvider extends QuickSearchProviderDefaults {
 
     private actions: QuickSearchResultItem[];
 
-    constructor() {
-        super();
+    constructor(public shouldDebounceInput = false) {
+        super(shouldDebounceInput);
 
         // Build actions
         this.actions = actions.map((action) => {
@@ -108,6 +108,10 @@ export class LazyLoadedActionsSearchProvider extends QuickSearchProviderDefaults
 
     order = -1;
 
+    constructor(public shouldDebounceInput = false) {
+        super(shouldDebounceInput);
+    }
+
     private actions: QuickSearchResultItem[] = actions.map((action) => {
         return {
             displayText: `Lazy loaded ${action}`,
@@ -129,8 +133,8 @@ export class PagedActionsSearchProvider extends QuickSearchProviderDefaults {
 
     private actions: QuickSearchResultItem[];
 
-    constructor() {
-        super();
+    constructor(public shouldDebounceInput = false) {
+        super(shouldDebounceInput);
         // Build actions
         this.actions = [...Array(200)].map((_, i) => {
             const action = `Action - ${i + 1}`;

--- a/projects/examples/src/components/quick-search/quick-search-sync-async.example.module.ts
+++ b/projects/examples/src/components/quick-search/quick-search-sync-async.example.module.ts
@@ -18,6 +18,11 @@ import {
     declarations: [QuickSearchSyncAsyncExampleComponent],
     exports: [QuickSearchSyncAsyncExampleComponent],
     entryComponents: [QuickSearchSyncAsyncExampleComponent],
-    providers: [ActionsSearchProvider],
+    providers: [
+        {
+            provide: ActionsSearchProvider,
+            useValue: new ActionsSearchProvider(false),
+        },
+    ],
 })
 export class QuickSearchSyncAsyncExampleModule {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [YES] Tests for the changes have been added (for bug fixes/features)
-   [YES] Examples have been added / updated (for bug fixes / features)
-   [YES] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [x] Other... Please describe: Simplify for the caller of a search provider to debounce the calling of the search function

## What does this change do?
Simplify for the caller of a search provider to debounce the calling of the search function by 300 ms since the last keystroke.

## What manual testing did you do?
Toggled the debouncing logic in one of the examples on examples app verified that it gets executed successfully.

## Screenshots (if applicable)
![debounceActionSearch](https://user-images.githubusercontent.com/10735165/101681446-26e03080-3a30-11eb-97a5-e9c9a2ecda30.gif)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

## Other information
The unit tests and examples will be added in a separate commit from the first commit