### PR TITLE
Fix Quick Search 'Content Projection' example not opening on Stackblitz

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix Quick Search 'Content Projection' live examples opening on Stackblitz
+
 
 ## [1.0.0-dev.51] - 2020-12-4
 ### Added

--- a/projects/examples/src/components/quick-search/quick-search-content-projection.example.component.ts
+++ b/projects/examples/src/components/quick-search/quick-search-content-projection.example.component.ts
@@ -20,7 +20,7 @@ import Mousetrap from 'mousetrap';
     templateUrl: './quick-search-content-projection.example.component.html',
     providers: [QuickSearchRegistrarService],
 })
-export class QuickSearchContentProjectionComponent implements OnInit, OnDestroy {
+export class QuickSearchContentProjectionExampleComponent implements OnInit, OnDestroy {
     formGroup: FormGroup;
     kbdShortcut = 'mod+f';
     spotlightOpen: boolean;

--- a/projects/examples/src/components/quick-search/quick-search-content-projection.example.module.ts
+++ b/projects/examples/src/components/quick-search/quick-search-content-projection.example.module.ts
@@ -8,12 +8,12 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { QuickSearchModule, VcdFormModule } from '@vcd/ui-components';
-import { QuickSearchContentProjectionComponent } from './quick-search-content-projection.example.component';
+import { QuickSearchContentProjectionExampleComponent } from './quick-search-content-projection.example.component';
 
 @NgModule({
     imports: [CommonModule, ClarityModule, QuickSearchModule, VcdFormModule, ReactiveFormsModule],
-    declarations: [QuickSearchContentProjectionComponent],
-    exports: [QuickSearchContentProjectionComponent],
-    entryComponents: [QuickSearchContentProjectionComponent],
+    declarations: [QuickSearchContentProjectionExampleComponent],
+    exports: [QuickSearchContentProjectionExampleComponent],
+    entryComponents: [QuickSearchContentProjectionExampleComponent],
 })
 export class QuickSearchContentProjectionExampleModule {}

--- a/projects/examples/src/components/quick-search/quick-search.examples.module.ts
+++ b/projects/examples/src/components/quick-search/quick-search.examples.module.ts
@@ -6,7 +6,7 @@
 import { NgModule } from '@angular/core';
 import { QuickSearchComponent } from '@vcd/ui-components';
 import { Documentation } from '@vmw/ng-live-docs';
-import { QuickSearchContentProjectionComponent } from './quick-search-content-projection.example.component';
+import { QuickSearchContentProjectionExampleComponent } from './quick-search-content-projection.example.component';
 import { QuickSearchContentProjectionExampleModule } from './quick-search-content-projection.example.module';
 import { QuickSearchSyncAsyncExampleComponent } from './quick-search-sync-async.example.component';
 import { QuickSearchSyncAsyncExampleModule } from './quick-search-sync-async.example.module';
@@ -23,7 +23,7 @@ Documentation.registerDocumentationEntry({
             urlSegment: 'async-sync-sections',
         },
         {
-            component: QuickSearchContentProjectionComponent,
+            component: QuickSearchContentProjectionExampleComponent,
             forComponent: null,
             title: 'Content Projection',
             urlSegment: 'content-projection',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [x] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
The Quick Search 'Content Projection' example was not opening on stackblitz with an error in the console.
In order to run an example on stackblitz the component name should be matching its module name in the
following manner:
componentName.replace('ExampleComponent', 'ExampleModule')
In this specific case the name of the component was missing the 'Example' part, i.e. it was
`QuickSearchContentProjectionComponent` and for that reason the name replace was not working
correctly hence the error, hence the failure to open the example on stackblitz

## What manual testing did you do?
Verify that  'Content Projection' example can be opened on Stackblitz

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
