### PR TITLE
Update the action availability to accept observables

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-dev.7]
+### Changed
+- The availability property of action items now accepts observables so that their visibility can be updated from
+asynchronous responses  
+
 ## [2.0.0-dev.6]
 ### Changed
 - Quick search now performs much better with many providers.

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.6",
+    "version": "2.0.0-dev.7",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.html
+++ b/projects/components/src/action-menu/action-menu.component.html
@@ -1,13 +1,23 @@
 <div class="inline-actions-container" *ngIf="shouldDisplayActionsInline">
     <ng-container *ngIf="shouldDisplayStaticFeaturedActionsInline">
         <ng-container *ngFor="let action of staticFeaturedActions; trackBy: actionsTrackBy">
-            <ng-template *ngTemplateOutlet="actionButton; context: { $implicit: action }"></ng-template>
+            <ng-template
+                *ngTemplateOutlet="
+                    isObservable(action.availability) ? obsTmpl : actionButtonTmpl;
+                    context: { $implicit: action }
+                "
+            ></ng-template>
         </ng-container>
     </ng-container>
 
     <ng-container *ngIf="shouldDisplayContextualActionsInline">
         <ng-container *ngFor="let action of contextualFeaturedActions; trackBy: actionsTrackBy">
-            <ng-template *ngTemplateOutlet="actionButton; context: { $implicit: action }"></ng-template>
+            <ng-template
+                *ngTemplateOutlet="
+                    isObservable(action.availability) ? obsTmpl : actionButtonTmpl;
+                    context: { $implicit: action }
+                "
+            ></ng-template>
         </ng-container>
 
         <vcd-dropdown
@@ -28,7 +38,12 @@
     <ng-container *ngIf="shouldDisplayStaticActionsInline">
         <div class="static-actions-separator"></div>
         <ng-container *ngFor="let action of staticActions; trackBy: actionsTrackBy">
-            <ng-template *ngTemplateOutlet="actionButton; context: { $implicit: action }"></ng-template>
+            <ng-template
+                *ngTemplateOutlet="
+                    isObservable(action.availability) ? obsTmpl : actionButtonTmpl;
+                    context: { $implicit: action }
+                "
+            ></ng-template>
         </ng-container>
     </ng-container>
 </div>
@@ -61,7 +76,15 @@
     [isDropdownDisabled]="disabled"
 ></vcd-dropdown>
 
-<ng-template #actionButton let-action>
+<ng-template #obsTmpl let-action>
+    <ng-template
+        *ngIf="action.availability | async"
+        [ngTemplateOutlet]="actionButtonTmpl"
+        [ngTemplateOutletContext]="{ $implicit: action }"
+    ></ng-template>
+</ng-template>
+
+<ng-template #actionButtonTmpl let-action>
     <button
         class="btn btn-link"
         [ngClass]="action.class"

--- a/projects/components/src/action-menu/action-menu.component.spec.ts
+++ b/projects/components/src/action-menu/action-menu.component.spec.ts
@@ -162,18 +162,18 @@ describe('ActionMenuComponent', () => {
                 {
                     textKey: 'action.1',
                     handler: () => {},
-                    availability: () => false,
+                    availability: false,
                     disabled: () => true,
                 },
                 {
                     textKey: 'action.2',
                     handler: () => {},
-                    availability: () => true,
+                    availability: true,
                 },
                 {
                     textKey: 'action.3',
                     handler: () => {},
-                    availability: () => false,
+                    availability: false,
                 },
             ]);
             expect(availableActions.length).toEqual(2);
@@ -186,18 +186,18 @@ describe('ActionMenuComponent', () => {
                         {
                             textKey: 'action.1',
                             handler: () => {},
-                            availability: () => false,
+                            availability: false,
                             disabled: () => true,
                         },
                         {
                             textKey: 'action.2',
                             handler: () => {},
-                            availability: () => true,
+                            availability: true,
                         },
                         {
                             textKey: 'action.3',
                             handler: () => {},
-                            availability: () => false,
+                            availability: false,
                         },
                     ],
                 },
@@ -243,21 +243,22 @@ describe('ActionMenuComponent', () => {
             });
         });
         it('returns empty array if there are no selectedEntities', function (this: HasFinderAndActionMenu): void {
+            this.actionMenu.actions = [...CONTEXTUAL_ACTIONS];
             this.actionMenu.selectedEntities = null;
             expect(this.actionMenu.contextualActions.length).toEqual(0);
         });
         it('returns only actions that are available and either contextual or' + ' contextual_featured', function (
             this: HasFinderAndActionMenu
         ): void {
+            this.actionMenu.actions = [...CONTEXTUAL_ACTIONS]
+                .concat([...CONTEXTUAL_FEATURED_ACTIONS])
+                .concat([...STATIC_FEATURED_ACTIONS]);
             this.actionMenu.selectedEntities = [
                 {
                     value: 'foo',
                     paused: false,
                 },
             ];
-            this.actionMenu.actions = [...CONTEXTUAL_ACTIONS]
-                .concat([...CONTEXTUAL_FEATURED_ACTIONS])
-                .concat([...STATIC_FEATURED_ACTIONS]);
             this.finder.detectChanges();
             const availableActions = this.actionMenu.contextualActions;
             const availableContextualActions = this.actionMenu.getAvailableActions(
@@ -288,6 +289,7 @@ describe('ActionMenuComponent', () => {
                     handlerData,
                     availability: () => true,
                 };
+                this.actionMenu.actions = [action];
                 this.actionMenu.selectedEntities = selectedEntities;
                 const spy = spyOn(action, 'handler').and.returnValue(null);
                 this.actionMenu.runActionHandler(action);
@@ -340,9 +342,10 @@ describe('ActionMenuComponent', () => {
         it('emits event when selectedEntities input has changed', function (this: HasFinderAndActionMenu): void {
             const spy = createSpy('actionsUpdate');
             this.actionMenu.actionsUpdate.subscribe(spy);
+            this.actionMenu.actions = [];
             this.actionMenu.selectedEntities = [];
             this.finder.detectChanges();
-            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledTimes(2);
         });
     });
 
@@ -356,6 +359,7 @@ describe('ActionMenuComponent', () => {
                     actionType: ActionType.STATIC_FEATURED,
                 },
             ];
+            this.actionMenu.selectedEntities = [{ value: '', paused: true }];
             expect(this.actionMenu.staticFeaturedActions.length).toEqual(0);
             isActionAvailable = true;
             this.actionMenu.updateDisplayedActions();

--- a/projects/components/src/action-search-provider/action-search.provider.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.ts
@@ -4,6 +4,8 @@
  */
 
 import { TranslationService } from '@vcd/i18n';
+import { isObservable } from 'rxjs';
+import { last, take, takeLast } from 'rxjs/operators';
 import { ActionItem } from '../common/interfaces';
 import {
     QuickSearchProvider,
@@ -83,7 +85,7 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
         }
 
         if (this.flatListOfAvailableActions == null) {
-            this.flatListOfAvailableActions = this.getFlatListOfAvailableActions(this._actions);
+            this.flatListOfAvailableActions = await this.getFlatListOfAvailableActions(this._actions);
         }
         return { items: this.getActions(criteria.toLowerCase()) };
     }
@@ -97,30 +99,43 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
             }));
     }
 
-    private getFlatListOfAvailableActions(actions: ActionItem<R, T>[]): ActionItem<R, T>[] {
-        return actions.reduce((flatActionList, currentAction) => {
+    private async getFlatListOfAvailableActions(actions: ActionItem<R, T>[]): Promise<ActionItem<R, T>[]> {
+        let flatActionList = [];
+        for (const currentAction of actions) {
             if (currentAction?.children) {
-                if (currentAction.children.length === 0) {
-                    return flatActionList;
+                if (currentAction.children.length > 0) {
+                    flatActionList = flatActionList.concat(
+                        await this.getFlatListOfAvailableActions(currentAction.children)
+                    );
                 }
-                flatActionList = flatActionList.concat(this.getFlatListOfAvailableActions(currentAction.children));
-            } else if (this.isActionAvailable(currentAction)) {
+                continue;
+            }
+            if (await this.isActionAvailable(currentAction)) {
                 const textKey =
                     currentAction.isTranslatable === false
                         ? currentAction.textKey
                         : this.ts.translate(currentAction.textKey);
                 flatActionList.push({ ...currentAction, textKey });
             }
-            return flatActionList;
-        }, []);
+        }
+        return flatActionList;
     }
 
-    private isActionAvailable(action: ActionItem<R, T>): boolean {
-        return (
-            !action.isSeparator &&
-            (!action.availability || action.availability(this._selectedEntities)) &&
-            !this.isActionDisabled(action)
-        );
+    private async isActionAvailable(action: ActionItem<R, T>): Promise<boolean> {
+        if (action.isSeparator) {
+            return false;
+        }
+        let actionAvailability;
+        if (action.availability == null) {
+            actionAvailability = true;
+        } else if (typeof action.availability === 'boolean') {
+            actionAvailability = action.availability;
+        } else if (isObservable(action.availability)) {
+            actionAvailability = await action.availability.pipe(take(1)).toPromise();
+        } else {
+            actionAvailability = action.availability(this._selectedEntities);
+        }
+        return actionAvailability && !this.isActionDisabled(action);
     }
 
     private isActionDisabled(action: ActionItem<R, T>): boolean {

--- a/projects/components/src/common/interfaces/action-item.interface.ts
+++ b/projects/components/src/common/interfaces/action-item.interface.ts
@@ -6,6 +6,8 @@
 /**
  * List of different type of action buckets
  */
+import { Observable } from 'rxjs';
+
 export enum ActionType {
     /**
      * Global actions that are displayed always irrespective of the context. These display as the first set of actions
@@ -48,10 +50,10 @@ export interface ActionItem<R, T> {
     class?: string;
     /**
      * Condition whether or not the action is available.
-     * @param records Single item in case of an operation on single record and multiple in case of an operation on batch
+     * @param selectedEntities Single item in case of an operation on single record and multiple in case of an operation on batch
      * selection
      */
-    availability?: (records?: R[], additionalData?: any) => boolean;
+    availability?: Observable<boolean> | ((selectedEntities: R[]) => boolean) | boolean;
     /**
      * Indicates if an action that is available should be disabled. If true, a non available action is disabled.
      * If false, a non-available action is hidden

--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -50,6 +50,23 @@
                 </ng-container>
 
                 <ng-container *ngIf="!item.isSeparator && !item.children">
+                    <ng-template
+                        *ngTemplateOutlet="
+                            isObservable(item.availability) ? obsTmpl : actionButtonTmpl;
+                            context: { $implicit: item }
+                        "
+                    ></ng-template>
+                </ng-container>
+
+                <ng-template #obsTmpl let-item>
+                    <ng-template
+                        *ngIf="item.availability | async"
+                        [ngTemplateOutlet]="actionButtonTmpl"
+                        [ngTemplateOutletContext]="{ $implicit: item }"
+                    ></ng-template>
+                </ng-template>
+
+                <ng-template #actionButtonTmpl let-item>
                     <button
                         [ngClass]="[item.class ? item.class : '', shouldShowIcon ? 'btn-icon' : '', 'btn', 'btn-link']"
                         clrDropdownItem
@@ -70,7 +87,7 @@
                             }}</span>
                         </a>
                     </button>
-                </ng-container>
+                </ng-template>
             </ng-container>
         </clr-dropdown-menu>
     </ng-container>

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -22,6 +22,7 @@ import {
     ViewChildren,
 } from '@angular/core';
 import { ClrDropdown, ClrDropdownMenu, ClrDropdownTrigger } from '@clr/angular';
+import { isObservable } from 'rxjs';
 import { ActionItem, TextIcon } from '../common/interfaces';
 import { CliptextConfig, TooltipSize } from '../lib/directives';
 import { CommonUtil } from '../utils';
@@ -196,6 +197,11 @@ export class DropdownComponent implements AfterViewInit {
      * hovered over
      */
     @ViewChildren(DropdownComponent) vcdDropdownChildren: QueryList<DropdownComponent>;
+
+    /**
+     * Used for deciding if the availability has to be passed through an Async pipe in the template
+     */
+    isObservable = isObservable;
 
     private hideTimeout: number;
 

--- a/projects/examples/src/app/components/action-menu/hide-disable/action-menu-hide-disable-example.component.html
+++ b/projects/examples/src/app/components/action-menu/hide-disable/action-menu-hide-disable-example.component.html
@@ -16,6 +16,15 @@
     >
     </vcd-action-menu>
 
+    <h4>Action availability as observable</h4>
+    <p>
+        The availability of actions can also be a observable streams. This is useful for actions like static actions
+        whose availability sometimes depends on values coming from asynchronous server responses. Out of the following
+        actions, The static featured "Action 1" and the contextual "Nested Action 1" have their availability as
+        observable streams and they get updated every 2 seconds
+    </p>
+    <vcd-action-menu [actions]="observableActions" [selectedEntities]="[{}]"> </vcd-action-menu>
+
     <h4>Disabling of actions</h4>
     <p>Clicking on stop will disable it and enable start and vice versa.</p>
     <vcd-action-menu

--- a/projects/examples/src/app/components/action-menu/hide-disable/action-menu-hide-disable-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/hide-disable/action-menu-hide-disable-example.component.ts
@@ -5,6 +5,8 @@
 
 import { Component } from '@angular/core';
 import { ActionDisplayConfig, ActionItem, ActionStyling, ActionType, TextIcon } from '@vcd/ui-components';
+import { interval } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'vcd-dynamic-availability-example',
@@ -81,6 +83,36 @@ export class ActionMenuHideDisableExampleComponent {
             disabled: () => true,
         },
     ];
+
+    observableActions: ActionItem<any, any>[] = [
+        {
+            textKey: 'Action 1',
+            actionType: ActionType.STATIC_FEATURED,
+            availability: interval(2000).pipe(map((val) => val % 2 === 0)),
+            isTranslatable: false,
+        },
+        {
+            textKey: 'Action 2',
+            actionType: ActionType.STATIC,
+            isTranslatable: false,
+        },
+        {
+            textKey: 'Nested actions',
+            isTranslatable: false,
+            children: [
+                {
+                    textKey: 'Nested Action 1',
+                    availability: interval(2000).pipe(map((val) => val % 2 === 0)),
+                    isTranslatable: false,
+                },
+                {
+                    textKey: 'Nested Action 2',
+                    isTranslatable: false,
+                },
+            ],
+        },
+    ];
+
     dropdownActionDisplayConfig: ActionDisplayConfig = {
         contextual: {
             featuredCount: 2,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [X] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Some of the actions, particularly the visibility static actions depend
on values other than selected entities, like the response from async
requests. For such cases, we need to accept observables to keep their
visibility up to date.
There are some bugs in the VCD ui related to the visibility of static
actions not getting updated because the visibility is not calculated
when one of the variables on which their visibility depends is not
updated.

## What manual testing did you do?
- Started the local dev server on localhost:4200
- Opened the "Hiding and disabling of actions" section of the "Action Menu" tab in the examples app
- Made sure that the "Action availability as observable" section is visible
- In that section, making sure that the visibility of static featured "Action 1" and the contextual "Nested Action 1" is toggled every 2 seconds
- Also, visited the "Static and contextual actions" section made sure that the examples are shown the same as what is being rendered in https://vmware.github.io/vmware-cloud-director-ui-components/action-menu/example/action-menu-static-and-contextual-actions
- Ran the unit tests and made sure that all the unit tests are passing
- Changed the availability of the static actions to observable in the following VCD UI screens and tested that they work as expected:
1. Trusted certificates
2. Certificates library
3. Edge gateways
4. Users
5. External networks list

## Screenshots (if applicable)

https://user-images.githubusercontent.com/10735165/112892409-436bab80-90a7-11eb-9e26-48ea4ec60190.mov

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
