### PR TITLE
Fixed //@ ts-ignore issue with the Widget Object pattern

### DIFF
--- a/cypress/integration/examples/data-exporter.spec.ts
+++ b/cypress/integration/examples/data-exporter.spec.ts
@@ -14,7 +14,7 @@ context('Window', () => {
 
     it('lets you select many column', async () => {
         // https://on.cypress.io/window
-        const widget = findCypressWidget(DataExporterWidgetObject);
+        const widget = findCypressWidget<DataExporterWidgetObject<Cypress.Chainable>>(DataExporterWidgetObject);
         widget.getToggleSelectAll().click({
             force: true,
         });

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `hideWhenEmpty` flag to `QuickSearchProvider` to control section display when there is no data
 
 ### Fixed
-- BREAKING: Fixes the `//@ ts-ignore problem with the Widget Object finder`
+- BREAKING: Fixes the `//@ ts-ignore problem with the Widget Object finder`. Now, you need to supply the type of the widget object as a type parameter to any of the `findWidget` or Widget Finder calls. This is because the type is too complicated for the method to infer.
 
 ## [1.0.0-dev.56]
 ### Changed
@@ -50,7 +50,7 @@ calculation by ActionMenuComponent
 - For vcd-form-with-unit component, Focus is set on input element when unlimited is unchecked
 - internal: Changed implementation of responsive form inputs to use a directive so that grid classes to be used
    on form input can be changed from a single place.
-- Associate label with <select> input in vcd-form-select
+- Associate label with `<select>` input in vcd-form-select
 
 ### Changed
 - Make the signpost trigger on the form-checkbox consistent with the other form components
@@ -108,7 +108,3 @@ by 300 milliseconds
 4. Add ARIA role to the ErrorBannerComponent
 5. Prevent sub-menus that are opened on hover from closing when clicked
 6. Add custom focus handling logic for dropdown menu
-
-### Added
-
-

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `actionsUpdate` emitter to `ActionMenuComponent`
 - Add `hideWhenEmpty` flag to `QuickSearchProvider` to control section display when there is no data
 
+### Fixed
+- BREAKING: Fixes the `//@ ts-ignore problem with the Widget Object finder`
+
 ## [1.0.0-dev.56]
 ### Changed
 - BREAKING: Removed the calculateActionAvailability input which was acting as a switch to toggle the action availability

--- a/projects/components/src/data-exporter/data-exporter.component.spec.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.spec.ts
@@ -3,16 +3,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-
 import { Component, ViewChild } from '@angular/core';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
+import { TestElement } from '../utils';
 import { AngularWidgetObjectFinder } from '../utils/test/widget-object/angular-widget-finder';
 import { CsvExporterService } from './csv-exporter.service';
 import { DataExporterComponent, DataExportRequestEvent, ExportColumn } from './data-exporter.component';
 import { VcdDataExporterModule } from './data-exporter.module';
 import { DataExporterWidgetObject } from './data-exporter.wo';
+
 interface HasFinder2<T> {
     finder: AngularWidgetObjectFinder<T>;
 }
@@ -34,13 +35,13 @@ describe('DataExporterColumnsWithoutDisplayName', () => {
         }).compileComponents();
     });
 
-    beforeEach(function(this: HasFinder2<TestExporterColumnsWithoutDisplayNameComponent>): void {
+    beforeEach(function (this: HasFinder2<TestExporterColumnsWithoutDisplayNameComponent>): void {
         this.finder = new AngularWidgetObjectFinder(TestExporterColumnsWithoutDisplayNameComponent);
         this.finder.detectChanges();
     });
 
-    it('uses field name if there is no displayName', function(this: TestExporterColumnsWithoutDisplayNameFinder, done): void {
-        const exporter = this.finder.find(DataExporterWidgetObject);
+    it('uses field name if there is no displayName', function (this: TestExporterColumnsWithoutDisplayNameFinder, done): void {
+        const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
         const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
         spyOn(downloadService, 'downloadCsvFile');
         spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake(async (e: DataExportRequestEvent) => {
@@ -48,8 +49,8 @@ describe('DataExporterColumnsWithoutDisplayName', () => {
             await e.exportData(TestData.exportDataWithoutDisplayName);
             this.finder.detectChanges();
             const exportData: unknown[][] = [
-                TestData.exportColumnsWithoutDisplayName.map(col => col.fieldName),
-                ...TestData.exportDataWithoutDisplayName.map(row => Object.values(row)),
+                TestData.exportColumnsWithoutDisplayName.map((col) => col.fieldName),
+                ...TestData.exportDataWithoutDisplayName.map((row) => Object.values(row)),
             ];
             const csvString = downloadService.createCsv(exportData);
             expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(csvString, fileName);
@@ -61,8 +62,8 @@ describe('DataExporterColumnsWithoutDisplayName', () => {
         exporter.getExportButton().click();
     });
 
-    it('displays field name when there is no display name', function(this: TestExporterColumnsWithoutDisplayNameFinder): void {
-        const exporter = this.finder.find(DataExporterWidgetObject);
+    it('displays field name when there is no display name', function (this: TestExporterColumnsWithoutDisplayNameFinder): void {
+        const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
         exporter.getToggleSelectAll().click();
         this.finder.detectChanges();
         const dropdownMenuItemTexts = exporter.getColumnBubbles();
@@ -95,46 +96,46 @@ describe('VcdExportTableComponent', () => {
         }).compileComponents();
     });
 
-    beforeEach(function(this: HasFinder2<TestHostComponent>): void {
+    beforeEach(function (this: HasFinder2<TestHostComponent>): void {
         this.finder = new AngularWidgetObjectFinder(TestHostComponent);
         this.finder.detectChanges();
     });
 
     describe('@Input: columns', () => {
-        it('displays them as checkboxes', function(this: TestHostFinder): void {
-            const exporter = this.finder.find(DataExporterWidgetObject);
+        it('displays them as checkboxes', function (this: TestHostFinder): void {
+            const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
             exporter.getToggleSelectAll().click();
             expect(
                 exporter
                     .getColumnBubbles()
                     .toArray()
-                    .map(it => it.text())
+                    .map((it) => it.text())
             ).toEqual(['Name', 'Description']);
         });
 
-        it('hides column checkboxes when clicked', function(this: TestHostFinder): void {
-            const exporter = this.finder.find(DataExporterWidgetObject);
+        it('hides column checkboxes when clicked', function (this: TestHostFinder): void {
+            const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
             exporter.getToggleSelectAll().click();
             expect(
                 exporter
                     .getColumnBubbles()
                     .toArray()
-                    .map(it => it.text())
+                    .map((it) => it.text())
             ).toEqual(['Name', 'Description']);
             exporter.getColumnCheckbox(0).click();
             expect(exporter.getColumnBubbles().text()).toBe('Description');
         });
 
-        it('allows the user to remove selected columns', function(this: TestHostFinder): void {
-            const exporter = this.finder.find(DataExporterWidgetObject);
+        it('allows the user to remove selected columns', function (this: TestHostFinder): void {
+            const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
             exporter.getToggleSelectAll().click();
             exporter.getColumnCheckbox(0).click();
             expect(exporter.getColumnBubbles().text()).toBe('Description');
         });
 
-        it('allows the user to deselect and reselect columns', fakeAsync(function(this: TestHostFinder): void {
+        it('allows the user to deselect and reselect columns', fakeAsync(function (this: TestHostFinder): void {
             this.finder.detectChanges();
-            const exporter = this.finder.find(DataExporterWidgetObject);
+            const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
             exporter.getToggleSelectAll().click();
             exporter.getColumnCheckbox(0).click();
             expect(exporter.getColumnBubbles().text()).toBe('Description');
@@ -143,7 +144,7 @@ describe('VcdExportTableComponent', () => {
                 exporter
                     .getColumnBubbles()
                     .toArray()
-                    .map(it => it.text())
+                    .map((it) => it.text())
             ).toEqual(['Name', 'Description']);
             exporter.getToggleSelectAll().click();
             exporter.getColumnDropdown().click();
@@ -154,8 +155,8 @@ describe('VcdExportTableComponent', () => {
     });
 
     describe('@Input: fileName', () => {
-        it('customizes the file to be downloaded', function(this: TestHostFinder, done): void {
-            const exporter = this.finder.find(DataExporterWidgetObject);
+        it('customizes the file to be downloaded', function (this: TestHostFinder, done): void {
+            const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
             this.finder.hostComponent.component.fileName = 'my-export.csv';
             const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
             const spy = spyOn(downloadService, 'downloadCsvFile');
@@ -170,8 +171,8 @@ describe('VcdExportTableComponent', () => {
 
     describe('@Output - dataExporter', () => {
         describe('updateProgress', () => {
-            it('displays a looping progress bar when set to -1', function(this: TestHostFinder): void {
-                const exporter = this.finder.find(DataExporterWidgetObject);
+            it('displays a looping progress bar when set to -1', function (this: TestHostFinder): void {
+                const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
                 const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
                 spyOn(downloadService, 'downloadCsvFile');
 
@@ -183,8 +184,8 @@ describe('VcdExportTableComponent', () => {
                 exporter.getExportButton().click();
             });
 
-            it('updates the progress bar when passed values', function(this: TestHostFinder): void {
-                const exporter = this.finder.find(DataExporterWidgetObject);
+            it('updates the progress bar when passed values', function (this: TestHostFinder): void {
+                const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
                 const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
                 spyOn(downloadService, 'downloadCsvFile');
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
@@ -200,8 +201,8 @@ describe('VcdExportTableComponent', () => {
         });
 
         describe('exportData', () => {
-            it('dismisses the dialog and calls the service to create a client side download', function(this: TestHostFinder, done): void {
-                const exporter = this.finder.find(DataExporterWidgetObject);
+            it('dismisses the dialog and calls the service to create a client side download', function (this: TestHostFinder, done): void {
+                const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
                 const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
                 spyOn(downloadService, 'downloadCsvFile');
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake(async (e: DataExportRequestEvent) => {
@@ -209,8 +210,8 @@ describe('VcdExportTableComponent', () => {
                     await e.exportData(TestData.exportData);
                     this.finder.detectChanges();
                     const exportData: unknown[][] = [
-                        TestData.exportColumns.map(col => col.displayName),
-                        ...TestData.exportData.map(row => Object.values(row)),
+                        TestData.exportColumns.map((col) => col.displayName),
+                        ...TestData.exportData.map((row) => Object.values(row)),
                     ];
                     const csvString = downloadService.createCsv(exportData);
                     expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(csvString, fileName);
@@ -222,8 +223,8 @@ describe('VcdExportTableComponent', () => {
                 exporter.getExportButton().click();
             });
 
-            it('does not download a file if the dialog has been closed', function(this: TestHostFinder, done): void {
-                const exporter = this.finder.find(DataExporterWidgetObject);
+            it('does not download a file if the dialog has been closed', function (this: TestHostFinder, done): void {
+                const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
                 const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
                 spyOn(downloadService, 'downloadCsvFile');
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake(async (e: DataExportRequestEvent) => {
@@ -238,8 +239,8 @@ describe('VcdExportTableComponent', () => {
                 exporter.getExportButton().click();
             });
 
-            it('uses field name if there is no matching displayName for a field', function(this: TestHostFinder, done): void {
-                const exporter = this.finder.find(DataExporterWidgetObject);
+            it('uses field name if there is no matching displayName for a field', function (this: TestHostFinder, done): void {
+                const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
                 const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
                 spyOn(downloadService, 'downloadCsvFile');
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake(async (e: DataExportRequestEvent) => {
@@ -255,8 +256,8 @@ describe('VcdExportTableComponent', () => {
                 exporter.getExportButton().click();
             });
 
-            it('allows the user to sanitize injection', function(this: TestHostFinder, done): void {
-                const exporter = this.finder.find(DataExporterWidgetObject);
+            it('allows the user to sanitize injection', function (this: TestHostFinder, done): void {
+                const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
                 const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
                 spyOn(downloadService, 'downloadCsvFile');
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake(async (e: DataExportRequestEvent) => {
@@ -264,8 +265,8 @@ describe('VcdExportTableComponent', () => {
                     await e.exportData(InjectionData.exportData);
                     this.finder.detectChanges();
                     const exportData: unknown[][] = [
-                        TestData.exportColumns.map(col => col.displayName),
-                        ...FixedInjection.exportData.map(row => Object.values(row)),
+                        TestData.exportColumns.map((col) => col.displayName),
+                        ...FixedInjection.exportData.map((row) => Object.values(row)),
                     ];
                     const csvString = downloadService.createCsv(exportData);
                     expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(csvString, fileName);
@@ -274,8 +275,8 @@ describe('VcdExportTableComponent', () => {
                 exporter.getExportButton().click();
             });
 
-            it('allows the user to export raw column names', function(this: TestHostFinder, done): void {
-                const exporter = this.finder.find(DataExporterWidgetObject);
+            it('allows the user to export raw column names', function (this: TestHostFinder, done): void {
+                const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
                 const downloadService = TestBed.inject(CsvExporterService) as CsvExporterService;
                 spyOn(downloadService, 'downloadCsvFile');
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake(async (e: DataExportRequestEvent) => {
@@ -283,8 +284,8 @@ describe('VcdExportTableComponent', () => {
                     await e.exportData(TestData.exportData);
                     this.finder.detectChanges();
                     const exportData: unknown[][] = [
-                        TestData.exportColumns.map(col => col.fieldName),
-                        ...TestData.exportData.map(row => Object.values(row)),
+                        TestData.exportColumns.map((col) => col.fieldName),
+                        ...TestData.exportData.map((row) => Object.values(row)),
                     ];
                     const csvString = downloadService.createCsv(exportData);
                     expect(downloadService.downloadCsvFile).toHaveBeenCalledWith(csvString, fileName);
@@ -296,8 +297,8 @@ describe('VcdExportTableComponent', () => {
         });
 
         describe('selectedColumns', () => {
-            it('contains the columns selected by the users', function(this: TestHostFinder): void {
-                const exporter = this.finder.find(DataExporterWidgetObject);
+            it('contains the columns selected by the users', function (this: TestHostFinder): void {
+                const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
                     expect(e.selectedColumns).toEqual(TestData.exportColumns);
                 });
@@ -310,19 +311,34 @@ describe('VcdExportTableComponent', () => {
 const TestData = {
     /** The progress calls that to updateProgress will be called with the following values */
     progressStates: [-1, 0.5, 1],
-    exportColumns: [{ fieldName: 'name', displayName: 'Name' }, { fieldName: 'desc', displayName: 'Description' }],
+    exportColumns: [
+        { fieldName: 'name', displayName: 'Name' },
+        { fieldName: 'desc', displayName: 'Description' },
+    ],
     exportColumnsWithoutDisplayName: [{ fieldName: 'col1' }, { fieldName: 'col2' }],
-    exportData: [{ name: 'Jaak', desc: 'Tis what tis' }, { name: 'Jill', desc: 'Still tis what tis' }],
-    exportDataWithoutDisplayName: [{ col1: 'hi', col2: 'alice' }, { col1: 'Hi', col2: 'Bob' }],
+    exportData: [
+        { name: 'Jaak', desc: 'Tis what tis' },
+        { name: 'Jill', desc: 'Still tis what tis' },
+    ],
+    exportDataWithoutDisplayName: [
+        { col1: 'hi', col2: 'alice' },
+        { col1: 'Hi', col2: 'Bob' },
+    ],
     exportDataWrongField: [{ noexist: 'Jack' }, { noexist: 'Jill' }],
 };
 
 const InjectionData = {
-    exportData: [{ name: '+a', desc: 'Tis what tis' }, { name: 'Jill', desc: 'Still tis what tis' }],
+    exportData: [
+        { name: '+a', desc: 'Tis what tis' },
+        { name: 'Jill', desc: 'Still tis what tis' },
+    ],
 };
 
 const FixedInjection = {
-    exportData: [{ name: '\t+a', desc: 'Tis what tis' }, { name: 'Jill', desc: 'Still tis what tis' }],
+    exportData: [
+        { name: '\t+a', desc: 'Tis what tis' },
+        { name: 'Jill', desc: 'Still tis what tis' },
+    ],
 };
 
 @Component({

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -56,7 +56,7 @@ interface HasFinderAndGrid {
 }
 
 describe('DatagridComponent', () => {
-    beforeEach(async function(this: HasFinderAndGrid): Promise<void> {
+    beforeEach(async function (this: HasFinderAndGrid): Promise<void> {
         await TestBed.configureTestingModule({
             imports: [VcdDatagridModule, BrowserAnimationsModule],
             providers: [
@@ -70,35 +70,34 @@ describe('DatagridComponent', () => {
         }).compileComponents();
 
         this.finder = new AngularWidgetObjectFinder(HostWithDatagridComponent);
-        // @ts-ignore
-        this.vcdDatagrid = this.finder.find(VcdDatagridWidgetObject);
+        this.vcdDatagrid = this.finder.find<VcdDatagridWidgetObject<TestElement>>(VcdDatagridWidgetObject);
         this.clrGridWidget = this.vcdDatagrid.clrDatagrid;
         this.hostComponent = this.finder.hostComponent as HostWithDatagridComponent;
     });
 
     describe('Grid', () => {
         describe('', () => {
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 (this.hostComponent as HostWithDatagridComponent).columns = [
                     { displayName: 'Name', renderer: 'name' },
                     { displayName: 'City', renderer: 'city' },
                 ];
                 this.finder.detectChanges();
             });
-            it('displays number of columns', function(this: HasFinderAndGrid): void {
+            it('displays number of columns', function (this: HasFinderAndGrid): void {
                 expect(this.clrGridWidget.getColumns().length()).toBe(this.hostComponent.columns.length);
             });
 
-            it('displays columns with headers', function(this: HasFinderAndGrid): void {
+            it('displays columns with headers', function (this: HasFinderAndGrid): void {
                 expect(
                     this.clrGridWidget
                         .getColumnHeaders()
                         .toArray()
                         .map((columnHeader: TestElement) => columnHeader.text())
-                ).toEqual(this.hostComponent.columns.map(col => col.displayName));
+                ).toEqual(this.hostComponent.columns.map((col) => col.displayName));
             });
 
-            it('displays the correct headers even when columns are reloaded', function(this: HasFinderAndGrid): void {
+            it('displays the correct headers even when columns are reloaded', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [{ displayName: 'One More', renderer: 'name' }];
                 this.finder.detectChanges();
                 expect(
@@ -106,25 +105,25 @@ describe('DatagridComponent', () => {
                         .getColumnHeaders()
                         .toArray()
                         .map((columnHeader: TestElement) => columnHeader.text())
-                ).toEqual(this.hostComponent.columns.map(col => col.displayName));
+                ).toEqual(this.hostComponent.columns.map((col) => col.displayName));
                 expect(this.clrGridWidget.getColumnHeader(0).text()).toEqual(this.hostComponent.columns[0].displayName);
             });
 
-            it('displays rows based on the grid data received', function(this: HasFinderAndGrid): void {
+            it('displays rows based on the grid data received', function (this: HasFinderAndGrid): void {
                 expect(this.clrGridWidget.getRows().length()).toBe(mockData.length);
             });
 
-            it('gives proper css class for the grid', function(this: HasFinderAndGrid): void {
+            it('gives proper css class for the grid', function (this: HasFinderAndGrid): void {
                 this.hostComponent.clrDatagridCssClass = 'some_class';
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.clrDatagrid.classes()).toContain('some_class');
             });
 
-            it('sets no default CSS classnames for the rows', function(this: HasFinderAndGrid): void {
+            it('sets no default CSS classnames for the rows', function (this: HasFinderAndGrid): void {
                 expect(this.clrGridWidget.getRow(0).classes()).toEqual(['datagrid-row', 'ng-star-inserted']);
             });
 
-            it('sets CSS classnames on rows', function(this: HasFinderAndGrid): void {
+            it('sets CSS classnames on rows', function (this: HasFinderAndGrid): void {
                 const firstCall = ['firstRowA', 'secondRowA'];
                 const secondCall = ['firstRowB', 'secondRowB'];
                 this.hostComponent.clrDatarowCssClassGetter = (rec: MockRecord, index: number) => {
@@ -154,7 +153,7 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() columns', () => {
-                beforeEach(function(this: HasFinderAndGrid): void {
+                beforeEach(function (this: HasFinderAndGrid): void {
                     this.hostComponent.gridData = {
                         items: [],
                         totalItems: 0,
@@ -162,7 +161,7 @@ describe('DatagridComponent', () => {
                     this.finder.detectChanges();
                 });
 
-                it('allows users to update the columns', fakeAsync(function(this: HasFinderAndGrid): void {
+                it('allows users to update the columns', fakeAsync(function (this: HasFinderAndGrid): void {
                     this.hostComponent.columns = [...this.hostComponent.columns];
                     this.finder.detectChanges();
                     tick();
@@ -170,13 +169,13 @@ describe('DatagridComponent', () => {
                         this.vcdDatagrid.clrDatagrid
                             .getColumnHeaders()
                             .toArray()
-                            .map(el => el.text())
+                            .map((el) => el.text())
                     ).toEqual(['Name', 'City']);
                 }));
             });
 
             describe('@Input() columns.disableCliptext', () => {
-                beforeEach(function(this: HasFinderAndGrid): void {
+                beforeEach(function (this: HasFinderAndGrid): void {
                     this.hostComponent.gridData = {
                         items: mockData,
                         totalItems: 2,
@@ -184,43 +183,34 @@ describe('DatagridComponent', () => {
                     this.finder.detectChanges();
                 });
 
-                it('clips text when disableCliptext is unset', function(this: HasFinderAndGrid): void {
+                it('clips text when disableCliptext is unset', function (this: HasFinderAndGrid): void {
                     this.hostComponent.columns = [{ displayName: 'Name', renderer: 'name' }];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget
-                        .getCell(0, 0)
-                        .getInjector()
-                        .get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeFalsy();
                 });
 
-                it('clips text when disableCliptext is false', function(this: HasFinderAndGrid): void {
+                it('clips text when disableCliptext is false', function (this: HasFinderAndGrid): void {
                     this.hostComponent.columns = [
                         { displayName: 'Name', renderer: 'name', cliptextConfig: { size: TooltipSize.md } },
                     ];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget
-                        .getCell(0, 0)
-                        .getInjector()
-                        .get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeFalsy();
                 });
 
-                it('does not clip text when disableCliptext is true', function(this: HasFinderAndGrid): void {
+                it('does not clip text when disableCliptext is true', function (this: HasFinderAndGrid): void {
                     this.hostComponent.columns = [
                         { displayName: 'Name', renderer: 'name', cliptextConfig: { disabled: true } },
                     ];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget
-                        .getCell(0, 0)
-                        .getInjector()
-                        .get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeTruthy();
                 });
             });
 
             describe('@Input() columns.clrDgColumnClassName', () => {
-                beforeEach(function(this: HasFinderAndGrid): void {
+                beforeEach(function (this: HasFinderAndGrid): void {
                     this.hostComponent.gridData = {
                         items: mockData,
                         totalItems: 2,
@@ -228,7 +218,7 @@ describe('DatagridComponent', () => {
                     this.finder.detectChanges();
                 });
 
-                it('sets the width of the column to the given height', function(this: HasFinderAndGrid): void {
+                it('sets the width of the column to the given height', function (this: HasFinderAndGrid): void {
                     this.hostComponent.columns = [
                         { displayName: 'Name', renderer: 'name', clrDgColumnClassName: 'some-class' },
                         { displayName: 'Name', renderer: 'name' },
@@ -240,19 +230,19 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() selectionType', () => {
-                it('has multi selection capabilities when set to multi selection', function(this: HasFinderAndGrid): void {
+                it('has multi selection capabilities when set to multi selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
                     expect(this.clrGridWidget.getCheckboxWrapper().length()).toBeGreaterThan(0);
                 });
 
-                it('has single selection capabilities when set to single selection', function(this: HasFinderAndGrid): void {
+                it('has single selection capabilities when set to single selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     expect(this.clrGridWidget.getRadioWrapper().length()).toBeGreaterThan(0);
                 });
 
-                it('has none selection capabilities when set to none', function(this: HasFinderAndGrid): void {
+                it('has none selection capabilities when set to none', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.None;
                     this.finder.detectChanges();
                     expect(this.clrGridWidget.getCheckboxWrapper().length()).toEqual(0);
@@ -261,7 +251,7 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() datagridSelection', () => {
-                it('emits multiple rows when set to multi selection', function(this: HasFinderAndGrid): void {
+                it('emits multiple rows when set to multi selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
                     this.clrGridWidget.getSelectionLabelForRow(0).click();
@@ -270,7 +260,7 @@ describe('DatagridComponent', () => {
                     expect(this.hostComponent.datagridSelection).toEqual(mockData);
                 });
 
-                it('emits only one row when set to single selection', function(this: HasFinderAndGrid): void {
+                it('emits only one row when set to single selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     this.clrGridWidget.getSelectionLabelForRow(0).click();
@@ -279,7 +269,7 @@ describe('DatagridComponent', () => {
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                 });
 
-                it('returns an empty array when there is no initial selection', function(this: HasFinderAndGrid): void {
+                it('returns an empty array when there is no initial selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     expect(this.hostComponent.datagridSelection).toEqual([]);
@@ -287,7 +277,7 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Output() selectionChanged', () => {
-                it('emits multiple rows when set to multi selection', function(this: HasFinderAndGrid): void {
+                it('emits multiple rows when set to multi selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
@@ -297,7 +287,7 @@ describe('DatagridComponent', () => {
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith(mockData);
                 });
 
-                it('emits only one row when set to single selection', function(this: HasFinderAndGrid): void {
+                it('emits only one row when set to single selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
@@ -307,7 +297,7 @@ describe('DatagridComponent', () => {
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([mockData[1]]);
                 });
 
-                it('emits empty array when single selection is cleared', function(this: HasFinderAndGrid): void {
+                it('emits empty array when single selection is cleared', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
@@ -318,7 +308,7 @@ describe('DatagridComponent', () => {
                     expect(this.hostComponent.selectionChanged).toHaveBeenCalledWith([]);
                 });
 
-                it('emits empty array when multiple selection is cleared', function(this: HasFinderAndGrid): void {
+                it('emits empty array when multiple selection is cleared', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
                     spyOn(this.hostComponent, 'selectionChanged');
@@ -332,7 +322,7 @@ describe('DatagridComponent', () => {
 
             describe('@Input() gridData', () => {
                 describe('when data is refreshed removed a row selected a row if the row is removed', () => {
-                    it('in single selection', fakeAsync(async function(this: HasFinderAndGrid): Promise<void> {
+                    it('in single selection', fakeAsync(async function (this: HasFinderAndGrid): Promise<void> {
                         this.hostComponent.selectionType = GridSelectionType.Single;
                         this.hostComponent.gridData = {
                             items: mockData,
@@ -353,7 +343,7 @@ describe('DatagridComponent', () => {
                         expect(component.datagridSelection).toEqual([]);
                     }));
 
-                    it('in multi selection', async function(this: HasFinderAndGrid): Promise<void> {
+                    it('in multi selection', async function (this: HasFinderAndGrid): Promise<void> {
                         this.hostComponent.selectionType = GridSelectionType.Multi;
                         this.hostComponent.gridData = {
                             items: mockData,
@@ -368,13 +358,13 @@ describe('DatagridComponent', () => {
                             totalItems: 2,
                         };
                         this.finder.detectChanges();
-                        await new Promise(resolve => setTimeout(() => resolve()));
+                        await new Promise((resolve) => setTimeout(() => resolve()));
                         this.finder.detectChanges();
                         expect(this.hostComponent.datagridSelection).toEqual([mockData[0]]);
                     });
                 });
 
-                it('keeps selected an item if the item is not removed on refresh', function(this: HasFinderAndGrid): void {
+                it('keeps selected an item if the item is not removed on refresh', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
                     this.clrGridWidget.getSelectionLabelForRow(1).click();
@@ -387,7 +377,7 @@ describe('DatagridComponent', () => {
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
                 });
 
-                it('allows you to initially select an item not on the current page', async function(this: HasFinderAndGrid): Promise<
+                it('allows you to initially select an item not on the current page', async function (this: HasFinderAndGrid): Promise<
                     void
                 > {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
@@ -406,7 +396,7 @@ describe('DatagridComponent', () => {
                         totalItems: 2,
                     };
                     this.finder.detectChanges();
-                    await new Promise(resolve => setTimeout(() => resolve()));
+                    await new Promise((resolve) => setTimeout(() => resolve()));
                     this.finder.detectChanges();
                     console.log(this.hostComponent.datagridSelection);
                     expect(this.hostComponent.datagridSelection).toEqual([mockData[1]]);
@@ -419,7 +409,7 @@ describe('DatagridComponent', () => {
                     translationService = TestBed.inject(TranslationService);
                 });
                 describe('pageSize', () => {
-                    it('can set the page size before AfterViewInit', function(this: HasFinderAndGrid): void {
+                    it('can set the page size before AfterViewInit', function (this: HasFinderAndGrid): void {
                         this.finder.detectChanges();
                         expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
@@ -428,7 +418,7 @@ describe('DatagridComponent', () => {
                         );
                     });
 
-                    it('finds the most rows that can fit in the set height with magic pagination', fakeAsync(function(
+                    it('finds the most rows that can fit in the set height with magic pagination', fakeAsync(function (
                         this: HasFinderAndGrid
                     ): void {
                         this.hostComponent.parentHeight = '2000px';
@@ -446,7 +436,7 @@ describe('DatagridComponent', () => {
                         );
                     }));
 
-                    it('shows a minimum of 15 rows', function(this: HasFinderAndGrid): void {
+                    it('shows a minimum of 15 rows', function (this: HasFinderAndGrid): void {
                         this.hostComponent.parentHeight = '200px';
                         this.finder.detectChanges();
                         this.hostComponent.pagination = {
@@ -461,7 +451,7 @@ describe('DatagridComponent', () => {
                         );
                     });
 
-                    it('allows the user to set a custom row height with magic pagination ', function(this: HasFinderAndGrid): void {
+                    it('allows the user to set a custom row height with magic pagination ', function (this: HasFinderAndGrid): void {
                         this.hostComponent.parentHeight = '2000px';
                         this.finder.detectChanges();
                         this.hostComponent.pagination = {
@@ -477,7 +467,7 @@ describe('DatagridComponent', () => {
                         );
                     });
 
-                    it('uses grid height when height is set to calculate page size ', fakeAsync(function(
+                    it('uses grid height when height is set to calculate page size ', fakeAsync(function (
                         this: HasFinderAndGrid
                     ): void {
                         this.hostComponent.parentHeight = '2000px';
@@ -495,7 +485,7 @@ describe('DatagridComponent', () => {
                         );
                     }));
 
-                    it('lets the user set rows per page', function(this: HasFinderAndGrid): void {
+                    it('lets the user set rows per page', function (this: HasFinderAndGrid): void {
                         this.hostComponent.pagination = {
                             pageSize: 100,
                             pageSizeOptions: [10],
@@ -508,7 +498,7 @@ describe('DatagridComponent', () => {
                         );
                     });
 
-                    it('creates a smaller page when action buttons are present', function(this: HasFinderAndGrid): void {
+                    it('creates a smaller page when action buttons are present', function (this: HasFinderAndGrid): void {
                         this.hostComponent.parentHeight = '2000px';
                         this.hostComponent.actions = [
                             {
@@ -532,7 +522,7 @@ describe('DatagridComponent', () => {
                         );
                     });
 
-                    it('creates a smaller page size when a header is present', function(this: HasFinderAndGrid): void {
+                    it('creates a smaller page size when a header is present', function (this: HasFinderAndGrid): void {
                         this.hostComponent.parentHeight = '1990px';
                         this.hostComponent.header = 'Some Header';
                         this.finder.detectChanges();
@@ -550,7 +540,7 @@ describe('DatagridComponent', () => {
                 });
 
                 describe('pageSizeOptions', () => {
-                    it('allows the user to input undefined', function(this: HasFinderAndGrid): void {
+                    it('allows the user to input undefined', function (this: HasFinderAndGrid): void {
                         this.hostComponent.pagination = {
                             ...this.hostComponent.pagination,
                             shouldShowPageSizeSelector: true,
@@ -562,7 +552,7 @@ describe('DatagridComponent', () => {
                 });
 
                 describe('shouldShowPageSizeSelector', () => {
-                    it('hides the dropdown when set to false', function(this: HasFinderAndGrid): void {
+                    it('hides the dropdown when set to false', function (this: HasFinderAndGrid): void {
                         this.hostComponent.pagination = {
                             ...this.hostComponent.pagination,
                             shouldShowPageSizeSelector: false,
@@ -571,7 +561,7 @@ describe('DatagridComponent', () => {
                         expect(this.clrGridWidget.getPaginationSizeSelector().length()).toEqual(0);
                     });
 
-                    it('shows the dropdown when set to true', function(this: HasFinderAndGrid): void {
+                    it('shows the dropdown when set to true', function (this: HasFinderAndGrid): void {
                         this.hostComponent.pagination = {
                             ...this.hostComponent.pagination,
                             shouldShowPageSizeSelector: true,
@@ -583,7 +573,7 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() paginationDropdownText', () => {
-                it('displays the pagination dropdown information on page one', function(this: HasFinderAndGrid): void {
+                it('displays the pagination dropdown information on page one', function (this: HasFinderAndGrid): void {
                     this.hostComponent.pagination = {
                         ...this.hostComponent.pagination,
                         shouldShowPageSizeSelector: true,
@@ -594,20 +584,20 @@ describe('DatagridComponent', () => {
             });
 
             describe('@Input() height', () => {
-                it('defaults to parent height when height is not set', function(this: HasFinderAndGrid): void {
+                it('defaults to parent height when height is not set', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = undefined;
                     this.finder.detectChanges();
                     expect(this.vcdDatagrid.vcdDatagrid.classes()).toContain('fill-parent');
                     expect(this.vcdDatagrid.vcdDatagrid.getStylePropertyValue('--datagrid-height')).toEqual('unset');
                 });
 
-                it('uses the given height when height is set', function(this: HasFinderAndGrid): void {
+                it('uses the given height when height is set', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = 200;
                     this.finder.detectChanges();
                     expect(this.vcdDatagrid.vcdDatagrid.getStylePropertyValue('--datagrid-height')).toEqual('200px');
                 });
 
-                it('allows the height to be dynamically changed', function(this: HasFinderAndGrid): void {
+                it('allows the height to be dynamically changed', function (this: HasFinderAndGrid): void {
                     this.hostComponent.height = 200;
                     this.finder.detectChanges();
                     expect(this.vcdDatagrid.vcdDatagrid.getStylePropertyValue('--datagrid-height')).toEqual('200px');
@@ -620,13 +610,13 @@ describe('DatagridComponent', () => {
         });
 
         describe('@Input() emptyGridPlaceholder', () => {
-            it('does not show the placeholder while the grid is loading', function(this: HasFinderAndGrid): void {
+            it('does not show the placeholder while the grid is loading', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
                 expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('');
             });
 
-            it('shows the placeholder if the grid is empty', function(this: HasFinderAndGrid): void {
+            it('shows the placeholder if the grid is empty', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
                 this.hostComponent.gridData = {
@@ -638,7 +628,7 @@ describe('DatagridComponent', () => {
                 expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('Placeholder');
             });
 
-            it('does not show the placeholder if the grid has data', function(this: HasFinderAndGrid): void {
+            it('does not show the placeholder if the grid has data', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
                 this.hostComponent.gridData = {
@@ -651,7 +641,7 @@ describe('DatagridComponent', () => {
             });
         });
 
-        it('displays loading indicators while data is loading', function(this: HasFinderAndGrid): void {
+        it('displays loading indicators while data is loading', function (this: HasFinderAndGrid): void {
             this.finder.detectChanges();
             expect(this.clrGridWidget.clrDatagrid.getComponentInstance().loading).toBe(
                 true,
@@ -673,13 +663,13 @@ describe('DatagridComponent', () => {
                 return element.elements[0].classes['datagrid-hidden-column'] !== true;
             }
 
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Component Renderer',
                         renderer: ColumnComponentRendererSpec({
                             type: BoldTextRendererComponent,
-                            config: record => ({
+                            config: (record) => ({
                                 text: record.name,
                             }),
                         }),
@@ -705,15 +695,15 @@ describe('DatagridComponent', () => {
                 ];
                 this.finder.detectChanges();
             });
-            it('shows the columns with hidable value of  "Never"', function(this: HasFinderAndGrid): void {
+            it('shows the columns with hidable value of  "Never"', function (this: HasFinderAndGrid): void {
                 expect(isColumnDisplayed(this.clrGridWidget.getColumn(0))).toBe(true);
             });
 
-            it('shows the columns with hidable value of  "Shown"', function(this: HasFinderAndGrid): void {
+            it('shows the columns with hidable value of  "Shown"', function (this: HasFinderAndGrid): void {
                 expect(isColumnDisplayed(this.clrGridWidget.getColumn(1))).toBe(true);
             });
 
-            it('hides the columns with hidable value of  "Hidden"', function(this: HasFinderAndGrid): void {
+            it('hides the columns with hidable value of  "Hidden"', function (this: HasFinderAndGrid): void {
                 expect(isColumnDisplayed(this.clrGridWidget.getColumn(2))).toBe(false);
                 expect(
                     this.clrGridWidget
@@ -723,13 +713,13 @@ describe('DatagridComponent', () => {
                 ).toEqual(['Default Renderer']);
             });
 
-            it('shows the columns with hidable value of undefined', function(this: HasFinderAndGrid): void {
+            it('shows the columns with hidable value of undefined', function (this: HasFinderAndGrid): void {
                 expect(isColumnDisplayed(this.clrGridWidget.getColumn(3))).toBe(true);
             });
         });
 
         describe('@Input() detailComponent', () => {
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Column',
@@ -740,17 +730,14 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
 
-            it('opens one detail pane when you click the button', function(this: HasFinderAndGrid): void {
-                this.clrGridWidget
-                    .getDetailRowButtons()
-                    .toArray()[0]
-                    .click();
+            it('opens one detail pane when you click the button', function (this: HasFinderAndGrid): void {
+                this.clrGridWidget.getDetailRowButtons().toArray()[0].click();
                 expect(this.clrGridWidget.getDetailRows().length()).toEqual(1);
             });
         });
 
         describe('@Input() isRowExpanded', () => {
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Column',
@@ -761,11 +748,11 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
 
-            it('does NOT expand row when false', function(this: HasFinderAndGrid): void {
+            it('does NOT expand row when false', function (this: HasFinderAndGrid): void {
                 expect(this.clrGridWidget.getDetailRows().length()).toEqual(0);
             });
 
-            it('expands row when true', function(this: HasFinderAndGrid): void {
+            it('expands row when true', function (this: HasFinderAndGrid): void {
                 this.hostComponent.isRowExpanded = true;
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getDetailRows().length()).toEqual(2);
@@ -773,7 +760,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('@Input() detailPane', () => {
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Column',
@@ -783,32 +770,23 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
 
-            it('opens one detail pane when you click the button', function(this: HasFinderAndGrid): void {
-                this.clrGridWidget
-                    .getDetailPaneButtons()
-                    .toArray()[0]
-                    .click();
+            it('opens one detail pane when you click the button', function (this: HasFinderAndGrid): void {
+                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getDetailPanes().length()).toEqual(1);
                 expect(this.clrGridWidget.getDetailPaneHeader().text()).toEqual('Palo Alto');
             });
 
-            it('gives the same config when called with the same arguments', function(this: HasFinderAndGrid): void {
-                this.clrGridWidget
-                    .getDetailPaneButtons()
-                    .toArray()[0]
-                    .click();
+            it('gives the same config when called with the same arguments', function (this: HasFinderAndGrid): void {
+                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
                 this.finder.detectChanges();
                 expect(this.hostComponent.grid.getDetailPaneRenderSpec(mockData[0])).toEqual(
                     this.hostComponent.grid.getDetailPaneRenderSpec(mockData[0])
                 );
             });
 
-            it('updates the detail pane when the record changes', function(this: HasFinderAndGrid): void {
-                this.clrGridWidget
-                    .getDetailPaneButtons()
-                    .toArray()[0]
-                    .click();
+            it('updates the detail pane when the record changes', function (this: HasFinderAndGrid): void {
+                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getDetailPanes().length()).toEqual(1);
                 expect(this.clrGridWidget.getDetailPaneHeader().text()).toEqual('Palo Alto');
@@ -828,7 +806,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('getRowLoadingListenerInjector()', () => {
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Column',
@@ -840,7 +818,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('@Output() refresh', () => {
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Column',
@@ -855,7 +833,7 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
 
-            it('emits the column information when the column sorted', function(this: HasFinderAndGrid): void {
+            it('emits the column information when the column sorted', function (this: HasFinderAndGrid): void {
                 const refreshMethod = spyOn(this.hostComponent, 'refresh');
                 this.clrGridWidget.getColumnHeader(0).click();
                 expect(refreshMethod).toHaveBeenCalledWith({
@@ -875,13 +853,13 @@ describe('DatagridComponent', () => {
                 });
             });
 
-            it('does not sort a column without a queryFieldName', function(this: HasFinderAndGrid): void {
+            it('does not sort a column without a queryFieldName', function (this: HasFinderAndGrid): void {
                 const refreshMethod = spyOn(this.hostComponent, 'refresh');
                 this.clrGridWidget.getColumnHeader(1).click();
                 expect(refreshMethod).toHaveBeenCalledTimes(0);
             });
 
-            it('allows the user to change pages', function(this: HasFinderAndGrid): void {
+            it('allows the user to change pages', function (this: HasFinderAndGrid): void {
                 const refreshMethod = spyOn(this.hostComponent, 'refresh');
                 this.clrGridWidget.getNextButton().click();
                 expect(refreshMethod).toHaveBeenCalledWith({
@@ -892,7 +870,7 @@ describe('DatagridComponent', () => {
                 });
             });
 
-            it('goes to page 1 when sorting is clicked', function(this: HasFinderAndGrid): void {
+            it('goes to page 1 when sorting is clicked', function (this: HasFinderAndGrid): void {
                 const refreshMethod = spyOn(this.hostComponent, 'refresh');
                 this.clrGridWidget.getNextButton().click();
                 this.clrGridWidget.getColumnHeader(0).click();
@@ -907,7 +885,7 @@ describe('DatagridComponent', () => {
             it(
                 'adds the logic of calling datagrids actionReporter.monitorGet method to action handler' +
                     ' when the handler returns a promise',
-                function(this: HasFinderAndGrid): void {
+                function (this: HasFinderAndGrid): void {
                     this.finder.detectChanges();
                     const component = this.hostComponent.grid;
                     const actionHandlerWithoutPromise: ActionHandlerType<any, any> = () => null;
@@ -934,7 +912,7 @@ describe('DatagridComponent', () => {
                 }
             );
 
-            it('does not change what trackBy is used', function(this: HasFinderAndGrid): void {
+            it('does not change what trackBy is used', function (this: HasFinderAndGrid): void {
                 this.hostComponent.gridData = {
                     items: mockData,
                     totalItems: 2,
@@ -958,7 +936,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('shouldShowActionBarOnTop', () => {
-            it('returns true when there are static actions', function(this: HasFinderAndGrid): void {
+            it('returns true when there are static actions', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 const component = this.hostComponent.grid;
                 this.hostComponent.actions = [
@@ -972,7 +950,7 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
                 expect(component.shouldShowActionBarOnTop).toBeTruthy();
             });
-            it('returns true when there are contextual actions to be displayed on top', function(this: HasFinderAndGrid): void {
+            it('returns true when there are contextual actions to be displayed on top', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 const component = this.hostComponent.grid;
                 this.hostComponent.gridData = {
@@ -999,7 +977,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('@Input() header', () => {
-            it('shows the header if set and allows it to be changed', function(this: HasFinderAndGrid): void {
+            it('shows the header if set and allows it to be changed', function (this: HasFinderAndGrid): void {
                 this.hostComponent.header = 'Some Header!';
                 this.finder.detectChanges();
                 expect(this.vcdDatagrid.getHeader().text()).toEqual('Some Header!');
@@ -1008,7 +986,7 @@ describe('DatagridComponent', () => {
                 expect(this.vcdDatagrid.getHeader().text()).toEqual('Some Other Header!');
             });
 
-            it('does not show a header when none is set', function(this: HasFinderAndGrid): void {
+            it('does not show a header when none is set', function (this: HasFinderAndGrid): void {
                 this.hostComponent.header = undefined;
                 this.finder.detectChanges();
                 expect(this.vcdDatagrid.getHeader().length()).toEqual(0);
@@ -1016,7 +994,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('GridColumn', () => {
-            it('enables only sorting when queryFieldName is given but no filter is provided', function(this: HasFinderAndGrid): void {
+            it('enables only sorting when queryFieldName is given but no filter is provided', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [{ displayName: 'Name', renderer: 'name', queryFieldName: 'name' }];
                 this.finder.detectChanges();
                 const el = this.clrGridWidget.clrDatagrid.getComponentInstance();
@@ -1024,7 +1002,7 @@ describe('DatagridComponent', () => {
                 expect(el.columns.first.customFilter).toEqual(false);
             });
             // tslint:disable-next-line:max-line-length
-            it('enables only filtering when queryFieldName, filter are provided and sortable is set to false', function(this: HasFinderAndGrid): void {
+            it('enables only filtering when queryFieldName, filter are provided and sortable is set to false', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Name',
@@ -1040,7 +1018,7 @@ describe('DatagridComponent', () => {
                 expect(el.columns.first.customFilter).toEqual(true);
             });
             // tslint:disable-next-line:max-line-length
-            it('enables both filtering and sorting when queryFieldName, filter are provided and sortable is not set to false', function(this: HasFinderAndGrid): void {
+            it('enables both filtering and sorting when queryFieldName, filter are provided and sortable is not set to false', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Name',
@@ -1057,7 +1035,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('columnsUpdated event', () => {
-            it('is fired when columns is set', function(this: HasFinderAndGrid): void {
+            it('is fired when columns is set', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 const spy = spyOn(this.hostComponent.grid.columnsUpdated, 'emit').and.callThrough();
                 this.hostComponent.columns = [
@@ -1069,7 +1047,7 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
                 expect(spy).toHaveBeenCalled();
             });
-            it('is not fired when addColumn or removeColumn is called', function(this: HasFinderAndGrid): void {
+            it('is not fired when addColumn or removeColumn is called', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 const spy = spyOn(this.hostComponent.grid.columnsUpdated, 'emit').and.callThrough();
                 this.hostComponent.grid.addColumn({
@@ -1088,7 +1066,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('addColumn', () => {
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Column',
@@ -1097,7 +1075,7 @@ describe('DatagridComponent', () => {
                 ];
                 this.finder.detectChanges();
             });
-            it('adds the passed in column to list of existing grid columns', function(this: HasFinderAndGrid): void {
+            it('adds the passed in column to list of existing grid columns', function (this: HasFinderAndGrid): void {
                 expect(this.hostComponent.grid.columns.length).toBe(1);
                 this.hostComponent.grid.addColumn({
                     displayName: 'Column2',
@@ -1109,7 +1087,7 @@ describe('DatagridComponent', () => {
             });
             it(
                 'updates a existing column if a column exists with same display name as the column passed ' + 'in',
-                function(this: HasFinderAndGrid): void {
+                function (this: HasFinderAndGrid): void {
                     expect(this.hostComponent.grid.columns[0].renderer).toBe('name');
                     this.hostComponent.grid.addColumn({
                         displayName: 'Column',
@@ -1122,7 +1100,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('removeColumn', () => {
-            beforeEach(function(this: HasFinderAndGrid): void {
+            beforeEach(function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Column',
@@ -1131,7 +1109,7 @@ describe('DatagridComponent', () => {
                 ];
                 this.finder.detectChanges();
             });
-            it('removes the column from list of existing grid columns', function(this: HasFinderAndGrid): void {
+            it('removes the column from list of existing grid columns', function (this: HasFinderAndGrid): void {
                 expect(this.hostComponent.grid.columns.length).toBe(1);
                 this.hostComponent.grid.removeColumn({
                     displayName: 'Column',
@@ -1142,7 +1120,7 @@ describe('DatagridComponent', () => {
             });
             it(
                 'does not do anything if there is no column with same display name as the column passed ' + 'in',
-                function(this: HasFinderAndGrid): void {
+                function (this: HasFinderAndGrid): void {
                     expect(this.hostComponent.grid.columns.length).toBe(1);
                     this.hostComponent.grid.removeColumn({
                         displayName: 'Non-existing-Column',
@@ -1155,7 +1133,7 @@ describe('DatagridComponent', () => {
         });
 
         describe('getPaginationTranslation', () => {
-            it('returns translated string', async function(this: HasFinderAndGrid): Promise<void> {
+            it('returns translated string', async function (this: HasFinderAndGrid): Promise<void> {
                 this.finder.detectChanges();
                 const component = this.hostComponent.grid;
                 const translatedString = await (component.getPaginationTranslation({
@@ -1177,7 +1155,7 @@ describe('DatagridComponent', () => {
 
     describe('Column Renderers', () => {
         describe('Default renderer', () => {
-            it('uses property path from  "renderer" property of column config ', function(this: HasFinderAndGrid): void {
+            it('uses property path from  "renderer" property of column config ', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [{ displayName: '', renderer: 'details.gender' }];
                 this.finder.detectChanges();
                 expect(this.clrGridWidget.getCell(0, 0).text()).toEqual(mockData[0].details.gender);
@@ -1191,11 +1169,11 @@ describe('DatagridComponent', () => {
         });
 
         describe('Function renderer', () => {
-            it('renders the string returned from the renderer function', function(this: HasFinderAndGrid): void {
+            it('renders the string returned from the renderer function', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Function Renderer',
-                        renderer: record => `${record.city}, ${record.state}`,
+                        renderer: (record) => `${record.city}, ${record.state}`,
                     },
                 ];
                 this.finder.detectChanges();
@@ -1204,25 +1182,20 @@ describe('DatagridComponent', () => {
         });
 
         describe('Component renderer', () => {
-            it('renders the passed in component using config from RendererSpec', function(this: HasFinderAndGrid): void {
+            it('renders the passed in component using config from RendererSpec', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [
                     {
                         displayName: 'Component Renderer',
                         renderer: ColumnComponentRendererSpec({
                             type: BoldTextRendererComponent,
-                            config: record => ({
+                            config: (record) => ({
                                 text: record.name,
                             }),
                         }),
                     },
                 ];
                 this.finder.detectChanges();
-                expect(
-                    this.clrGridWidget
-                        .getCell(0, 0)
-                        .queryElements('strong')
-                        .text()
-                ).toBe(mockData[0].name);
+                expect(this.clrGridWidget.getCell(0, 0).queryElements('strong').text()).toBe(mockData[0].name);
             });
         });
     });
@@ -1333,18 +1306,14 @@ export class HostWithDatagridComponent {
 }
 
 @Component({
-    template: `
-        DETAILS
-    `,
+    template: ` DETAILS `,
 })
 class DatagridDetailsComponent {
     constructor(public loadingListener: LoadingListener) {}
 }
 
 @Component({
-    template: `
-        <h2 class="config">Count{{ configSetTimes }}</h2>
-    `,
+    template: ` <h2 class="config">Count{{ configSetTimes }}</h2> `,
 })
 class DatagridDetailsPaneComponent {
     configSetTimes = 0;

--- a/projects/components/src/dropdown/dropdown-focus-handler.directive.spec.ts
+++ b/projects/components/src/dropdown/dropdown-focus-handler.directive.spec.ts
@@ -39,7 +39,7 @@ describe('DropdownFocusHandlerDirective', () => {
 
         this.finder = new AngularWidgetObjectFinder(TestHostComponent);
         this.finder.detectChanges();
-        this.dropdownWidget = this.finder.find(VcdDropdownWidgetObject);
+        this.dropdownWidget = this.finder.find<VcdDropdownWidgetObject<TestElement>>(VcdDropdownWidgetObject);
         this.dropdownComponent = this.dropdownWidget
             .getDropdown(PRIMARY_DROPDOWN_TOGGLE_CLASS_NAME)
             .getComponentInstance();

--- a/projects/components/src/dropdown/dropdown.component.spec.ts
+++ b/projects/components/src/dropdown/dropdown.component.spec.ts
@@ -198,7 +198,7 @@ describe('DropdownComponent', () => {
 
             this.finder = new AngularWidgetObjectFinder(TestHostComponent);
             this.finder.detectChanges();
-            this.dropdownWidget = this.finder.find(VcdDropdownWidgetObject);
+            this.dropdownWidget = this.finder.find<VcdDropdownWidgetObject<TestElement>>(VcdDropdownWidgetObject);
             this.dropdownComponent = this.dropdownWidget
                 .getDropdown(PRIMARY_DROPDOWN_TOGGLE_CLASS_NAME)
                 .getComponentInstance();

--- a/projects/components/src/utils/test/datagrid/filter-utils.ts
+++ b/projects/components/src/utils/test/datagrid/filter-utils.ts
@@ -5,7 +5,6 @@
 
 import { Component, Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import {
     DatagridFilter,
@@ -69,7 +68,7 @@ export function createDatagridFilterTestHelper<V, C>(
 
     // Add the filter to grid column
     const finder = new AngularWidgetObjectFinder(FilterTestHostComponent);
-    const grid = finder.find(ClrDatagridWidgetObject);
+    const grid = finder.find<ClrDatagridWidgetObject<TestElement>>(ClrDatagridWidgetObject);
 
     finder.hostComponent.setFilter(filterType, finder, config || ({} as C));
     grid.clrDatagrid.fixture.detectChanges();
@@ -88,7 +87,7 @@ export function createDatagridFilterTestHelperWithFinder<V, C>(
 
     // Add the filter to grid column
     const finder = new AngularWidgetObjectFinder(FilterTestHostComponent);
-    const grid = finder.find(ClrDatagridWidgetObject);
+    const grid = finder.find<ClrDatagridWidgetObject<TestElement>>(ClrDatagridWidgetObject);
     finder.hostComponent.setFilter(filterType, finder, config || ({} as C));
     grid.clrDatagrid.fixture.detectChanges();
     grid.filterToggle.click();

--- a/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/vcd-datagrid.wo.ts
@@ -21,8 +21,7 @@ export class VcdDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * Gives the widget object for this `clr-datagrid`.
      */
     get clrDatagrid(): ClrDatagridWidgetObject<T> {
-        // @ts-ignore
-        return this.locatorDriver.findWidget(ClrDatagridWidgetObject);
+        return this.locatorDriver.findWidget<ClrDatagridWidgetObject<T>>(ClrDatagridWidgetObject);
     }
 
     /**

--- a/projects/components/src/utils/test/widget-object/angular-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-finder.ts
@@ -8,7 +8,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AngularLocatorDriver, TestElement } from './angular-widget-object';
 import { BaseWidgetObject, FindableWidget } from './widget-object';
-import { CorrectReturnTypes } from './widget-object';
 
 /**
  * Knows how to find Angular objects in the DOM.
@@ -44,11 +43,11 @@ export class AngularWidgetObjectFinder<H = unknown> {
      *
      * @throws An error if the widget is not found or if there are multiple instances
      */
-    public find<W extends BaseWidgetObject<TestElement>, C extends FindableWidget<TestElement, W>>(
-        widgetConstructor: C,
+    public find<W extends BaseWidgetObject<TestElement>>(
+        widgetConstructor: FindableWidget<TestElement, W>,
         ancestor?: DebugElement,
         cssSelector?: string
-    ): CorrectReturnTypes<InstanceType<C>, TestElement> {
+    ): W {
         let query = widgetConstructor.tagName;
         if (cssSelector) {
             query += `${cssSelector}`;
@@ -63,7 +62,7 @@ export class AngularWidgetObjectFinder<H = unknown> {
         }
 
         const widget = new widgetConstructor(new AngularLocatorDriver(new TestElement([root], this.fixture), root));
-        return (widget as any) as CorrectReturnTypes<InstanceType<C>, TestElement>;
+        return widget;
     }
 
     /**

--- a/projects/components/src/utils/test/widget-object/angular-widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-object.spec.ts
@@ -70,7 +70,7 @@ class ClickTrackerWidgetObject<T> extends BaseWidgetObject<T> {
     }
 
     findHeaderWidget(): HeaderWidgetObject<T> {
-        return this.locatorDriver.findWidget(HeaderWidgetObject);
+        return this.locatorDriver.findWidget<HeaderWidgetObject<T>>(HeaderWidgetObject);
     }
 
     getSelf(): T {
@@ -99,7 +99,7 @@ interface HasClickTracker {
 }
 
 function setup(fixtureRoot: Type<unknown>): void {
-    beforeEach(async function(this: HasAngularFinder): Promise<void> {
+    beforeEach(async function (this: HasAngularFinder): Promise<void> {
         await TestBed.configureTestingModule({
             imports: [FormsModule],
             declarations: [ClickTrackerComponent, fixtureRoot],
@@ -114,8 +114,8 @@ describe('AngularWidgetFinder', () => {
         setup(HostComponent);
 
         describe('find', () => {
-            it('returns the first one within the fixture if no classname is specified', function(this: HasAngularFinder): void {
-                const widget = this.finder.find(ClickTrackerWidgetObject);
+            it('returns the first one within the fixture if no classname is specified', function (this: HasAngularFinder): void {
+                const widget = this.finder.find<ClickTrackerWidgetObject<TestElement>>(ClickTrackerWidgetObject);
                 expect(widget.getHeaderText().text()).toEqual('hello');
             });
         });
@@ -123,7 +123,7 @@ describe('AngularWidgetFinder', () => {
 });
 
 describe('AngularLocatorDriver', () => {
-    beforeEach(async function(this: HasClickTracker): Promise<void> {
+    beforeEach(async function (this: HasClickTracker): Promise<void> {
         await TestBed.configureTestingModule({
             imports: [FormsModule],
             declarations: [ClickTrackerComponent],
@@ -140,26 +140,26 @@ describe('AngularLocatorDriver', () => {
     });
 
     describe('get', () => {
-        it('can find elements by CSS selector', function(this: HasClickTracker): void {
+        it('can find elements by CSS selector', function (this: HasClickTracker): void {
             expect(this.clickTracker.getClickCount().text()).toEqual('0');
         });
     });
 
     describe('findWidget', () => {
-        it('can find widgets within widgets', function(this: HasClickTracker): void {
+        it('can find widgets within widgets', function (this: HasClickTracker): void {
             expect(this.clickTracker.findHeaderWidget().getBoldText().text()).toEqual('hello');
         });
     });
 
     describe('parents', () => {
-        it('can find a parent by css selector', function(this: HasClickTracker): void {
+        it('can find a parent by css selector', function (this: HasClickTracker): void {
             this.clickTracker.getTrackerElementUsingParent().click();
             expect(this.clickTracker.getClickCount().text()).toEqual('1');
         });
     });
 
     describe('getByText', () => {
-        it('can find an element by text', function(this: HasClickTracker): void {
+        it('can find an element by text', function (this: HasClickTracker): void {
             expect(this.clickTracker.getButton().text()).toEqual('BUTTON');
         });
     });
@@ -170,7 +170,7 @@ describe('AngularLocatorDriver', () => {
  * in the concrete {@link ClickTrackerWidgetObject}
  */
 describe('TestElement', () => {
-    beforeEach(async function(this: HasClickTracker): Promise<void> {
+    beforeEach(async function (this: HasClickTracker): Promise<void> {
         await TestBed.configureTestingModule({
             imports: [FormsModule],
             declarations: [ClickTrackerComponent],
@@ -187,20 +187,20 @@ describe('TestElement', () => {
     });
 
     describe('text', () => {
-        it('can find elements within itself passing a css query', function(this: HasClickTracker): void {
+        it('can find elements within itself passing a css query', function (this: HasClickTracker): void {
             expect(this.clickTracker.getClickCount().text()).toEqual('0');
         });
     });
 
     describe('click', () => {
-        it('calls detectChanges after clicking', function(this: HasClickTracker): void {
+        it('calls detectChanges after clicking', function (this: HasClickTracker): void {
             this.clickTracker.getTrackerElement().click();
             expect(this.clickTracker.getClickCount().text()).toEqual('1');
         });
     });
 
     describe('value', () => {
-        it('gives the value from an input', fakeAsync(function(this: HasClickTracker): void {
+        it('gives the value from an input', fakeAsync(function (this: HasClickTracker): void {
             this.clickTracker.getSelf().getComponentInstance().name = 'Ryan';
             this.clickTracker.getSelf().detectChanges();
             tick();
@@ -209,7 +209,7 @@ describe('TestElement', () => {
     });
 
     describe('clear', () => {
-        it('clears the input', fakeAsync(function(this: HasClickTracker): void {
+        it('clears the input', fakeAsync(function (this: HasClickTracker): void {
             this.clickTracker.getSelf().getComponentInstance().name = 'Ryan';
             this.clickTracker.getSelf().detectChanges();
             tick();
@@ -220,13 +220,13 @@ describe('TestElement', () => {
     });
 
     describe('length', () => {
-        it('says how many elements are in this TestElement', function(this: HasClickTracker): void {
+        it('says how many elements are in this TestElement', function (this: HasClickTracker): void {
             expect(this.clickTracker.getButtons().length()).toEqual(2);
         });
     });
 
     describe('toArray', () => {
-        it('turns the TestElement to an array of TestElements', function(this: HasClickTracker): void {
+        it('turns the TestElement to an array of TestElements', function (this: HasClickTracker): void {
             expect(
                 this.clickTracker
                     .getButtons()
@@ -237,7 +237,7 @@ describe('TestElement', () => {
     });
 
     describe('classes', () => {
-        it('gives the classes of an input', function(this: HasClickTracker): void {
+        it('gives the classes of an input', function (this: HasClickTracker): void {
             expect(this.clickTracker.getNameInput().classes()).toContain('name');
         });
     });

--- a/projects/components/src/utils/test/widget-object/angular-widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/angular-widget-object.ts
@@ -7,8 +7,7 @@ import { DebugElement, Injector, Type } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AngularWidgetObjectFinder } from './angular-widget-finder';
-import { BaseWidgetObject, FindableWidget } from './widget-object';
-import { CorrectReturnTypes, LocatorDriver } from './widget-object';
+import { BaseWidgetObject, FindableWidget, LocatorDriver } from './widget-object';
 
 /**
  * Knows how to find Angular TestElements in the DOM.
@@ -74,10 +73,10 @@ export class AngularLocatorDriver implements LocatorDriver<TestElement> {
     /**
      * @inheritdoc
      */
-    findWidget<W extends BaseWidgetObject<TestElement>, C extends FindableWidget<TestElement, W>>(
-        widget: C,
+    findWidget<W extends BaseWidgetObject<TestElement>>(
+        widget: FindableWidget<TestElement, W>,
         cssSelector?: string
-    ): CorrectReturnTypes<InstanceType<C>, TestElement> {
+    ): W {
         return new AngularWidgetObjectFinder(this.testElement.fixture).find(widget, this.rootElement, cssSelector);
     }
 }

--- a/projects/components/src/utils/test/widget-object/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress-widget-finder.ts
@@ -5,7 +5,7 @@
 
 import { IdGenerator } from '../../id-generator/id-generator';
 import { CypressLocatorDriver } from './cypress-widget-object';
-import { BaseWidgetObject, CorrectReturnTypes, FindableWidget } from './widget-object';
+import { BaseWidgetObject, FindableWidget } from './widget-object';
 
 declare const cy;
 const idGenerator = new IdGenerator('cy-id');
@@ -29,11 +29,11 @@ export class CypressWidgetObjectFinder<T> {
      * @param cssSelector - The cssSelector to append to the tagName for the search
      *
      */
-    public find<W extends BaseWidgetObject<T>, C extends FindableWidget<T, W>>(
-        widgetConstructor: C,
+    public find<W extends BaseWidgetObject<T>>(
+        widgetConstructor: FindableWidget<T, W>,
         ancestor?: string,
         cssSelector?: string
-    ): CorrectReturnTypes<InstanceType<C>, T> {
+    ): W {
         let tagName = widgetConstructor.tagName;
         if (cssSelector) {
             tagName += `${cssSelector}`;
@@ -42,6 +42,6 @@ export class CypressWidgetObjectFinder<T> {
         const search = ancestor ? cy.get(ancestor).find(tagName) : cy.get(tagName);
         const root = search.as(id);
         const widget = new widgetConstructor(new CypressLocatorDriver(root, true, id));
-        return (widget as any) as CorrectReturnTypes<InstanceType<C>, T>;
+        return widget;
     }
 }

--- a/projects/components/src/utils/test/widget-object/cypress-widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/cypress-widget-object.ts
@@ -4,7 +4,7 @@
  */
 
 import { CypressWidgetObjectFinder } from './cypress-widget-finder';
-import { BaseWidgetObject, CorrectReturnTypes, FindableWidget, LocatorDriver } from './widget-object';
+import { BaseWidgetObject, FindableWidget, LocatorDriver } from './widget-object';
 
 declare const cy;
 
@@ -55,14 +55,8 @@ export class CypressLocatorDriver<T> implements LocatorDriver<T> {
     /**
      * @inheritdoc
      */
-    findWidget<W extends BaseWidgetObject<T>, C extends FindableWidget<T, W>>(
-        widget: C,
-        cssSelector?: string
-    ): CorrectReturnTypes<InstanceType<C>, T> {
-        return new CypressWidgetObjectFinder<T>().find(widget, '@' + this.alias, cssSelector) as CorrectReturnTypes<
-            InstanceType<C>,
-            T
-        >;
+    findWidget<W extends BaseWidgetObject<T>>(widget: FindableWidget<T, W>, cssSelector?: string): W {
+        return new CypressWidgetObjectFinder<T>().find(widget, '@' + this.alias, cssSelector);
     }
 
     /**

--- a/projects/components/src/utils/test/widget-object/find-cypress-widget.ts
+++ b/projects/components/src/utils/test/widget-object/find-cypress-widget.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { BaseWidgetObject, CorrectReturnTypes, CypressWidgetObjectFinder, FindableWidget } from '@vcd/ui-components';
+import { BaseWidgetObject, CypressWidgetObjectFinder, FindableWidget } from '@vcd/ui-components';
 // import Cypress from 'cypress';
 
 /**
@@ -16,13 +16,10 @@ import { BaseWidgetObject, CorrectReturnTypes, CypressWidgetObjectFinder, Findab
  * @param cssSelector - The cssSelector to append to the tagName for the search
  *
  */
-export function findCypressWidget<
-    W extends BaseWidgetObject<Cypress.Chainable>,
-    C extends FindableWidget<Cypress.Chainable, W>
->(
-    widgetConstructor: C,
+export function findCypressWidget<W extends BaseWidgetObject<Cypress.Chainable>>(
+    widgetConstructor: FindableWidget<Cypress.Chainable, W>,
     ancestor?: string,
     cssSelector?: string
-): CorrectReturnTypes<InstanceType<C>, Cypress.Chainable> {
+): W {
     return new CypressWidgetObjectFinder<Cypress.Chainable>().find(widgetConstructor, ancestor, cssSelector);
 }

--- a/projects/components/src/utils/test/widget-object/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/widget-object.ts
@@ -35,21 +35,21 @@ export class BaseWidgetObject<T> {
     /**
      * Returns an element locator that will find a child with the given cssSelector when called.
      */
-    protected locatorForCssSelectors ? = (cssSelector: string): ElementLocator<T> => {
+    protected locatorForCssSelectors? = (cssSelector: string): ElementLocator<T> => {
         return (options?: unknown) => this.locatorDriver.get(cssSelector, options).unwrap();
     };
 
     /**
      * Returns an element locator that will find a parent with the given cssSelector when called.
      */
-    protected locatorForAncestors ? = (cssSelector: string): ElementLocator<T> => {
+    protected locatorForAncestors? = (cssSelector: string): ElementLocator<T> => {
         return (options?: unknown) => this.locatorDriver.parents(cssSelector, options).unwrap();
     };
 
     /**
      * Returns an element locator that will find a child with the given cssSelector and text when called.
      */
-    protected locatorForText ? = (cssSelector: string, text: string): ElementLocator<T> => {
+    protected locatorForText? = (cssSelector: string, text: string): ElementLocator<T> => {
         return (options?: unknown) => this.locatorDriver.getByText(cssSelector, text, options).unwrap();
     };
 }
@@ -76,10 +76,7 @@ export interface LocatorDriver<T> {
     /**
      * Returns an instance of the given widget within this widget object.
      */
-    findWidget<W extends BaseWidgetObject<T>, C extends FindableWidget<T, W>>(
-        widget: C,
-        cssSelector?: string
-    ): CorrectReturnTypes<InstanceType<C>, T>;
+    findWidget<W extends BaseWidgetObject<T>>(widget: FindableWidget<T, W>, cssSelector?: string): W;
 
     /**
      * Unwraps the value from this query and turns it into the resulting object type.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

The Widget object finder was trying to imply the type of the widget object it was locating. This meant it had to both imply the widget type but also the type of the underlying driver. This was very difficult to do in Typescript and we had to put in a hacky solution.

This change removes this hacky solution and instead has the client of our widget supply the type of the widget that is being located. See review for examples.

## Testing

- Verified all unit tests pass without ts-ignore.
- Verified all E2E tests pass without ts-ignore.

## Does this PR introduce a breaking change?

-   [X] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Any user of either of the Widget Finders or the `LocatorDriver.findWidget` method will need to add a type annotation before that contains the type of the widget that is being located.