### PR TITLE
Add new feature for disabling options in vcd-form-select

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added functionality to disable an option in `FormSelectComponent`
 
 ## [2.0.0-dev.3]
 ### Changed

--- a/projects/components/src/common/interfaces/select-option.ts
+++ b/projects/components/src/common/interfaces/select-option.ts
@@ -19,4 +19,8 @@ export interface SelectOption {
      * Used for translation of the {@link SelectOption.display} text
      */
     isTranslatable?: boolean;
+    /**
+     * Wheather the option is disabled
+     */
+    disabled?: boolean;
 }

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -14,7 +14,7 @@
                     [attr.aria-describedby]="showErrors ? errorsId : ''"
                     [formControl]="formControl"
                 >
-                    <option *ngFor="let option of options" [value]="option.value">
+                    <option *ngFor="let option of options" [value]="option.value" [disabled]="option.disabled">
                         {{ option.isTranslatable ? (option.display | translate) : option.display }}
                     </option>
                 </select>

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -61,7 +61,7 @@ describe('FormSelectComponent', () => {
             expect(hostComponent.selectInputComponent.selectedOption).toEqual(getOptionWithValueAsNumber());
         });
         it('is of number type, when it is selected', () => {
-            selectInput.select(hostComponent.options.length - 1);
+            selectInput.select(hostComponent.options.length - 2);
             expect(hostComponent.selectInputComponent.selectedOption).toEqual(getOptionWithValueAsNumber());
         });
         it('is undefined if the component does not have a value set', () => {
@@ -73,6 +73,10 @@ describe('FormSelectComponent', () => {
         it('allows falsy  values', () => {
             selectInput.component.formControl.setValue('');
             expect(selectInput.component.selectedOption.value).toBe('');
+        });
+        it('is disabled if the option property `disabled` is set to true', () => {
+            selectInput.component.formControl.setValue('five');
+            expect(selectInput.component.selectedOption.disabled).toBe(true);
         });
     });
 
@@ -136,6 +140,9 @@ class TestHostComponent {
         {
             ...getOptionWithValueAsNumber(),
         },
+        {
+            ...getDisabledOption(),
+        },
     ];
 
     constructor(private fb: FormBuilder) {
@@ -147,4 +154,12 @@ class TestHostComponent {
 
 function getOptionWithValueAsNumber(): SelectOption {
     return { display: 'option4', value: 4 };
+}
+
+function getDisabledOption(): SelectOption {
+    return {
+        display: 'option5',
+        value: 'five',
+        disabled: true,
+    };
 }

--- a/projects/examples/src/components/form-input/form-input-components.examples.module.ts
+++ b/projects/examples/src/components/form-input/form-input-components.examples.module.ts
@@ -15,6 +15,7 @@ import { FormCheckboxExampleComponent } from './form-checkbox.example.component'
 import { FormCheckboxExampleModule } from './form-checkbox.example.module';
 import { FormInputExampleComponent } from './form-input.example.component';
 import { FormInputExampleModule } from './form-input.example.module';
+import { FormSelectDisabledExampleComponent } from './form-select-disabled.example.component';
 import { FormSelectExampleComponent } from './form-select.example.component';
 import { FormSelectExampleModule } from './form-select.example.module';
 import { NumberWithUnitFormInputUnitlessExampleComponent } from './number-with-unit-form-input-unitless.example.component';
@@ -46,6 +47,12 @@ Documentation.registerDocumentationEntry({
             forComponent: null,
             title: 'Select form input',
             urlSegment: 'form-select',
+        },
+        {
+            component: FormSelectDisabledExampleComponent,
+            forComponent: null,
+            title: 'Select form input with disabled options',
+            urlSegment: 'form-select-disabled',
         },
     ],
 });

--- a/projects/examples/src/components/form-input/form-select-disabled.example.component.html
+++ b/projects/examples/src/components/form-input/form-select-disabled.example.component.html
@@ -1,0 +1,9 @@
+<form [formGroup]="formGroup" class="clr-form-horizontal">
+    <vcd-form-select
+        [showAsterisk]="true"
+        [label]="'Select Input with disabled option'"
+        [options]="options"
+        [formControlName]="'selectInput'"
+    >
+    </vcd-form-select>
+</form>

--- a/projects/examples/src/components/form-input/form-select-disabled.example.component.ts
+++ b/projects/examples/src/components/form-input/form-select-disabled.example.component.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormSelectComponent, SelectOption } from '@vcd/ui-components';
+
+/**
+ * Options within the select element can be disabled by passing in disabled property. See {@link SelectOption#disabled}
+ */
+@Component({
+    selector: 'vcd-form-select-disabled-example',
+    templateUrl: './form-select-disabled.example.component.html',
+})
+export class FormSelectDisabledExampleComponent implements OnInit {
+    formGroup: FormGroup;
+
+    @ViewChild('selectInputComponent', { static: true }) selectInputComponent: FormSelectComponent;
+
+    options: SelectOption[] = [
+        {
+            display: '-',
+            value: '',
+            disabled: true,
+        },
+        {
+            display: 'option1',
+            value: 'one',
+        },
+        {
+            display: 'option2',
+            value: 'two',
+            disabled: true,
+        },
+        {
+            display: 'option3',
+            value: 'three',
+        },
+    ];
+
+    constructor(private fb: FormBuilder) {
+        this.formGroup = this.fb.group({
+            selectInput: ['one', [Validators.required]],
+        });
+    }
+
+    ngOnInit() {}
+}

--- a/projects/examples/src/components/form-input/form-select.example.module.ts
+++ b/projects/examples/src/components/form-input/form-select.example.module.ts
@@ -6,10 +6,11 @@
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { VcdFormModule } from '@vcd/ui-components';
+import { FormSelectDisabledExampleComponent } from './form-select-disabled.example.component';
 import { FormSelectExampleComponent } from './form-select.example.component';
 
 @NgModule({
-    declarations: [FormSelectExampleComponent],
+    declarations: [FormSelectExampleComponent, FormSelectDisabledExampleComponent],
     imports: [VcdFormModule, ReactiveFormsModule],
     exports: [FormSelectExampleComponent],
     entryComponents: [FormSelectExampleComponent],


### PR DESCRIPTION

Signed-off-by: Yoana Boyanova <yboyanova@vmware.com

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
HTML's option object has a feature where an option is not selectable
by the user when you set the disabled attribute. vcd-form-select takes
SelectOption objects that don't have a disabled property

Changes made:
- Added new property 'disabled' in the SelectOption type
- Change template to handle disabled select options
- Add unit tests
- Add demo
## What manual testing did you do?
Checked if the correct option is disabled
## Screenshots (if applicable)
<img width="1666" alt="Screen Shot 2021-03-25 at 5 42 40 PM" src="https://user-images.githubusercontent.com/61990435/112506496-7f94c880-8d96-11eb-8170-a3f851befb94.png">

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This is related to https://github.com/vmware/vmware-cloud-director-ui-components/issues/302