### PR TITLE
Removed hideWhenEmpty and creates a single no results section

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The availability property of action items now accepts observables so that their visibility can be updated from
 asynchronous responses  
 
+### Change
+- BREAKING: All quick search sections now hide when empty.
+
 ## [2.0.0-dev.6]
 ### Changed
 - Quick search now performs much better with many providers.

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,20 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Added functionality to disable an option in `FormSelectComponent`
+
+## [2.0.0-dev.8]
 
 ### Added
 - `clear` is now a method in a widget object.
+- Added functionality to disable an option in `FormSelectComponent`
 
 ### Fixed
 - Allows findWidget in the widget object to use all given findOption.
+
+### Change
+- BREAKING: All quick search sections now hide when empty.
 ## [2.0.0-dev.7]
 ### Changed
 - The availability property of action items now accepts observables so that their visibility can be updated from
 asynchronous responses  
-
-### Change
-- BREAKING: All quick search sections now hide when empty.
 
 ## [2.0.0-dev.6]
 ### Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.7",
+    "version": "2.0.0-dev.8",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -14,9 +14,6 @@
         >
             {{ item.displayText }}
         </li>
-        <li class="no-results" data-ui="no-results" *ngIf="showNoResults(searchSection)">
-            {{ 'vcd.cc.quickSearch.noResults' | translate }}
-        </li>
         <li>
             <clr-alert
                 *ngIf="searchSection.hasPartialResult"
@@ -61,6 +58,9 @@
     <clr-control-helper class="input-helper">{{ helper }}</clr-control-helper>
     <ng-content select=".top-of-results"></ng-content>
     <div class="search-result-container">
+        <section class="no-results" data-ui="no-results" *ngIf="hasNoResults()">
+            {{ 'vcd.cc.quickSearch.noResults' | translate }}
+        </section>
         <section
             *ngFor="let searchSection of ungroupedSearchSections; let i = index; trackBy: sectionTrackBy"
             class="search-result-section section-index-0-{{ i + 1 }}"

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -58,7 +58,7 @@
     <clr-control-helper class="input-helper">{{ helper }}</clr-control-helper>
     <ng-content select=".top-of-results"></ng-content>
     <div class="search-result-container">
-        <section class="no-results" data-ui="no-results" *ngIf="hasNoResults()">
+        <section class="no-results" data-ui="no-results" *ngIf="hasNoResults">
             {{ 'vcd.cc.quickSearch.noResults' | translate }}
         </section>
         <section

--- a/projects/components/src/quick-search/quick-search.component.spec.ts
+++ b/projects/components/src/quick-search/quick-search.component.spec.ts
@@ -286,7 +286,7 @@ describe('QuickSearchComponent', () => {
             expect(searchHandlerSpy).toHaveBeenCalledWith('copy');
         });
 
-        it('display "No results found" when there are no results', function (this: Test): void {
+        it('display a single "No results found" when there are no results', function (this: Test): void {
             // Register one more provider
             this.quickSearchData.simpleProvider.sectionName = 'new section';
             this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.simpleProvider);
@@ -298,7 +298,7 @@ describe('QuickSearchComponent', () => {
             //
             const noResults = TestBed.inject(TranslationService).translate('vcd.cc.quickSearch.noResults', []);
             expect(this.quickSearch.searchResults.length).toBe(0);
-            expect(this.quickSearch.noSearchResults).toEqual([noResults, noResults]);
+            expect(this.quickSearch.noSearchResults).toEqual([noResults]);
         });
 
         describe('partial search result', () => {
@@ -422,23 +422,8 @@ describe('QuickSearchComponent', () => {
             expect(this.quickSearch.sectionTitles).toEqual(['section']);
         });
 
-        it('display section title if there are no results', function (this: Test): void {
-            // Register one more provider
-            this.quickSearchData.simpleProvider.sectionName = 'new section';
-            this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.simpleProvider);
-            // Open
-            this.finder.hostComponent.spotlightOpen = true;
-            this.finder.detectChanges();
-            // Set search
-            this.quickSearch.searchInputValue = 'no match';
-            //
-            expect(this.quickSearch.searchResults.length).toBe(0);
-            expect(this.quickSearch.sectionTitles.length).toEqual(2);
-        });
-
-        it('does not display section title if there are no results and hideWhenEmpty is set to `true`', function (this: Test): void {
+        it('does not display section title if there are no results', function (this: Test): void {
             // Set the flag to hide the section when there is no result
-            this.quickSearchData.simpleProvider.hideWhenEmpty = true;
             // Open
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
@@ -449,32 +434,8 @@ describe('QuickSearchComponent', () => {
             expect(this.quickSearch.sectionTitles.length).toEqual(0);
         });
 
-        it('displays section title during search when hideWhenEmpty is set to `true`', fakeAsync(function (
-            this: Test
-        ): void {
-            // Set the flag to hide the section when there is no result
-            this.quickSearchData.simpleProvider.hideWhenEmpty = true;
-            this.quickSearchData.asyncProvider.hideWhenEmpty = true;
-            this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.asyncProvider);
-            // Open
-            this.finder.hostComponent.spotlightOpen = true;
-            this.finder.detectChanges();
-            // Set search
-            this.quickSearch.searchInputValue = 'no match';
-            // Check expectations
-            expect(this.quickSearch.searchResults.length).toBe(0);
-            expect(this.quickSearch.sectionTitles.length).toEqual(1, 'There should be 1 section during search');
-            // Simulate search has ended
-            tick(1000);
-            this.finder.detectChanges();
-            // Check expectations
-            expect(this.quickSearch.searchResults.length).toBe(0);
-            expect(this.quickSearch.sectionTitles.length).toEqual(0, 'There should be no sections finishing search');
-        }));
-
         it('displays nested providers title correctly with nested, filtered providers', function (this: Test): void {
             // Open
-            this.quickSearchData.anotherSimpleProvider.hideWhenEmpty = true;
             this.quickSearchData.anotherSimpleProvider.sectionName = 'another section';
             this.quickSearchData.spotlightSearchService.registerNestedProvider({
                 sectionName: 'Some Nested Provider',
@@ -826,7 +787,7 @@ describe('QuickSearchComponent', () => {
             this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.anotherSimpleProvider);
             this.quickSearch.searchInputValue = 'copy';
             this.finder.detectChanges();
-            expect(this.quickSearch.sectionTitles.length).toEqual(2);
+            expect(this.quickSearch.sectionTitles.length).toEqual(1);
 
             // When the type filter is present,, the list of providers is filtered based on it.
             // In this case, the type:simple filter is set and anotherSimpleProvider is removed.

--- a/projects/components/src/quick-search/quick-search.component.ts
+++ b/projects/components/src/quick-search/quick-search.component.ts
@@ -549,8 +549,8 @@ export class QuickSearchComponent {
             return true;
         }
 
-        // Do not show when the provider has no results and it is marked with {@link QuickSearchProvider#hideWhenEmpty}
-        if (searchSection.provider.hideWhenEmpty && !searchSection.result?.items?.length) {
+        // Do not show when the provider has no results
+        if (!searchSection.result?.items?.length) {
             return false;
         }
 
@@ -561,12 +561,8 @@ export class QuickSearchComponent {
         return parentSection.subSections.some((section) => section.shouldShowText);
     }
 
-    showNoResults(searchSection: SearchSection): boolean {
-        // Show 'No Results' if the section is empty and the section title is shown
-        if (searchSection.result?.items?.length === 0 && searchSection.shouldShowText) {
-            return true;
-        }
-        return false;
+    hasNoResults(): boolean {
+        return this.getFlattenedSearchSections().every((section) => section.result?.items?.length === 0);
     }
 
     /**

--- a/projects/components/src/quick-search/quick-search.component.ts
+++ b/projects/components/src/quick-search/quick-search.component.ts
@@ -187,6 +187,7 @@ export class QuickSearchComponent {
     @Output() resultActivated: EventEmitter<ResultActivatedEvent> = new EventEmitter<ResultActivatedEvent>();
 
     isPinned = false;
+    hasNoResults = false;
 
     constructor(
         private searchService: QuickSearchService,
@@ -375,6 +376,7 @@ export class QuickSearchComponent {
             searchSection.result = searchResult;
             searchSection.hasPartialResult = this.hasPartialResult(searchSection);
             searchSection.isLoading = false;
+            this.hasNoResults = this.checkHasNoResults();
             searchSection.shouldShowText = this.showSectionTitle(searchSection);
             if (!this.selectedItem) {
                 this.selectFirst(true);
@@ -561,7 +563,7 @@ export class QuickSearchComponent {
         return parentSection.subSections.some((section) => section.shouldShowText);
     }
 
-    hasNoResults(): boolean {
+    checkHasNoResults(): boolean {
         return this.getFlattenedSearchSections().every((section) => section.result?.items?.length === 0);
     }
 

--- a/projects/components/src/quick-search/quick-search.provider.ts
+++ b/projects/components/src/quick-search/quick-search.provider.ts
@@ -63,13 +63,6 @@ export interface QuickSearchProvider {
     data: unknown;
 
     /**
-     * Whether a provider section should be hidden if there are no results.
-     * When `true` the section will not be displayed if it contains no data.
-     * Defaults to `false` and in that case the section is always visible, rendering 'No results found.'
-     */
-    hideWhenEmpty?: boolean;
-
-    /**
      * Returns an array or a promise of array of items that comply with the search criteria.
      * @param criteria The search string provided by the user when typing in the Quick Search Component
      */
@@ -97,7 +90,6 @@ export abstract class QuickSearchProviderDefaults implements QuickSearchProvider
     }
     sectionName = '';
     order = -1;
-    hideWhenEmpty = false;
     data: unknown;
     parentSectionName?: string;
 

--- a/projects/examples/src/components/quick-search/quick-search-hide-empty-section-example.component.ts
+++ b/projects/examples/src/components/quick-search/quick-search-hide-empty-section-example.component.ts
@@ -54,11 +54,6 @@ export class QuickSearchHideEmptySectionExampleComponent implements OnInit, OnDe
         });
 
         this.searchRegistrar.register(this.actionsSearchProvider);
-
-        this.subscriptionTracker.subscribe(this.formGroup.controls.hideEmptySections.valueChanges, (value) => {
-            // Configure hiding the section if there is no result
-            this.actionsSearchProvider.hideWhenEmpty = value;
-        });
     }
 
     ngOnDestroy(): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Changes quick search to only display one "no results" section at the very top when all sections have returned no results. 

## What manual testing did you do?

Loaded to VCD_UI, and searched for "aaaaaa". Observed one section that said "No Results."

## Screenshots (if applicable)

<img width="690" alt="Screen Shot 2021-03-30 at 3 00 07 PM" src="https://user-images.githubusercontent.com/7528512/113047329-2c908c00-916f-11eb-86bb-7cfea866cfc8.png">

## Does this PR introduce a breaking change?

-   [X] Yes
-   [ ] No

`hideWhenEmpty` did not make sense to keep around if we want to enforce that there is always one no results section. Now, all sections hide when empty all the time.

## Other information
