### PR TITLE
Forgot to bump the package version with previous merge

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.55",
+    "version": "1.0.0-dev.56",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },


### PR DESCRIPTION
I forgot to bump the components package version with the PR https://github.com/vmware/vmware-cloud-director-ui-components/pull/290 that got merged into master. This change is just to bump the number in components/package.json 