### PR TITLE
Vapp add action bug fix

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-dev.1]
+### Fixed
+- Vapp Add action bug which exposed the bug with quick search showing grouped actions with empty children in the search result
+
 ## [1.0.0-dev.58]
 - Upgrades to Angular 10 and Clarity 4.
 

--- a/projects/components/src/action-menu/action-menu.component.spec.ts
+++ b/projects/components/src/action-menu/action-menu.component.spec.ts
@@ -204,6 +204,24 @@ describe('ActionMenuComponent', () => {
             ]);
             expect(availableActions[0].children.length).toEqual(2);
         });
+        it('filters out the grouped actions with empty children array', function (this: HasFinderAndActionMenu): void {
+            const availableActions = this.actionMenu.getAvailableActions([
+                {
+                    textKey: 'Grouped action with empty children',
+                    children: [],
+                },
+                {
+                    textKey: 'Grouped action with children',
+                    children: [
+                        {
+                            textKey: 'child action',
+                            handler: () => {},
+                        },
+                    ],
+                },
+            ]);
+            expect(availableActions.length).toEqual(1);
+        });
     });
     describe('getContextualActions', () => {
         beforeEach(function (this: HasFinderAndActionMenu): void {

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -212,18 +212,14 @@ export class ActionMenuComponent<R, T> {
      */
     getAvailableActions(actions: ActionItem<R, T>[]): ActionItem<R, T>[] {
         return actions
-            .filter((action) => this.isActionAvailable(action))
+            .filter((action) => this.isActionAvailable(action) && (!action.children || action.children.length !== 0))
             .map((action) => {
                 const actionCopy = { ...action, children: action.children ? [...action.children] : null };
                 if (actionCopy.children) {
-                    if (actionCopy.children.length === 0) {
-                        return null;
-                    }
                     actionCopy.children = this.getAvailableActions(actionCopy.children);
                 }
                 return actionCopy;
-            })
-            .filter((action) => !!action);
+            });
     }
 
     /**

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -215,11 +215,15 @@ export class ActionMenuComponent<R, T> {
             .filter((action) => this.isActionAvailable(action))
             .map((action) => {
                 const actionCopy = { ...action, children: action.children ? [...action.children] : null };
-                if (actionCopy.children?.length) {
+                if (actionCopy.children) {
+                    if (actionCopy.children.length === 0) {
+                        return null;
+                    }
                     actionCopy.children = this.getAvailableActions(actionCopy.children);
                 }
                 return actionCopy;
-            });
+            })
+            .filter((action) => !!action);
     }
 
     /**

--- a/projects/components/src/action-search-provider/action-search.provider.spec.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.spec.ts
@@ -41,11 +41,11 @@ const getMockActionsList = (): ActionItem<MockRecord, any>[] => [
 ];
 
 describe('ActionSearchProvider', () => {
-    beforeEach(function(this: HasActionSearchProvider): void {
+    beforeEach(function (this: HasActionSearchProvider): void {
         this.actionSearchProvider = new ActionSearchProvider(new MockTranslationService());
     });
     describe('actions', () => {
-        it('when set, the search method will give the action that matches with the search' + ' text', async function(
+        it('when set, the search method will give the action that matches with the search' + ' text', async function (
             this: HasActionSearchProvider
         ): Promise<void> {
             const searchResults = await this.actionSearchProvider.search('sta');
@@ -62,7 +62,7 @@ describe('ActionSearchProvider', () => {
         it(
             'when set with an entity that will yield ActionItem.availability as false, the search method does not return the ActionItem' +
                 ' as it is unavailable',
-            async function(this: HasActionSearchProvider): Promise<void> {
+            async function (this: HasActionSearchProvider): Promise<void> {
                 this.actionSearchProvider.actions = getMockActionsList();
 
                 let searchResults = await this.actionSearchProvider.search('sto');
@@ -83,7 +83,7 @@ describe('ActionSearchProvider', () => {
         it(
             'when pause is not called by default, search returns a promise which is resolved without having to' +
                 'call unpause',
-            async function(this: HasActionSearchProvider): Promise<void> {
+            async function (this: HasActionSearchProvider): Promise<void> {
                 this.actionSearchProvider.actions = getMockActionsList();
                 let searchResultsBeforePausing;
                 searchResultsBeforePausing = await this.actionSearchProvider.search('sta');
@@ -92,7 +92,7 @@ describe('ActionSearchProvider', () => {
         );
         it(
             'when pause method is called, search returns a promise which is not resolved until unpause' + 'is called',
-            async function(this: HasActionSearchProvider): Promise<void> {
+            async function (this: HasActionSearchProvider): Promise<void> {
                 this.actionSearchProvider.actions = getMockActionsList();
                 const unpauseAfter1second = (): void => {
                     setTimeout(() => {
@@ -118,5 +118,35 @@ describe('ActionSearchProvider', () => {
                 const searchResultsAfterPausing = await this.actionSearchProvider.search('sta');
             }
         );
+    });
+
+    describe('search', () => {
+        it('will not return actions with empty children as part of the search' + 'result', async function (
+            this: HasActionSearchProvider
+        ): Promise<void> {
+            const actions: ActionItem<any, any>[] = [
+                {
+                    textKey: 'No children group',
+                    children: [],
+                    isTranslatable: false,
+                },
+                {
+                    textKey: 'Group with children',
+                    children: [
+                        {
+                            textKey: 'some action',
+                            handler: () => null,
+                            isTranslatable: false,
+                        },
+                    ],
+                    isTranslatable: false,
+                },
+            ];
+            this.actionSearchProvider.actions = actions;
+            const searchResults2 = await this.actionSearchProvider.search('no children');
+            expect(searchResults2.items.length).toEqual(0);
+            const searchResults1 = await this.actionSearchProvider.search('some action');
+            expect(searchResults1.items.length).toEqual(1);
+        });
     });
 });

--- a/projects/components/src/action-search-provider/action-search.provider.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.ts
@@ -99,7 +99,10 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
 
     private getFlatListOfAvailableActions(actions: ActionItem<R, T>[]): ActionItem<R, T>[] {
         return actions.reduce((flatActionList, currentAction) => {
-            if (currentAction?.children?.length) {
+            if (currentAction?.children) {
+                if (currentAction.children.length === 0) {
+                    return flatActionList;
+                }
                 flatActionList = flatActionList.concat(this.getFlatListOfAvailableActions(currentAction.children));
             } else if (this.isActionAvailable(currentAction)) {
                 const textKey =

--- a/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.html
+++ b/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.html
@@ -1,7 +1,8 @@
 <div>
     <p>
-        Press 'command+.' on Mac OS or 'ctrl+.' on PC to open quick search and search through all the actions displayed
-        below
+        Press 'command+.' on Mac OS or 'ctrl+.' on PC to open quick search and search through all the available actions.
+        If there is an action with no children, it is not displayed in the search results. Try searching for `No
+        children action` being passed in the list of actions and notice that it is not going to be a search result.
     </p>
     <vcd-action-menu
         [actions]="actions"

--- a/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
@@ -104,7 +104,7 @@ export class ActionMenuSearchExampleComponent<R extends Record, T extends Handle
 
     actionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 1,
+            featuredCount: 2,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },

--- a/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
@@ -95,6 +95,11 @@ export class ActionMenuSearchExampleComponent<R extends Record, T extends Handle
                 },
             ],
         },
+        {
+            textKey: 'No children action',
+            actionType: ActionType.CONTEXTUAL,
+            children: [],
+        },
     ];
 
     actionDisplayConfig: ActionDisplayConfig = {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes/features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Fix the following bug...
Showing grouped actions with no children in the quick search as a search result. Eg., If a vapp action called
'Add' has no actions as its children, it is still being shown in the search results of quick search resulting in an error
when it is selected as it is not an executable action

## What manual testing did you do?
Tested it on the vcd using local dev server by connecting to Cassini. Please refer to the GIF below, the first half is with this fix(Add action doesn't show up in quick search results), and the next half is without the fix(Add action shows up in the quick search results)

## Screenshots (if applicable)
![vapp-add-action-bug](https://user-images.githubusercontent.com/10735165/106677714-3dfe5300-6587-11eb-81cb-00747c9e31c6.gif)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
