### PR TITLE
Updated `ClrDatagridWidget` to remove functions that are specific to `VcdDatagrid`

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0-dev.52] - 2020-12-16
 ### Fixed
 - Fix Quick Search 'Content Projection' live examples opening on Stackblitz
-
+### Changed
+1. Enabled `TestElement` to query children elements by css selector
+### Removed
+1. Removed functions in `ClrDatagridWidget` that are specific to VcdDatagrid
 
 ## [1.0.0-dev.51] - 2020-12-4
 ### Added
@@ -27,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Underlying page scrolling when navigating the action menu using arrow keys.
 - Space/Enter keys not closing the action menu after a action menu item is activated.
-- Esc key not closing the action menu it is pressed on. 
+- Esc key not closing the action menu it is pressed on.
 - Not being able to navigate using arrow keys on action menu with separators
 
 ## [1.0.0-dev.49] - 2020-11-10

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.51",
+    "version": "1.0.0-dev.52",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -233,18 +233,18 @@ describe('DatagridComponent', () => {
                 it('emits multiple rows when set to multi selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
-                    this.clrGridWidget.getRowSelect(0).click();
+                    this.clrGridWidget.getSelectionLabelForRow(0).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[0]]);
-                    this.clrGridWidget.getRowSelect(1).click();
+                    this.clrGridWidget.getSelectionLabelForRow(1).click();
                     expect(this.hostComponent.datagridSelection).toEqual(mockData);
                 });
 
                 it('emits only one row when set to single selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    this.clrGridWidget.getRowSelect(0).click();
+                    this.clrGridWidget.getSelectionLabelForRow(0).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[0]]);
-                    this.clrGridWidget.getRowSelect(1).click();
+                    this.clrGridWidget.getSelectionLabelForRow(1).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                 });
 
@@ -260,9 +260,9 @@ describe('DatagridComponent', () => {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
-                    this.clrGridWidget.getRowSelect(0).click();
+                    this.clrGridWidget.getSelectionLabelForRow(0).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
-                    this.clrGridWidget.getRowSelect(1).click();
+                    this.clrGridWidget.getSelectionLabelForRow(1).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith(mockData);
                 });
 
@@ -270,9 +270,9 @@ describe('DatagridComponent', () => {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
-                    this.clrGridWidget.getRowSelect(0).click();
+                    this.clrGridWidget.getSelectionLabelForRow(0).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
-                    this.clrGridWidget.getRowSelect(1).click();
+                    this.clrGridWidget.getSelectionLabelForRow(1).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[1]]);
                 });
 
@@ -280,7 +280,7 @@ describe('DatagridComponent', () => {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
-                    this.clrGridWidget.getSingleSelectionRadioLabel(0).click();
+                    this.clrGridWidget.getSelectionLabelForRow(0).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
                     this.hostComponent.datagridSelection = [];
                     this.finder.detectChanges();
@@ -291,7 +291,7 @@ describe('DatagridComponent', () => {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
-                    this.clrGridWidget.getSingleSelectionRadioLabel(0).click();
+                    this.clrGridWidget.getSelectionLabelForRow(0).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
                     this.hostComponent.datagridSelection = [];
                     this.finder.detectChanges();
@@ -309,7 +309,7 @@ describe('DatagridComponent', () => {
                         };
                         this.finder.detectChanges();
                         tick();
-                        this.clrGridWidget.getRowSelect(1).click();
+                        this.clrGridWidget.getSelectionLabelForRow(1).click();
                         tick();
                         const component = this.vcdDatagrid.vcdDatagrid.getComponentInstance() as MockRecordDatagridComponent;
                         expect(component.datagridSelection).toEqual([mockData[1]]);
@@ -329,8 +329,8 @@ describe('DatagridComponent', () => {
                             totalItems: 2,
                         };
                         this.finder.detectChanges();
-                        this.clrGridWidget.getRowSelect(0).click();
-                        this.clrGridWidget.getRowSelect(1).click();
+                        this.clrGridWidget.getSelectionLabelForRow(0).click();
+                        this.clrGridWidget.getSelectionLabelForRow(1).click();
                         expect(this.hostComponent.datagridSelection).toEqual(mockData);
                         this.hostComponent.gridData = {
                             items: [mockData[0]],
@@ -346,7 +346,7 @@ describe('DatagridComponent', () => {
                 it('keeps selected an item if the item is not removed on refresh', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    this.clrGridWidget.getRowSelect(1).click();
+                    this.clrGridWidget.getSelectionLabelForRow(1).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                     this.hostComponent.gridData = {
                         items: [mockData[1]],
@@ -949,7 +949,7 @@ describe('DatagridComponent', () => {
                 ];
                 this.finder.detectChanges();
                 // This is because contextual actions requires entities to be selected
-                this.clrGridWidget.getRowSelect(0).click();
+                this.clrGridWidget.getSelectionLabelForRow(0).click();
                 this.finder.detectChanges();
                 expect(component.shouldShowActionBarOnTop).toBeTruthy();
             });

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -72,7 +72,7 @@ describe('DatagridComponent', () => {
         this.finder = new AngularWidgetObjectFinder(HostWithDatagridComponent);
         // @ts-ignore
         this.vcdDatagrid = this.finder.find(VcdDatagridWidgetObject);
-        this.clrGridWidget = this.vcdDatagrid.findClrDatagrid();
+        this.clrGridWidget = this.vcdDatagrid.clrDatagrid;
         this.hostComponent = this.finder.hostComponent as HostWithDatagridComponent;
     });
 
@@ -233,18 +233,18 @@ describe('DatagridComponent', () => {
                 it('emits multiple rows when set to multi selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
-                    this.clrGridWidget.getRowInput(0).click();
+                    this.clrGridWidget.getRowSelect(0).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[0]]);
-                    this.clrGridWidget.getRowInput(1).click();
+                    this.clrGridWidget.getRowSelect(1).click();
                     expect(this.hostComponent.datagridSelection).toEqual(mockData);
                 });
 
                 it('emits only one row when set to single selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    this.clrGridWidget.getRowInput(0).click();
+                    this.clrGridWidget.getRowSelect(0).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[0]]);
-                    this.clrGridWidget.getRowInput(1).click();
+                    this.clrGridWidget.getRowSelect(1).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                 });
 
@@ -260,9 +260,9 @@ describe('DatagridComponent', () => {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
-                    this.clrGridWidget.getRowInput(0).click();
+                    this.clrGridWidget.getRowSelect(0).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
-                    this.clrGridWidget.getRowInput(1).click();
+                    this.clrGridWidget.getRowSelect(1).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith(mockData);
                 });
 
@@ -270,9 +270,9 @@ describe('DatagridComponent', () => {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
-                    this.clrGridWidget.getRowInput(0).click();
+                    this.clrGridWidget.getRowSelect(0).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[0]]);
-                    this.clrGridWidget.getRowInput(1).click();
+                    this.clrGridWidget.getRowSelect(1).click();
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[1]]);
                 });
 
@@ -309,7 +309,7 @@ describe('DatagridComponent', () => {
                         };
                         this.finder.detectChanges();
                         tick();
-                        this.clrGridWidget.getRowInput(1).click();
+                        this.clrGridWidget.getRowSelect(1).click();
                         tick();
                         const component = this.vcdDatagrid.vcdDatagrid.getComponentInstance() as MockRecordDatagridComponent;
                         expect(component.datagridSelection).toEqual([mockData[1]]);
@@ -329,8 +329,8 @@ describe('DatagridComponent', () => {
                             totalItems: 2,
                         };
                         this.finder.detectChanges();
-                        this.clrGridWidget.getRowInput(0).click();
-                        this.clrGridWidget.getRowInput(1).click();
+                        this.clrGridWidget.getRowSelect(0).click();
+                        this.clrGridWidget.getRowSelect(1).click();
                         expect(this.hostComponent.datagridSelection).toEqual(mockData);
                         this.hostComponent.gridData = {
                             items: [mockData[0]],
@@ -346,7 +346,7 @@ describe('DatagridComponent', () => {
                 it('keeps selected an item if the item is not removed on refresh', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    this.clrGridWidget.getRowInput(1).click();
+                    this.clrGridWidget.getRowSelect(1).click();
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                     this.hostComponent.gridData = {
                         items: [mockData[1]],
@@ -949,7 +949,7 @@ describe('DatagridComponent', () => {
                 ];
                 this.finder.detectChanges();
                 // This is because contextual actions requires entities to be selected
-                this.clrGridWidget.getRowInput(0).click();
+                this.clrGridWidget.getRowSelect(0).click();
                 this.finder.detectChanges();
                 expect(component.shouldShowActionBarOnTop).toBeTruthy();
             });
@@ -1174,7 +1174,7 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getCellStrong(0, 0).text()).toBe(mockData[0].name);
+                expect(this.clrGridWidget.getCell(0, 0).queryElements('strong').text()).toBe(mockData[0].name);
             });
         });
     });

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -21,8 +21,6 @@ const Css = {
     PAGE_SIZE: 'clr-dg-page-size',
     PAGINATION_NEXT: '.pagination-next',
     TOP_POSITIONED_BUTTON: 'clr-dg-action-bar button',
-    // Do not use this. This is specific to VCD datagrid.
-    ROW_BUTTON_CONTAINER: '.action-button-cell',
     ROW_ACTION_CONTAINER: '.datagrid-select label',
     CHECKBOX_WRAPPER: 'clr-checkbox-wrapper',
     RADIO_WRAPPER: 'clr-radio-wrapper',
@@ -131,39 +129,14 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     }
 
     /**
-     * Helper function to retrieve a cell
-     * @param row 0-based index of row
-     * @param col 0-based index of column
-     */
-    private _getCell(row: number, col: number): LocatorDriver<T> {
-        return this._getRow(row).get(`${Css.CELL}:nth-of-type(${col + 1})`);
-    }
-
-    /**
      * Retrieves the cell
      * @param row 0-based index of row
      * @param col 0-based index of column
      */
     getCell(row: number, col: number): T {
-        return this._getCell(row, col).unwrap();
-    }
-
-    /**
-     * Gives the linked tag in the given cell
-     * @param row 0-based index of row
-     * @param col 0-based index of column
-     */
-    getCellLink(row: number, col: number): T {
-        return this._getCell(row, col).get('a').unwrap();
-    }
-
-    /**
-     * Gives the `strong` tag in the given cell
-     * @param row 0-based index of row
-     * @param col 0-based index of column
-     */
-    getCellStrong(row: number, col: number): T {
-        return this._getCell(row, col).get('strong').unwrap();
+        return this._getRow(row)
+            .get(`${Css.CELL}:nth-of-type(${col + 1})`)
+            .unwrap();
     }
 
     /**
@@ -179,17 +152,15 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * @param col 0-based index of column
      */
     getColumn(col: number): T {
-        // return this.locatorDriver.get(`${Css.COLUMN}:nth-of-type(${col + 1})`).unwrap();
         return this.locatorForCssSelectors(`${Css.COLUMN}:nth-of-type(${col + 1})`)();
     }
 
     /**
-     * Returns input element in the given row
+     * Returns datagrid select element in the given row
      * @param row 0-based index of row
-     * @deprecated It doesn't make sense to grab a random input out of a row.
      */
-    getRowInput(row: number): T {
-        return this._getRow(row).get('input').unwrap();
+    getRowSelect(row: number): T {
+        return this._getRow(row).get(Css.ROW_ACTION_CONTAINER).unwrap();
     }
 
     /**
@@ -204,7 +175,6 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * Returns the button on the top of the grid with the given buttonClass
      */
     getTopButton(btnClass: string): T {
-        // return this.locatorDriver.get(`button.${btnClass}`).unwrap();
         return this.locatorForCssSelectors(`button.${btnClass}`)();
     }
 
@@ -220,16 +190,7 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * @param col 0-based index of header
      */
     getColumnHeader(col: number): T {
-        // return this.locatorDriver.get(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`).unwrap();
         return this.locatorForCssSelectors(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`)();
-    }
-
-    /**
-     * Returns a row button
-     * @param row 0-based index
-     */
-    getRowButtonContainer(row: number): T {
-        return this._getRow(row).get(Css.ROW_BUTTON_CONTAINER).unwrap();
     }
 
     getSingleSelectionRadioLabel(row: number): T {
@@ -239,7 +200,7 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * Returns filter toggle
      */
-    getFilterToggle(): T {
+    get filterToggle(): T {
         return this.locatorDriver.get(Css.COLUMN).get(Css.FILTER).get(Css.FILTER_TOGGLE).unwrap();
     }
 

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -156,14 +156,6 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     }
 
     /**
-     * Returns datagrid select element in the given row
-     * @param row 0-based index of row
-     */
-    getRowSelect(row: number): T {
-        return this._getRow(row).get(Css.ROW_ACTION_CONTAINER).unwrap();
-    }
-
-    /**
      * Returns all the cell elements in the given row
      * @param row 0-based index of row
      */
@@ -193,7 +185,12 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
         return this.locatorForCssSelectors(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`)();
     }
 
-    getSingleSelectionRadioLabel(row: number): T {
+    /**
+     * Returns label of `.datagrid-select` element in the given row. This function can be used to
+     * perform both single and multiple selection
+     * @param row 0-based index of row
+     */
+    getSelectionLabelForRow(row: number): T {
         return this._getRow(row).get(Css.ROW_ACTION_CONTAINER).unwrap();
     }
 

--- a/projects/components/src/utils/test/datagrid/filter-utils.ts
+++ b/projects/components/src/utils/test/datagrid/filter-utils.ts
@@ -73,7 +73,7 @@ export function createDatagridFilterTestHelper<V, C>(
 
     finder.hostComponent.setFilter(filterType, finder, config || ({} as C));
     grid.clrDatagrid.fixture.detectChanges();
-    grid.getFilterToggle().click();
+    grid.filterToggle.click();
     return getFilter(grid.clrDatagrid, filterType);
 }
 
@@ -91,7 +91,7 @@ export function createDatagridFilterTestHelperWithFinder<V, C>(
     const grid = finder.find(ClrDatagridWidgetObject);
     finder.hostComponent.setFilter(filterType, finder, config || ({} as C));
     grid.clrDatagrid.fixture.detectChanges();
-    grid.getFilterToggle().click();
+    grid.filterToggle.click();
 
     return {
         finder,

--- a/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
@@ -20,7 +20,7 @@ export class VcdDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * Gives the widget object for this `clr-datagrid`.
      */
-    findClrDatagrid(): ClrDatagridWidgetObject<T> {
+    get clrDatagrid(): ClrDatagridWidgetObject<T> {
         // @ts-ignore
         return this.locatorDriver.findWidget(ClrDatagridWidgetObject);
     }

--- a/projects/components/src/utils/test/widget-object/angular-widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-object.ts
@@ -234,6 +234,14 @@ export class TestElement implements Iterable<TestElement> {
     }
 
     /**
+     * Returns children of the first element that matches css selector
+     */
+    queryElements(cssSelector: string): TestElement {
+        const result = this.elements[0].queryAll(By.css(cssSelector));
+        return new TestElement(result ? result : [], this.fixture);
+    }
+
+    /**
      * Allows a TestElement to be used in a `for ... of ...` loop.
      */
     [Symbol.iterator](): Iterator<TestElement, any, undefined> {


### PR DESCRIPTION
Signed-off-by: yumengwu <yumengwu95@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [x] Version bump
-   [ ] Other... Please describe:

## What does this change do?
- Added function `queryElements` to enable `TestElement` to query children elements by css selector
- Removed functions in `ClrDatagridWidget` that are specific to VcdDatagrid

## What manual testing did you do?
Ran the unit tests and observed all the tests passed

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
