### PR TITLE
Allows findWidget to use all given findOptions and adds clear to widget object

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -13,6 +13,10 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
+// Load system JS registery
+import System from 'systemjs/dist/system';
+// Provides the @vcd/common module so loading the VcdApiClient does not throw an error.
+window.SystemJs = System.registry.set('@vcd/common', System.newModule({})); // >= 9.5
 // Import commands.js using ES2015 syntax:
 import './commands';
 

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Allows findWidget in the widget object to use all given findOption.
 ## [2.0.0-dev.7]
 ### Changed
 - The availability property of action items now accepts observables so that their visibility can be updated from

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `clear` is now a method in a widget object.
+
 ### Fixed
 - Allows findWidget in the widget object to use all given findOption.
 ## [2.0.0-dev.7]

--- a/projects/components/src/utils/test/widget-object/angular/angular-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/angular/angular-widget-finder.ts
@@ -51,21 +51,33 @@ export class AngularWidgetObjectFinder<H = unknown> {
         widgetConstructor: FindableWidget<TestElement, W>,
         findOptions: FindAngularWidgetOptions = {}
     ): W {
-        const { cssSelector, ancestor } = findOptions;
+        const { ancestor } = findOptions;
+
+        const ancestorWidget = new AngularWidgetObjectElement(
+            new TestElement([ancestor ? ancestor : this.fixture.debugElement], this.fixture)
+        );
         let query = widgetConstructor.tagName;
-        if (cssSelector) {
-            query += `${cssSelector}`;
+        if (findOptions?.cssSelector) {
+            query = query + findOptions.cssSelector;
         }
-        if (ancestor) {
-            query = query;
+        const parentQuery: FindAngularWidgetOptions = {
+            cssSelector: query,
+            text: findOptions?.text,
+            index: findOptions?.index,
+            options: findOptions?.options,
+        };
+
+        const element = ancestorWidget.get(parentQuery).unwrap();
+        if (!element.length()) {
+            throw new Error(`Could not find the widget using the query`);
+        }
+        if (element.length() > 1) {
+            throw new Error(`Found ${element.length} elements matching the given query`);
         }
 
-        const root = (ancestor ? ancestor : this.fixture.debugElement).query(By.css(query));
-        if (!root) {
-            throw new Error(`Could not find the widget using the query ${query}`);
-        }
-
-        const widget = new widgetConstructor(new AngularWidgetObjectElement(new TestElement([root], this.fixture)));
+        const widget = new widgetConstructor(
+            new AngularWidgetObjectElement(new TestElement(element.elements, this.fixture))
+        );
         return widget;
     }
 

--- a/projects/components/src/utils/test/widget-object/angular/angular-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/angular/angular-widget-object-element.ts
@@ -65,6 +65,13 @@ export class AngularWidgetObjectElement implements WidgetObjectElement<TestEleme
     /**
      * @inheritdoc
      */
+    clear(): void {
+        this.testElement.clear();
+    }
+
+    /**
+     * @inheritdoc
+     */
     check(options?: unknown): void {}
 
     /**

--- a/projects/components/src/utils/test/widget-object/angular/angular-widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object/angular/angular-widget-object.spec.ts
@@ -86,6 +86,7 @@ class ClickTrackerWidgetObject<T> extends BaseWidgetObject<T> {
 
     getTrackerElement = this.factory.dataUi(DataUi.clickReceiver);
 
+    _getNameInput = this.internalFactory.dataUi(DataUi.nameInput);
     getNameInput = this.factory.dataUi(DataUi.nameInput);
 
     getButtons = this.factory.dataUi(DataUi.button);
@@ -98,6 +99,11 @@ class ClickTrackerWidgetObject<T> extends BaseWidgetObject<T> {
 
     findHeaderWidget(): HeaderWidgetObject<T> {
         return this.el.findWidget<HeaderWidgetObject<T>>(HeaderWidgetObject);
+    }
+
+    typeNameInput(value: string) {
+        this._getNameInput().clear();
+        this._getNameInput().type(value);
     }
 }
 
@@ -256,6 +262,15 @@ describe('TestElement', () => {
     describe('classes', () => {
         it('gives the classes of an input', function (this: HasClickTracker): void {
             expect(this.clickTracker.getNameInput().classes()).toContain('name');
+        });
+    });
+
+    describe('clear', () => {
+        it('clears a given input', function (this: HasClickTracker): void {
+            this.clickTracker.typeNameInput('ryan');
+            expect(this.clickTracker.getNameInput().value()).toEqual('ryan');
+            this.clickTracker.typeNameInput('hannah');
+            expect(this.clickTracker.getNameInput().value()).toEqual('hannah');
         });
     });
 });

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
@@ -40,11 +40,23 @@ export class CypressWidgetObjectFinder<T> {
         if (findOptions?.cssSelector) {
             tagName += `${findOptions.cssSelector}`;
         }
+
         const id = idGenerator.generate();
-        const search = findOptions?.ancestor
-            ? cy.get(findOptions.ancestor).find(tagName)
-            : cy.get(tagName, findOptions?.options);
-        const root = search.as(id);
+
+        const ancestor = findOptions?.ancestor ? cy.get(findOptions?.ancestor) : cy.get('body');
+        const parentWidget = new CypressWidgetObjectElement(ancestor, false, undefined);
+        let query = widgetConstructor.tagName;
+        if (findOptions?.cssSelector) {
+            query = query + findOptions.cssSelector;
+        }
+        const parentQuery: FindCypressWidgetOptions = {
+            cssSelector: query,
+            text: findOptions?.text,
+            index: findOptions?.index,
+            options: findOptions?.options,
+        };
+
+        const root = parentWidget.get(parentQuery).unwrap().as(id);
         return new widgetConstructor(new CypressWidgetObjectElement(root, true, id));
     }
 }

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
@@ -43,7 +43,9 @@ export class CypressWidgetObjectFinder<T> {
 
         const id = idGenerator.generate();
 
-        const ancestor = findOptions?.ancestor ? cy.get(findOptions?.ancestor) : cy.get('body');
+        const ancestor = findOptions?.ancestor
+            ? cy.get(findOptions?.ancestor, { timeout: findOptions?.options?.timeout })
+            : cy.get('body', { timeout: findOptions?.options?.timeout });
         const parentWidget = new CypressWidgetObjectElement(ancestor, false, undefined);
         let query = widgetConstructor.tagName;
         if (findOptions?.cssSelector) {
@@ -55,7 +57,6 @@ export class CypressWidgetObjectFinder<T> {
             index: findOptions?.index,
             options: findOptions?.options,
         };
-
         const root = parentWidget.get(parentQuery).unwrap().as(id);
         return new widgetConstructor(new CypressWidgetObjectElement(root, true, id));
     }

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
@@ -50,6 +50,10 @@ class MockCy {
     eq() {
         return this;
     }
+
+    clear(options: any) {
+        return this;
+    }
 }
 
 // eslint-disable-next-line no-var
@@ -107,6 +111,15 @@ describe('CypressWidgetObjectElement', () => {
             expect(getSpy).toHaveBeenCalledWith('@1');
             expect(parentSpy).toHaveBeenCalledWith('some_parent');
             expect(parent.isRoot).toBeFalsy();
+        });
+    });
+
+    describe('clear', () => {
+        it('clears the given input', () => {
+            const clearSpy = spyOn(cy, 'clear').and.callThrough();
+            const widget = new CypressWidgetObjectElement(cy, true, '1');
+            widget.clear({ a: 'test' });
+            expect(clearSpy).toHaveBeenCalledWith({ a: 'test' });
         });
     });
 });

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
@@ -1,0 +1,112 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { BaseWidgetObject } from '../widget-object';
+import { CypressWidgetObjectFinder } from './cypress-widget-finder';
+import { CypressWidgetObjectElement } from './cypress-widget-object-element';
+
+class MockCy {
+    as(id: string) {
+        return this;
+    }
+
+    get(selector: string, options: any) {
+        return this;
+    }
+
+    find(selector: string, options: any) {
+        return this;
+    }
+
+    contains(text: string, options: any) {
+        return this;
+    }
+
+    click(options: any) {
+        return this;
+    }
+
+    type(text: string, options: any) {
+        return this;
+    }
+
+    select(text: string, options: any) {
+        return this;
+    }
+
+    check(options: any) {
+        return this;
+    }
+
+    uncheck(options: any) {
+        return this;
+    }
+
+    parents(selector: string) {
+        return this;
+    }
+
+    eq() {
+        return this;
+    }
+}
+
+// eslint-disable-next-line no-var
+var cy = new MockCy();
+
+// Define a global constant in NodeJS
+Object.defineProperty(global, 'cy', {
+    value: cy,
+});
+
+class FakeWidget<T> extends BaseWidgetObject<T> {
+    static tagName = 'hello';
+}
+
+describe('CypressWidgetObjectFinder', () => {
+    describe('find', () => {
+        it('finds a widget using text', () => {
+            const getSpy = spyOn(cy, 'get').and.callThrough();
+            const containsSpy = spyOn(cy, 'contains').and.callThrough();
+            new CypressWidgetObjectFinder().find(FakeWidget, { text: 'text' });
+            expect(getSpy).toHaveBeenCalledWith('body');
+            expect(containsSpy).toHaveBeenCalledWith(FakeWidget.tagName, 'text', { matchCase: false });
+        });
+
+        it('finds a widget using index', () => {
+            const getSpy = spyOn(cy, 'get').and.callThrough();
+            const findSpy = spyOn(cy, 'find').and.callThrough();
+            const eqSpy = spyOn(cy, 'eq').and.callThrough();
+            new CypressWidgetObjectFinder().find(FakeWidget, { index: 1 });
+            expect(getSpy).toHaveBeenCalledWith('body');
+            expect(findSpy).toHaveBeenCalledWith(FakeWidget.tagName, undefined);
+            expect(eqSpy).toHaveBeenCalledWith(1);
+        });
+    });
+});
+
+describe('CypressWidgetObjectElement', () => {
+    describe('findWidget', () => {
+        it('gets a sub-widget', () => {
+            const getSpy = spyOn(cy, 'get').and.callThrough();
+            const findSpy = spyOn(cy, 'find').and.callThrough();
+            const widget = new CypressWidgetObjectElement(cy, true, '1');
+            widget.findWidget(FakeWidget, {});
+            expect(getSpy).toHaveBeenCalledWith('@1');
+            expect(findSpy).toHaveBeenCalledWith(FakeWidget.tagName, undefined);
+        });
+    });
+
+    describe('parents', () => {
+        it('finds a parent element', () => {
+            const getSpy = spyOn(cy, 'get').and.callThrough();
+            const parentSpy = spyOn(cy, 'parents').and.callThrough();
+            const widget = new CypressWidgetObjectElement(cy, true, '1');
+            const parent: any = widget.parents('some_parent');
+            expect(getSpy).toHaveBeenCalledWith('@1');
+            expect(parentSpy).toHaveBeenCalledWith('some_parent');
+            expect(parent.isRoot).toBeFalsy();
+        });
+    });
+});

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
@@ -74,7 +74,7 @@ describe('CypressWidgetObjectFinder', () => {
             const getSpy = spyOn(cy, 'get').and.callThrough();
             const containsSpy = spyOn(cy, 'contains').and.callThrough();
             new CypressWidgetObjectFinder().find(FakeWidget, { text: 'text' });
-            expect(getSpy).toHaveBeenCalledWith('body');
+            expect(getSpy).toHaveBeenCalledWith('body', { timeout: undefined });
             expect(containsSpy).toHaveBeenCalledWith(FakeWidget.tagName, 'text', { matchCase: false });
         });
 
@@ -83,7 +83,7 @@ describe('CypressWidgetObjectFinder', () => {
             const findSpy = spyOn(cy, 'find').and.callThrough();
             const eqSpy = spyOn(cy, 'eq').and.callThrough();
             new CypressWidgetObjectFinder().find(FakeWidget, { index: 1 });
-            expect(getSpy).toHaveBeenCalledWith('body');
+            expect(getSpy).toHaveBeenCalledWith('body', { timeout: undefined });
             expect(findSpy).toHaveBeenCalledWith(FakeWidget.tagName, undefined);
             expect(eqSpy).toHaveBeenCalledWith(1);
         });
@@ -97,7 +97,7 @@ describe('CypressWidgetObjectElement', () => {
             const findSpy = spyOn(cy, 'find').and.callThrough();
             const widget = new CypressWidgetObjectElement(cy, true, '1');
             widget.findWidget(FakeWidget, {});
-            expect(getSpy).toHaveBeenCalledWith('@1');
+            expect(getSpy).toHaveBeenCalledWith('@1', { timeout: undefined });
             expect(findSpy).toHaveBeenCalledWith(FakeWidget.tagName, undefined);
         });
     });

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
@@ -95,7 +95,7 @@ export class CypressWidgetObjectElement<T extends ElementActions> implements Wid
      * @inheritdoc
      */
     uncheck(options?: unknown): void {
-        this.chainable.uncheck();
+        this.chainable.uncheck(options);
     }
 
     /**

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
@@ -101,6 +101,13 @@ export class CypressWidgetObjectElement<T extends ElementActions> implements Wid
     /**
      * @inheritdoc
      */
+    clear(options?: unknown): void {
+        this.chainable.clear(options);
+    }
+
+    /**
+     * @inheritdoc
+     */
     findWidget<W extends BaseWidgetObject<T>>(widget: FindableWidget<T, W>, findOptions: FindCypressWidgetOptions): W {
         return new CypressWidgetObjectFinder<T>().find(widget, { ancestor: '@' + this.alias, ...findOptions });
     }

--- a/projects/components/src/utils/test/widget-object/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/widget-object.ts
@@ -91,6 +91,12 @@ export interface ElementActions {
      * @param options Options to be passed down to implementations
      */
     select(value: string, options: UnknownOptions): void;
+
+    /**
+     * For inputs or text areas, clears the current value.
+     * @param options Options to be passed down to implementations
+     */
+    clear(options?: UnknownOptions): void;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
The widget finder was ignoring most of the arguments given to `findOptions` in a call to `findWidget`. This meant we couldn't find widgets by text or index. This patches the bug.

Also, this adds tests for the cypress widget objects. It does this by mocking the cy object and making assertions about calls to it.

Furthermore, clear was not a method that was callable from inside a widget object, even though it should have been. This adds clear as a method to a widget object.

## What manual testing did you do?
1. Ran the data exporter tests and observed them passing.

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
