### PR TITLE
Remove calculateActionAvailability input

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
+## [1.0.0-dev.56]
+### Changed
+- BREAKING: Removed the calculateActionAvailability input which was acting as a switch to toggle the action availability
+calculation by ActionMenuComponent  
 
 ## [1.0.0-dev.55] - 2020-12-16
 - Merged a11y branch, changes described below

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -101,19 +101,6 @@ export class ActionMenuComponent<R, T> {
     shouldDisplayContextualActionsDropdownInline = false;
 
     /**
-     * This flag is for the parent to say to the action menu that it is already calculating the actions availability and
-     * telling it not to calculate the availability
-     */
-    @Input() set calculateActionsAvailability(val: boolean) {
-        this._calculateActionsAvailability = val;
-        this.updateActionListsAndDisplayFlags();
-    }
-    private _calculateActionsAvailability = true;
-    get calculateActionsAvailability(): boolean {
-        return this._calculateActionsAvailability;
-    }
-
-    /**
      * Text Content of the action menu dropdown trigger button. Used when {@link #actionDisplayConfig} styling is
      * {@link ActionStyling.DROPDOWN}
      */
@@ -143,7 +130,7 @@ export class ActionMenuComponent<R, T> {
         this._selectedEntities = val;
         this.updateActionListsAndDisplayFlags();
     }
-    private _selectedEntities: R[];
+    private _selectedEntities: R[] = [];
     get selectedEntities(): R[] {
         return this._selectedEntities;
     }
@@ -241,9 +228,6 @@ export class ActionMenuComponent<R, T> {
      * Returns the actions to be shown
      */
     getAvailableActions(actions: ActionItem<R, T>[]): ActionItem<R, T>[] {
-        if (!this.calculateActionsAvailability) {
-            return actions;
-        }
         return actions
             .filter((action) => this.isActionAvailable(action))
             .map((action) => {
@@ -291,7 +275,7 @@ export class ActionMenuComponent<R, T> {
     }
 
     private getContextualFeaturedActions(): ActionItem<R, T>[] {
-        if (this.calculateActionsAvailability && !this.selectedEntities?.length) {
+        if (!this.selectedEntities?.length) {
             return [];
         }
         const flattenedFeaturedActionList = this.getFlattenedActionList(this.actions, ActionType.CONTEXTUAL_FEATURED);
@@ -313,7 +297,7 @@ export class ActionMenuComponent<R, T> {
     }
 
     private getContextualActions(): ActionItem<R, T>[] {
-        if (this.calculateActionsAvailability && !this.selectedEntities?.length) {
+        if (!this.selectedEntities?.length) {
             return [];
         }
         const contextualActions = this.actions.filter(
@@ -321,11 +305,6 @@ export class ActionMenuComponent<R, T> {
                 !action.actionType ||
                 (action.actionType !== ActionType.STATIC_FEATURED && action.actionType !== ActionType.STATIC)
         );
-        // The error logged and not thrown because, there might be a case where the availability of contextual actions might not depend on
-        // selected entities
-        if (this.calculateActionsAvailability && contextualActions.length && !this.selectedEntities?.length) {
-            console.error('There are no selected entities to calculate contextual actions availability!');
-        }
         const availableContextualActions = this.getAvailableActions(contextualActions);
         if (this._extensionEntityActions) {
             availableContextualActions.push(...this._extensionEntityActions);
@@ -401,7 +380,7 @@ export class ActionMenuComponent<R, T> {
 
     private shouldDisplayContextualActions(style: ActionStyling): boolean {
         return (
-            (!this.calculateActionsAvailability || this.selectedEntities?.length) &&
+            this.selectedEntities?.length &&
             this.contextualActions.length &&
             this.actionDisplayConfig.contextual.styling === style
         );

--- a/projects/examples/src/app/components/action-menu/with-separators/action-menu-with-separators.example.component.html
+++ b/projects/examples/src/app/components/action-menu/with-separators/action-menu-with-separators.example.component.html
@@ -11,7 +11,6 @@
     <vcd-action-menu
         [actions]="actions"
         [actionDisplayConfig]="actionDisplayConfig"
-        [calculateActionsAvailability]="false"
         [dropdownTriggerBtnText]="'vcd.cc.action.menu.actions'"
     >
     </vcd-action-menu>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ X ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ X ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ X ] Other... Please describe: Api changes

## What does this change do?
Some of the components calculate the visibility of actions by themselves without having to rely on the ActionMenuComponent. So, in the past, a boolean input to ActionMenuComponent called `calculateActionAvailability` was introduced to let the component know to not calculate the availability of actions. However, this input didn't seem like a clean API and we decided to remove that input and do the following:
- Make the availability callbacks of action objects as arrow functions and make them have access to component closure variables on which the visibility of the action depends on.
- Vapp/vm views(both list and entity details) follow a convoluted approach to calculating the visibility of their action items. So, these components require the action menu component to just display the actions and not calculate their action availability. These components make the availability call back of their action objects to always return true so that actions get displayed always by the menu component.

## What manual testing did you do?
![vapp-vm-list-views](https://user-images.githubusercontent.com/10735165/103831664-89861580-504a-11eb-86eb-834e740bcd94.gif)
![vapp-vm-details-views](https://user-images.githubusercontent.com/10735165/103831665-8ab74280-504a-11eb-8c15-6878b0701920.gif)

## Other information
This PR affects the MR at https://gitlab.eng.vmware.com/core-build/vcd_ui/-/merge_requests/3169