### PR TITLE
Fix bug where label text is not wrapped and labels is not associated with the 'Access Level' combo box

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Accessibility: Added blank alternative text to all svgs inside clr-icon elements
+- Label text is not wrapped in `vcd-select-form`
+- Labels is not associated with the 'Access Level' combo box.
 
 ## [1.0.0-a11y.7] - 2020-12-8
-### Fixed 
+### Fixed
 - `vcd-number-with-unit` alignment issues with the unit dropdown
 - Make `vcd-number-with-unit` select a default unit when the initial value is null
 

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -1,6 +1,6 @@
 <div class="form-group">
     <div class="clr-form-control" vcdResponsiveInput>
-        <label *ngIf="label" [attr.for]="id" class="clr-control-label" [ngClass]="{ 'required-field': showAsterisk }">{{
+        <label *ngIf="label" [for]="id" class="clr-control-label" [ngClass]="{ 'required-field': showAsterisk }">{{
             label
         }}</label>
         <span *ngIf="isReadOnly && selectedOption" class="readOnly">

--- a/projects/components/src/form/form-select/form-select.component.scss
+++ b/projects/components/src/form/form-select/form-select.component.scss
@@ -13,3 +13,7 @@
 :host(.site-selector-single-site) {
     display: none;
 }
+
+label {
+    white-space: normal;
+}


### PR DESCRIPTION
Signed-off-by: yumengwu <yumengwu95@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
- Add css style `white-space: normal` to label in `vcd-form-select` to make label text wrap
- Fix bug where labels is not associated with the 'Access Level' combo box.

## What manual testing did you do?
- Open `Create a vApp from an OVF file` modal and Observe that label text is wrapped in `Customize Hardware` step
- Follow the path (Libraries > Content Libraries > Catalogs > Actions > Share > Users), observe that dropdown could be opened by using tab and space

## Screenshots (if applicable)
<img width="996" alt="Screen Shot 2020-12-10 at 2 43 32 PM" src="https://user-images.githubusercontent.com/49406822/101821707-56f20700-3af6-11eb-80ea-65228fc7f238.png">

![Untitled](https://user-images.githubusercontent.com/49406822/101821806-79842000-3af6-11eb-839a-5f8fba56b4bb.gif)


## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
