### PR TITLE
Remove the unnecessary check for selected entities before calling the availability callbacks of actions

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.0.0-dev.8]
+### Changed
+- Remove the unnecessary check for selected entities before calculating the visibility of
+actions with availability as callbacks
 
 ## [2.0.0-dev.7]
 ### Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.7",
+    "version": "2.0.0-dev.8",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -318,7 +318,7 @@ export class ActionMenuComponent<R, T> {
             isActionAvailable = action.availability;
         }
         if (CommonUtil.isFunction(action.availability)) {
-            isActionAvailable = this.selectedEntities?.length > 0 && action.availability(this.selectedEntities);
+            isActionAvailable = action.availability(this.selectedEntities);
         }
         return isActionAvailable || this.isActionDisabled(action);
     }

--- a/projects/components/src/sharing-modal/tabs/sharing-modal-tab.component.ts
+++ b/projects/components/src/sharing-modal/tabs/sharing-modal-tab.component.ts
@@ -222,7 +222,7 @@ export class SharingModalTabComponent<T> implements OnInit, OnDestroy, AfterView
     actions: ActionItem<IsSelected<T>, unknown>[] = [
         {
             icon: 'trash',
-            availability: (record: IsSelected<T>[]) => !this.isOwner(record[0]),
+            availability: (record: IsSelected<T>[]) => record[0] && !this.isOwner(record[0]),
             actionType: ActionType.CONTEXTUAL_FEATURED,
             handler: (selected) => {
                 this.removeEntity(selected[0]);


### PR DESCRIPTION
Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Although we changed selected entities as the required parameter in the action item interface, Typescript still allows for defining the availability CBs without relying on selected entities. So, the following check I added for selectedEntities...
`isActionAvailable = this.selectedEntities?.length > 0 && action.availability(this.selectedEntities)` has created bugs where certain actions whose availability CBs don't depend on selected entities and have to be shown are not visible until there are selected entities. 'New' action on organizations list screen is one example of this.

## What manual testing did you do?
Manually visited the following screens in vcd ui and made sure that the actions(mostly Static actions) whose availability CBs are defined without selected entities are shown:
Organizations list screen
All events screen
Hosts component
Vdc templates screen
Vdc groups screen

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
