### PR TITLE
Bump a11y version to 1.0.0-a11y.9

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0-a11y.9] - 2020-12-10
 ### Fixed
 - Accessibility: Added blank alternative text to all svgs inside clr-icon elements
 - Label text is not wrapped in `vcd-select-form`
@@ -16,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Make the signpost trigger on the form-checkbox consistent with the other form components
 
-## [1.0.0-a11y.7] - 2020-12-8
+## [1.0.0-a11y.8] - 2020-12-9
 ### Fixed
 - `vcd-number-with-unit` alignment issues with the unit dropdown
 - Make `vcd-number-with-unit` select a default unit when the initial value is null

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-a11y.8",
+    "version": "1.0.0-a11y.9",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },


### PR DESCRIPTION
Signed-off-by: yumengwu <yumengwu95@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [x] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Bump a11y version to 1.0.0-a11y.9:
Added blank alternative text to all svgs inside clr-icon elements
Fixed issues where label text is not wrapped in `vcd-select-form` and is not associated with the 'Access Level' combo box
Fixed the text wrap inside signposts for all form components
Fixed number-with-unit asterisk was not showing when the input was required
Make the signpost trigger on the form-checkbox consistent with the other form components

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
