### PR TITLE
Add `mainActionMenu` property to `DatagridComponent`

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `actionsUpdate` emitter to `ActionMenuComponent`
 - Add `hideWhenEmpty` flag to `QuickSearchProvider` to control section display when there is no data
+- Add `mainActionMenu` property to `DatagridComponent`
 
 ### Fixed
 - BREAKING: Fixes the `//@ ts-ignore problem with the Widget Object finder`. Now, you need to supply the type of the widget object as a type parameter to any of the `findWidget` or Widget Finder calls. This is because the type is too complicated for the method to infer.

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0-dev.57]
 ### Added
 - Add `actionsUpdate` emitter to `ActionMenuComponent`
 - Add `hideWhenEmpty` flag to `QuickSearchProvider` to control section display when there is no data

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `actionsUpdate` emitter to `ActionMenuComponent`
 - Add `hideWhenEmpty` flag to `QuickSearchProvider` to control section display when there is no data
 - Add `mainActionMenu` property to `DatagridComponent`
-
 ### Fixed
 - BREAKING: Fixes the `//@ ts-ignore problem with the Widget Object finder`. Now, you need to supply the type of the widget object as a type parameter to any of the `findWidget` or Widget Finder calls. This is because the type is too complicated for the method to infer.
+- Fixed datagrid returning new `datagridSelection` reference even if there were no real changes
 
 ## [1.0.0-dev.56]
 ### Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "1.0.0-dev.56",
+    "version": "1.0.0-dev.57",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -115,6 +115,7 @@
 
 <ng-template #actionBar>
     <vcd-action-menu
+        #mainActionMenu
         [actions]="actions"
         [selectedEntities]="datagridSelection"
         [actionDisplayConfig]="actionDisplayConfig"

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -7,8 +7,8 @@
     [clrDgLoading]="isLoading"
     [ngClass]="[this.clrDatagridCssClass, this.height ? 'set-height' : 'fill-parent-grid']"
     (clrDgRefresh)="gridStateChanged($event)"
-    (clrDgSelectedChange)="datagridSelectionChange.emit(datagridSelection)"
-    (clrDgSingleSelectedChange)="datagridSelectionChange.emit(datagridSelection)"
+    (clrDgSelectedChange)="onClarityDatafridSelectionChange()"
+    (clrDgSingleSelectedChange)="onClarityDatafridSelectionChange()"
 >
     <clr-dg-placeholder>{{ emptyGridPlaceholder }}</clr-dg-placeholder>
     <clr-dg-action-bar class="top-action-bar" *ngIf="shouldShowActionBarOnTop">

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019-2020 VMware, Inc.
+ * Copyright 2019-2021 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -973,6 +973,79 @@ describe('DatagridComponent', () => {
                 this.clrGridWidget.getSelectionLabelForRow(0).click();
                 this.finder.detectChanges();
                 expect(component.shouldShowActionBarOnTop).toBeTruthy();
+            });
+        });
+
+        describe('mainActionMenu', () => {
+            it('is available when there are static actions even if they are not enabled', function (this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                const component = this.hostComponent.grid;
+                this.hostComponent.actions = [
+                    {
+                        textKey: 'static.action',
+                        handler: () => null,
+                        availability: () => false,
+                        actionType: ActionType.STATIC,
+                    },
+                ];
+                this.finder.detectChanges();
+                expect(component.mainActionMenu.first).toBeTruthy();
+            });
+            it('is available when there are contextual actions to be displayed at the top', function (this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                this.hostComponent.selectionType = GridSelectionType.Single;
+                // ContextualActionPosition.TOP is the default, so there is no need to set it explicitly
+                // this.hostComponent.contextualActionPosition = ContextualActionPosition.TOP;
+                this.hostComponent.actions = [
+                    {
+                        textKey: 'contextual.action',
+                        handler: () => null,
+                        availability: () => false,
+                        actionType: ActionType.CONTEXTUAL,
+                    },
+                ];
+                this.finder.detectChanges();
+                const component = this.hostComponent.grid;
+                expect(component.mainActionMenu.first).toBeFalsy(
+                    'Action should not be available unless there is a selection'
+                );
+                // This is because contextual actions requires entities to be selected
+                this.clrGridWidget.getSelectionLabelForRow(0).click();
+                this.finder.detectChanges();
+                expect(component.mainActionMenu.first).toBeTruthy(
+                    'Action should be available when there is a selection'
+                );
+            });
+            it('is not available when there are contextual actions to be displayed in the row', function (this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                this.hostComponent.selectionType = GridSelectionType.Single;
+                this.hostComponent.contextualActionPosition = ContextualActionPosition.ROW;
+                this.hostComponent.actions = [
+                    {
+                        textKey: 'contextual.action',
+                        handler: () => null,
+                        availability: () => false,
+                        actionType: ActionType.CONTEXTUAL,
+                    },
+                ];
+                this.finder.detectChanges();
+                const component = this.hostComponent.grid;
+                expect(component.mainActionMenu.first).toBeFalsy(
+                    'Action menu should not be available unless there is a selection'
+                );
+                // This is because contextual actions requires entities to be selected
+                this.clrGridWidget.getSelectionLabelForRow(0).click();
+                this.finder.detectChanges();
+                expect(component.mainActionMenu.first).toBeFalsy(
+                    'Action menu should not be available since it is displayed in row'
+                );
+            });
+            it('is not available when there are no actions', function (this: HasFinderAndGrid): void {
+                this.finder.detectChanges();
+                const component = this.hostComponent.grid;
+                this.hostComponent.actions = [];
+                this.finder.detectChanges();
+                expect(component.mainActionMenu.first).toBeFalsy();
             });
         });
 

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019-2020 VMware, Inc.
+ * Copyright 2019-2021 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -20,8 +20,6 @@ import {
     ViewChildren,
 } from '@angular/core';
 import { ClrDatagrid, ClrDatagridPagination, ClrDatagridStateInterface } from '@clr/angular';
-import { SelectionType } from '@clr/angular/data/datagrid/enums/selection-type';
-import { columnStateFactory } from '@clr/angular/data/datagrid/providers/column-state.provider';
 import { LazyString, TranslationService } from '@vcd/i18n';
 import { Observable } from 'rxjs';
 import { ActionMenuComponent } from '../action-menu/action-menu.component';
@@ -523,6 +521,14 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
      * Emitted whenever {@link #columns} input is updated
      */
     @Output() columnsUpdated = new EventEmitter<void>();
+
+    /**
+     * A reference to {@link ActionMenuComponent} that is positioned above the grid, in the grid action tool bar
+     * This action menu may be dynamically added to / removed from the DOM based on the actions availability so the
+     * very reference should be taken from subscription to the list changes.
+     */
+    @ViewChildren('mainActionMenu')
+    public readonly mainActionMenu: QueryList<ActionMenuComponent<unknown, unknown>>;
 
     /**
      * Columns are updated using set columns, addColumn and removeColumn methods. This cache helps in preserving changes

--- a/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.html
@@ -1,0 +1,38 @@
+This example shows how you can track the action menu availability and get the action state from it.
+<p>Use the form below to configure the Actions and observe the tracking response below the grid</p>
+
+<form [formGroup]="formGroup" clrForm class="clr-form clr-form-compact">
+    <vcd-form-checkbox
+        [label]="'Static actions'"
+        [styling]="CheckBoxStyling.TOGGLESWITCH"
+        [formControlName]="'staticActions'"
+    >
+    </vcd-form-checkbox>
+    <vcd-form-checkbox
+        [label]="'Contextual actions'"
+        [styling]="CheckBoxStyling.TOGGLESWITCH"
+        [formControlName]="'contextualActions'"
+    >
+    </vcd-form-checkbox>
+    <vcd-form-checkbox
+        [label]="'Enable actions'"
+        [styling]="CheckBoxStyling.TOGGLESWITCH"
+        [formControlName]="'enableActions'"
+    >
+    </vcd-form-checkbox>
+</form>
+<br />
+<vcd-datagrid
+    [gridData]="gridData"
+    (gridRefresh)="refresh($event)"
+    [columns]="columns"
+    [actions]="actions"
+    [actionDisplayConfig]="actionDisplayConfig"
+    [contextualActionPosition]="contextualActionPosition"
+    [selectionType]="GridSelectionType.Multi"
+></vcd-datagrid>
+
+<p>
+    {{ isActionMenuAvailable ? 'Action menu is available' : 'Action menu is NOT available' }}
+    <span *ngIf="isActionMenuAvailable"> <br />There are {{ numberOfAvailableActions }} available actions.</span>
+</p>

--- a/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.scss
+++ b/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.scss
@@ -1,0 +1,9 @@
+::ng-deep {
+    .clr-form-compact .clr-subtext {
+        display: none;
+    }
+
+    clr-dg-action-bar.top-action-bar {
+        margin-top: 0;
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.ts
@@ -1,0 +1,157 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { AfterViewInit, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import {
+    ActionDisplayConfig,
+    ActionItem,
+    ActionStyling,
+    ActionType,
+    CheckBoxStyling,
+    ContextualActionPosition,
+    DatagridComponent,
+    GridColumn,
+    GridDataFetchResult,
+    GridSelectionType,
+    GridState,
+    SubscriptionTracker,
+    TextIcon,
+} from '@vcd/ui-components';
+
+interface Record {
+    value: string;
+}
+
+@Component({
+    selector: 'vcd-datagrid-action-menu-tracking-example',
+    templateUrl: 'datagrid-action-menu-tracking-example.component.html',
+    styleUrls: ['datagrid-action-menu-tracking-example.component.scss'],
+})
+export class DatagridActionMenuTrackingExampleComponent<R extends Record> implements OnDestroy, OnInit, AfterViewInit {
+    @ViewChild(DatagridComponent, { static: false }) dg: DatagridComponent<R>;
+
+    gridData: GridDataFetchResult<Record> = {
+        items: [],
+    };
+
+    columns: GridColumn<R>[] = [
+        {
+            displayName: 'Some Value',
+            renderer: 'value',
+        },
+    ];
+
+    actions: ActionItem<R, unknown>[] = [];
+
+    actionDisplayConfig: ActionDisplayConfig = {
+        contextual: {
+            featuredCount: 3,
+            styling: ActionStyling.INLINE,
+            buttonContents: TextIcon.TEXT,
+        },
+        staticActionStyling: ActionStyling.INLINE,
+    };
+
+    contextualActionPosition: ContextualActionPosition = ContextualActionPosition.TOP;
+
+    private readonly staticActions: ActionItem<R, unknown>[] = [
+        {
+            textKey: 'Add',
+            handler: () => {
+                console.log('TODO Add!');
+            },
+            availability: () => this.formGroup.controls.enableActions.value,
+            class: 'add',
+            actionType: ActionType.STATIC_FEATURED,
+            isTranslatable: false,
+        },
+    ];
+
+    private readonly contextualActions: ActionItem<R, unknown>[] = [
+        {
+            textKey: 'Delete',
+            handler: () => {
+                console.log('TODO delete!');
+            },
+            availability: () => this.formGroup.controls.enableActions.value,
+            class: 'delete',
+            actionType: ActionType.CONTEXTUAL_FEATURED,
+            isTranslatable: false,
+        },
+    ];
+
+    GridSelectionType = GridSelectionType;
+
+    CheckBoxStyling = CheckBoxStyling;
+
+    formGroup: FormGroup;
+
+    isActionMenuAvailable = false;
+
+    numberOfAvailableActions = 0;
+
+    private subscriptionTracker = new SubscriptionTracker(this);
+    private actionsTracker = new SubscriptionTracker(this);
+
+    constructor(private fb: FormBuilder, private cd: ChangeDetectorRef) {
+        this.formGroup = this.fb.group({
+            ['enableActions']: [true],
+            ['contextualActions']: [true],
+            ['staticActions']: [true],
+        });
+    }
+
+    ngOnInit(): void {
+        this.subscriptionTracker.subscribe(this.formGroup.controls.contextualActions.valueChanges, this.setActions);
+        this.subscriptionTracker.subscribe(this.formGroup.controls.staticActions.valueChanges, this.setActions);
+        this.subscriptionTracker.subscribe(this.formGroup.controls.enableActions.valueChanges, this.setActions);
+        this.setActions();
+    }
+
+    ngAfterViewInit(): void {
+        this.processActionMenuAvailability();
+        this.subscriptionTracker.subscribe(this.dg.mainActionMenu.changes, this.processActionMenuAvailability);
+    }
+
+    ngOnDestroy(): void {}
+
+    refresh(eventData: GridState<R>): void {
+        this.gridData = {
+            items: [{ value: 'Value a' }, { value: 'Value b' }],
+            totalItems: 2,
+        };
+    }
+
+    private processActionMenuAvailability = () => {
+        const actionMenu = this.dg.mainActionMenu?.first;
+        this.isActionMenuAvailable = !!actionMenu;
+        this.actionsTracker.unsubscribeAll();
+        if (actionMenu) {
+            this.updateNumberOfAvailableActions();
+            this.actionsTracker.subscribe(actionMenu.actionsUpdate, this.updateNumberOfAvailableActions);
+        }
+        this.cd.detectChanges();
+    };
+
+    private updateNumberOfAvailableActions = () => {
+        this.numberOfAvailableActions = [
+            ...this.dg.mainActionMenu.first?.staticActions,
+            ...this.dg.mainActionMenu.first?.staticFeaturedActions,
+            ...this.dg.mainActionMenu.first?.contextualActions,
+        ].length;
+        this.cd.detectChanges();
+    };
+
+    private setActions = () => {
+        this.actions = [];
+        if (this.formGroup.controls.contextualActions.value) {
+            this.actions.push(...this.contextualActions);
+        }
+        if (this.formGroup.controls.staticActions.value) {
+            this.actions.push(...this.staticActions);
+        }
+    };
+}

--- a/projects/examples/src/components/datagrid/datagrid-action-menu-tracking.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-action-menu-tracking.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { VcdActionMenuModule, VcdComponentsModule } from '@vcd/ui-components';
+import { DatagridActionMenuTrackingExampleComponent } from './datagrid-action-menu-tracking-example.component';
+
+@NgModule({
+    declarations: [DatagridActionMenuTrackingExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule, VcdActionMenuModule],
+    exports: [DatagridActionMenuTrackingExampleComponent],
+    entryComponents: [DatagridActionMenuTrackingExampleComponent],
+})
+export class DatagridActionMenuTrackerExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -1,11 +1,13 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2019-2021 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 import { NgModule } from '@angular/core';
 import { DatagridComponent } from '@vcd/ui-components';
 import { Documentation } from '@vmw/ng-live-docs';
+import { DatagridActionMenuTrackingExampleComponent } from './datagrid-action-menu-tracking-example.component';
+import { DatagridActionMenuTrackerExampleModule } from './datagrid-action-menu-tracking.example.module';
 import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';
 import { DatagridActivityReporterExampleModule } from './datagrid-activity-reporter.example.module';
 import { DatagridCliptextExampleComponent } from './datagrid-cliptext.example.component';
@@ -107,6 +109,12 @@ Documentation.registerDocumentationEntry({
             urlSegment: 'datagrid-link',
         },
         {
+            component: DatagridActionMenuTrackingExampleComponent,
+            forComponent: null,
+            title: 'Action menu availability tracking',
+            urlSegment: 'action-menu-availability-tracking',
+        },
+        {
             component: DatagridFilterExampleComponent,
             forComponent: null,
             title: 'Data grid filters',
@@ -155,6 +163,7 @@ Documentation.registerDocumentationEntry({
  */
 @NgModule({
     imports: [
+        DatagridActionMenuTrackerExampleModule,
         DatagridThreeRenderersExampleModule,
         DatagridCssClassesExampleModule,
         DatagridShowHideExampleModule,


### PR DESCRIPTION
There are cases when it is needed to have a reference to the
action menu that is positioned above the grid, in the grid action tool bar.
This action menu may be dynamically added to / removed from the DOM based
on the actions availability.

Signed-off-by: Ivo Rahov <irahov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [x] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Add `mainActionMenu` property to `DatagridComponent`

There are cases when it is needed to have a reference to the
action menu that is positioned above the grid, in the grid action tool bar.
This action menu may be dynamically added to / removed from the DOM based
on the actions availability.

## What manual testing did you do?
Create an example `datagrid/example/action-menu-availability-tracking`.
Include / exclude actions and verify that the action menu is created destroyed and the information below the table
reflects its availability

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/866923/105178679-075d1d00-5b31-11eb-8d26-c7d23e134cad.png)


## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
