### PR TITLE
Allow disabling responsive input directive on form controls

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.0.0-a11y.10] - 2020-12-16
+### Added
+- Ability to disable the responsive input directive on form controls so 
+  they can by used in vertical forms.
+
 ## [1.0.0-a11y.9] - 2020-12-10
 ### Fixed
 - Accessibility: Added blank alternative text to all svgs inside clr-icon elements

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-a11y.9",
+    "version": "1.0.0-a11y.10",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/form/base-form-control.ts
+++ b/projects/components/src/form/base-form-control.ts
@@ -89,6 +89,16 @@ export class BaseFormControl implements ControlValueAccessor, CanBeReadOnly {
     @Input() errorLabels: string[] = [];
 
     /**
+     * If this is true, Clarity responsive classes will be added to the component's elements so that label and input
+     * elements are on separate lines when on small screens or inside small containers.
+     *
+     * Note that if a form control is being used inside a `.clr-form-vertical`, the controls should all have
+     * isResponsive set to false, since that will cause labels to always display on a separate line and adding
+     * the responsive styles would interfere with that
+     */
+    @Input() isResponsive = true;
+
+    /**
      * FormControlName directive
      */
     formControlNameDirective: NgControl;

--- a/projects/components/src/form/form-checkbox/form-checkbox.component.html
+++ b/projects/components/src/form/form-checkbox/form-checkbox.component.html
@@ -1,5 +1,9 @@
 <div class="form-group">
-    <div class="clr-form-control" vcdResponsiveInput [ngClass]="{ 'clr-form-control-disabled': disabled }">
+    <div
+        class="clr-form-control"
+        [vcdResponsiveInput]="{ disabled: !isResponsive }"
+        [ngClass]="{ 'clr-form-control-disabled': disabled }"
+    >
         <label class="clr-control-label" [for]="id" *ngIf="label">{{ label }}</label>
         <div class="clr-control-container" [ngClass]="{ 'clr-error': showErrors }">
             <div [ngClass]="{ 'clr-checkbox-wrapper': isCheckbox, 'clr-toggle-wrapper': !isCheckbox }">

--- a/projects/components/src/form/form-input/form-input.component.html
+++ b/projects/components/src/form/form-input/form-input.component.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-    <div class="clr-form-control" vcdResponsiveInput>
+    <div class="clr-form-control" [vcdResponsiveInput]="{ disabled: !isResponsive }">
         <label *ngIf="label" class="clr-control-label" [for]="id" [ngClass]="{ 'required-field': showAsterisk }">{{
             label
         }}</label>

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -1,5 +1,5 @@
 <div class="form-group">
-    <div class="clr-form-control" vcdResponsiveInput>
+    <div class="clr-form-control" [vcdResponsiveInput]="{ disabled: !isResponsive }">
         <label *ngIf="label" [for]="id" class="clr-control-label" [ngClass]="{ 'required-field': showAsterisk }">{{
             label
         }}</label>

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -1,10 +1,10 @@
-<div class="clr-form-control" vcdResponsiveInput *ngIf="isReadOnly">
+<div class="clr-form-control" [vcdResponsiveInput]="{ disabled: !isResponsive }" *ngIf="isReadOnly">
     <label class="clr-control-label">{{ label }}</label>
     <span class="clr-control-container readonly-text">{{ displayValue || '-' }}</span>
 </div>
 
 <div *ngIf="!isReadOnly">
-    <div class="clr-form-control" vcdResponsiveInput>
+    <div class="clr-form-control" [vcdResponsiveInput]="{ disabled: !isResponsive }">
         <label *ngIf="label" class="clr-control-label" [for]="id" [ngClass]="{ 'required-field': showAsterisk }">{{
             label
         }}</label>

--- a/projects/components/src/index.ts
+++ b/projects/components/src/index.ts
@@ -6,7 +6,6 @@
 export * from './components.module';
 export * from './data-exporter/data-exporter.module';
 export * from './datagrid/datagrid.module';
-export * from './form/form.module';
 export * from './common/activity-reporter/activity-reporter.module';
 export * from './common/error/error-banner.module';
 export * from './common/loading/loading-indicator.module';

--- a/projects/components/src/lib/directives/responsive-input/responsive-input.directive.spec.ts
+++ b/projects/components/src/lib/directives/responsive-input/responsive-input.directive.spec.ts
@@ -50,6 +50,15 @@ describe('ResponsiveInputDirective', () => {
         this.fixture.componentInstance.showInput = false;
         expect(() => this.fixture.detectChanges()).not.toThrow();
     });
+
+    describe('disabled', () => {
+        it('does not add classes if disabled', function (this: Test): void {
+            this.fixture.componentInstance.disabled = true;
+            this.fixture.detectChanges();
+            const helper = new TestHelper(this.fixture);
+            expect(helper.rootHasClass('clr-row')).toBe(false, 'clr-row was added to the control container');
+        });
+    });
 });
 
 class TestHelper {
@@ -70,7 +79,7 @@ class TestHelper {
 }
 @Component({
     template: `
-        <div class="clr-form-control" vcdResponsiveInput>
+        <div class="clr-form-control" [vcdResponsiveInput]="{ disabled: disabled }">
             <label *ngIf="showLabel" class="clr-control-label">Label</label>
             <div *ngIf="showInput" class="clr-control-container">input here</div>
         </div>
@@ -81,4 +90,6 @@ export class TestHostComponent {
     showLabel = true;
     @Input()
     showInput = true;
+    @Input()
+    disabled = false;
 }

--- a/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
+++ b/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { AfterViewChecked, Directive, ElementRef, HostBinding } from '@angular/core';
+import { AfterViewChecked, Directive, ElementRef, HostBinding, Input } from '@angular/core';
 
-declare type ColSize = '2' | '4' | '8' | '10';
+type ColSize = '2' | '4' | '8' | '10';
+
+export interface ResponsiveInputOptions {
+    disabled: boolean;
+}
 
 /**
  * Adds Clarity grid classes to form controls based on the host's width so that labels and inputs are on separate
@@ -21,10 +25,29 @@ export class ResponsiveInputDirective implements AfterViewChecked {
 
     private breakPoint = 768;
 
+    /**
+     * The directive will be a no-op if it's disabled. It does not support being changed after rendering.
+     */
+    @Input('vcdResponsiveInput')
+    set options(value: ResponsiveInputOptions) {
+        this._disabled = value.disabled;
+        this.clrGridRow = !this.disabled;
+    }
+
+    public get disabled(): boolean {
+        return this._disabled;
+    }
+
+    private _disabled = false;
+
     @HostBinding('class.clr-row') public clrGridRow = true;
+
     constructor(private el: ElementRef<HTMLElement>) {}
 
     ngAfterViewChecked(): void {
+        if (this._disabled) {
+            return;
+        }
         if (this.elementWidth !== 0) {
             return;
         }


### PR DESCRIPTION
Signed-off-by: Juan Mendes <jmendes@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [x] Version bump
-   [x] Unit Tests added

## What does this change do?
Allow users of form controls to disable the behavior that makes labels be on the same line when there's enough real estate.

This is needed when the user already has added clr-vertical-form which means they always want the form to be vertical (label and input on different lines)


## What manual testing did you do?
* Make sure the screen is really wide (> 1400 px wide)
* Loaded the temp build onto VCD_UI
* Started the tenant dev environment
* Went to both vapps and VMs advanced filtering (VDC specific or the global one)
* Opened the advanced filter
* Made sure labels were not wrapping
  * They were wrapping previously because labels were being set to `clr-col-md-2`
* Made sure inputs were taking up the full width
  * Previously they had `clr-col-md-10` which made it not take up the full width 
* Made sure that the responsive grid styles were not being added when the form controls have `[isResponsive]="false"` 

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/549331/102409338-e303a300-3fbc-11eb-8ec8-06ab45c39f05.png)

![image](https://user-images.githubusercontent.com/549331/102409366-eb5bde00-3fbc-11eb-9065-6c7db5c0e8ce.png)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
