### PR TITLE
Change Availability of static actions to not accept CBs

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0-dev.9]
-### Changed
+### Breaking
 - Changed the interface action availability such that the availability of static actions does not accept call backs
 
 ## [2.0.0-dev.8]

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0-dev.8]
+## [2.0.0-dev.9]
+### Changed
+- Changed the interface action availability such that the availability of static actions does not accept call backs
 
+## [2.0.0-dev.8]
 ### Added
 - Find widget by data ui attribute.
 

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0-dev.9]
-### Breaking
-- Changed the interface action availability such that the availability of static actions does not accept call backs
+### Changed
+- BREAKING: Changed the interface action availability such that the availability of static actions does not accept call backs
 
 ## [2.0.0-dev.8]
 ### Added

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.8",
+    "version": "2.0.0-dev.9",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.spec.ts
+++ b/projects/components/src/action-menu/action-menu.component.spec.ts
@@ -45,7 +45,7 @@ describe('ActionMenuComponent', () => {
         it('marks the actions with no actionType as ActionType.CONTEXTUAL', function (this: HasFinderAndActionMenu): void {
             this.actionMenu.actions = [...ACTIONS_WITH_NO_ACTION_TYPES];
             this.finder.detectChanges();
-            this.actionMenu.actions.forEach((action) => {
+            this.actionMenu._actions.forEach((action) => {
                 expect(action.actionType).toEqual(ActionType.CONTEXTUAL);
             });
         });
@@ -55,7 +55,7 @@ describe('ActionMenuComponent', () => {
             function (this: HasFinderAndActionMenu): void {
                 this.actionMenu.actions = [...FLAT_LIST_OF_ACTIONS_WITH_NO_ACTION_TYPE];
                 this.finder.detectChanges();
-                this.actionMenu.actions.forEach((action) => {
+                this.actionMenu._actions.forEach((action) => {
                     expect(action.actionType).toEqual(ActionType.CONTEXTUAL_FEATURED);
                 });
             }
@@ -179,6 +179,7 @@ describe('ActionMenuComponent', () => {
             expect(availableActions.length).toEqual(2);
         });
         it('returns nested actions that are either available or disabled', function (this: HasFinderAndActionMenu): void {
+            this.actionMenu.selectedEntities = [{ value: 'blah', paused: false }];
             const availableActions = this.actionMenu.getAvailableActions([
                 {
                     textKey: 'action',
@@ -186,18 +187,18 @@ describe('ActionMenuComponent', () => {
                         {
                             textKey: 'action.1',
                             handler: () => {},
-                            availability: false,
+                            availability: () => false,
                             disabled: () => true,
                         },
                         {
                             textKey: 'action.2',
                             handler: () => {},
-                            availability: true,
+                            availability: () => true,
                         },
                         {
                             textKey: 'action.3',
                             handler: () => {},
-                            availability: false,
+                            availability: () => false,
                         },
                     ],
                 },
@@ -356,14 +357,14 @@ describe('ActionMenuComponent', () => {
                 {
                     textKey: 'Some action',
                     availability: () => isActionAvailable,
-                    actionType: ActionType.STATIC_FEATURED,
+                    actionType: ActionType.CONTEXTUAL_FEATURED,
                 },
             ];
             this.actionMenu.selectedEntities = [{ value: '', paused: true }];
-            expect(this.actionMenu.staticFeaturedActions.length).toEqual(0);
+            expect(this.actionMenu.contextualFeaturedActions.length).toEqual(0);
             isActionAvailable = true;
             this.actionMenu.updateDisplayedActions();
-            expect(this.actionMenu.staticFeaturedActions.length).toEqual(1);
+            expect(this.actionMenu.contextualFeaturedActions.length).toEqual(1);
         });
     });
 });
@@ -420,7 +421,6 @@ const STATIC_ACTIONS = [
         handler: () => {
             return Promise.resolve('Static');
         },
-        availability: () => true,
         actionType: ActionType.STATIC,
     },
 ];
@@ -431,7 +431,6 @@ const STATIC_FEATURED_ACTIONS: any[] = [
         handler: () => {
             return Promise.resolve('Static featured');
         },
-        availability: () => true,
         actionType: ActionType.STATIC_FEATURED,
     },
 ];

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -4,8 +4,15 @@
  */
 
 import { Component, EventEmitter, Input, Output, TrackByFunction } from '@angular/core';
-import { isObservable } from 'rxjs';
-import { ActionDisplayConfig, ActionItem, ActionStyling, ActionType, TextIcon } from '../common/interfaces';
+import { isObservable, Observable } from 'rxjs';
+import {
+    ActionDisplayConfig,
+    ActionItem,
+    ActionStyling,
+    ActionType,
+    BaseActionItem,
+    TextIcon,
+} from '../common/interfaces';
 import { CommonUtil } from '../utils';
 
 /**
@@ -21,6 +28,21 @@ export function getDefaultActionDisplayConfig(cfg: ActionDisplayConfig = {}): Ac
         staticActionStyling: ActionStyling.INLINE,
     };
     return { ...defaults, ...cfg };
+}
+
+/**
+ * We internally convert the callbacks to booleans to avoid calling the callbacks all the time from template. However, we don't want to
+ * allow callers to assign boolean variables to availability as there is no way to know when those variables can get updated from outside.
+ */
+interface ActionItemInternal<R, T> extends BaseActionItem<R, T> {
+    /**
+     * Used for determining where in the action menu this action gets displayed
+     */
+    actionType?: ActionType;
+    /**
+     * Condition whether or not the action is available.
+     */
+    availability?: ((selectedEntities: R[]) => boolean) | Observable<boolean> | boolean;
 }
 
 /**
@@ -46,10 +68,7 @@ export class ActionMenuComponent<R, T> {
     @Input() set actions(actions: ActionItem<R, T>[]) {
         this.refreshActions(actions);
     }
-    private _actions: ActionItem<R, T>[] = [];
-    get actions(): ActionItem<R, T>[] {
-        return this._actions;
-    }
+    private _actions: ActionItemInternal<R, T>[] = [];
 
     private _actionDisplayConfig: ActionDisplayConfig = getDefaultActionDisplayConfig();
     /**
@@ -149,29 +168,29 @@ export class ActionMenuComponent<R, T> {
     /**
      * List of actions that are marked as {@link ActionType.STATIC_FEATURED} only
      */
-    staticFeaturedActions: ActionItem<R, T>[];
+    staticFeaturedActions: ActionItemInternal<R, T>[];
 
     /**
      * Actions that depend on selected entities and belong to main menu list. The returned list length is less than or
      * equal to the configured featured count in {@link actionDisplayConfig}
      */
-    contextualFeaturedActions: ActionItem<R, T>[];
+    contextualFeaturedActions: ActionItemInternal<R, T>[];
 
     /**
      * All the actions that depend on selected entities
      */
-    contextualActions: ActionItem<R, T>[];
+    contextualActions: ActionItemInternal<R, T>[];
 
     /**
      * List containing all the static actions. It has static featured actions in the beginning of the list followed by
      * non-featured static actions as children of grouped action called 'vcd.cc.action.menu.all.actions'
      */
-    staticDropdownActions: ActionItem<R, T>[] | object;
+    staticDropdownActions: ActionItemInternal<R, T>[] | object;
 
     /**
      * List of only the actions that are marked as {@link ActionType.STATIC}
      */
-    staticActions: ActionItem<R, T>[];
+    staticActions: ActionItemInternal<R, T>[];
 
     /**
      * To show or hide the container elements containing inline and also dropdown actions
@@ -212,13 +231,13 @@ export class ActionMenuComponent<R, T> {
     /**
      * Returns the actions to be shown
      */
-    getAvailableActions(actions: ActionItem<R, T>[]): ActionItem<R, T>[] {
+    getAvailableActions(actions: ActionItemInternal<R, T>[]): ActionItemInternal<R, T>[] {
         return actions
             .filter((action) => this.isActionAvailable(action) && (!action.children || action.children.length !== 0))
             .map((action) => {
                 const actionCopy = { ...action, children: action.children ? [...action.children] : null };
                 if (actionCopy.children) {
-                    actionCopy.children = this.getAvailableActions(actionCopy.children);
+                    actionCopy.children = this.getAvailableActions(actionCopy.children) as ActionItem<R, T>[];
                 }
                 return actionCopy;
             });
@@ -309,7 +328,7 @@ export class ActionMenuComponent<R, T> {
      * An action whose availability is false but has the disabled state set to true is still shown on the screen in
      * disabled mode
      */
-    private isActionAvailable(action: ActionItem<R, T>): boolean {
+    private isActionAvailable(action: ActionItem<R, T> | ActionItemInternal<R, T>): boolean {
         let isActionAvailable = true;
         if (action.availability == null) {
             isActionAvailable = true;
@@ -323,38 +342,40 @@ export class ActionMenuComponent<R, T> {
         return isActionAvailable || this.isActionDisabled(action);
     }
 
-    private getStaticFeaturedActions(): ActionItem<R, T>[] {
-        const staticFeaturedActions = this.actions.filter((action) => action.actionType === ActionType.STATIC_FEATURED);
+    private getStaticFeaturedActions(): ActionItemInternal<R, T>[] {
+        const staticFeaturedActions = this._actions.filter(
+            (action) => action.actionType === ActionType.STATIC_FEATURED
+        );
         return this.getAvailableActions(staticFeaturedActions);
     }
 
-    private getContextualFeaturedActions(): ActionItem<R, T>[] {
+    private getContextualFeaturedActions(): ActionItemInternal<R, T>[] {
         if (!this.selectedEntities?.length) {
             return [];
         }
-        const flattenedFeaturedActionList = this.getFlattenedActionList(this.actions, ActionType.CONTEXTUAL_FEATURED);
+        const flattenedFeaturedActionList = this.getFlattenedActionList(this._actions, ActionType.CONTEXTUAL_FEATURED);
         const availableFeaturedActions = this.getAvailableActions(flattenedFeaturedActionList);
         return this.actionDisplayConfig.contextual.featuredCount
             ? availableFeaturedActions.slice(0, this.actionDisplayConfig.contextual.featuredCount)
             : availableFeaturedActions;
     }
 
-    private getStaticActions(): ActionItem<R, T>[] {
-        const staticActions = this.actions.filter((action) => action.actionType === ActionType.STATIC);
+    private getStaticActions(): ActionItemInternal<R, T>[] {
+        const staticActions = this._actions.filter((action) => action.actionType === ActionType.STATIC);
         return this.getAvailableActions(staticActions);
     }
 
-    private getStaticDropdownActions(): ActionItem<R, T>[] | object {
+    private getStaticDropdownActions(): ActionItemInternal<R, T>[] | object {
         return this.staticFeaturedActions.concat([
-            { textKey: 'vcd.cc.action.menu.other.actions', children: this.staticActions },
+            { textKey: 'vcd.cc.action.menu.other.actions', children: this.staticActions as ActionItem<R, T>[] },
         ]);
     }
 
-    private getContextualActions(): ActionItem<R, T>[] {
+    private getContextualActions(): ActionItemInternal<R, T>[] {
         if (!this.selectedEntities?.length) {
             return [];
         }
-        const contextualActions = this.actions.filter(
+        const contextualActions = this._actions.filter(
             (action) =>
                 !action.actionType ||
                 (action.actionType !== ActionType.STATIC_FEATURED && action.actionType !== ActionType.STATIC)
@@ -365,8 +386,11 @@ export class ActionMenuComponent<R, T> {
     /**
      * Extracts the nested actions that are marked as featured and returns them as part of a flat list
      */
-    private getFlattenedActionList(actions: ActionItem<R, T>[], actionType: ActionType): ActionItem<R, T>[] {
-        let featuredActions: ActionItem<R, T>[] = [];
+    private getFlattenedActionList(
+        actions: ActionItemInternal<R, T>[],
+        actionType: ActionType
+    ): ActionItemInternal<R, T>[] {
+        let featuredActions: ActionItemInternal<R, T>[] = [];
         actions.forEach((action) => {
             if (action.children && action.children.length) {
                 featuredActions = featuredActions.concat(this.getFlattenedActionList(action.children, actionType));
@@ -392,7 +416,7 @@ export class ActionMenuComponent<R, T> {
     /**
      * To disable a displayed action
      */
-    isActionDisabled(action: ActionItem<R, T>): boolean {
+    isActionDisabled(action: ActionItem<R, T> | ActionItemInternal<R, T>): boolean {
         if (action.disabled == null) {
             return false;
         }
@@ -439,16 +463,4 @@ export class ActionMenuComponent<R, T> {
             this.actionDisplayConfig.contextual.styling === style
         );
     }
-}
-
-/**
- * Without the deep copy, the changes made to any of the action children in one of the methods will persist in other methods
- */
-export function getDeepCopyOfActionItems<R, T>(actions: ActionItem<R, T>[]): ActionItem<R, T>[] {
-    return actions.map((action) => {
-        if (action.children && action.children.length) {
-            action.children = getDeepCopyOfActionItems(action.children);
-        }
-        return { ...action };
-    });
 }

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -34,7 +34,7 @@ export function getDefaultActionDisplayConfig(cfg: ActionDisplayConfig = {}): Ac
  * We internally convert the callbacks to booleans to avoid calling the callbacks all the time from template. However, we don't want to
  * allow callers to assign boolean variables to availability as there is no way to know when those variables can get updated from outside.
  */
-interface ActionItemInternal<R, T> extends BaseActionItem<R, T> {
+export interface ActionItemInternal<R, T> extends BaseActionItem<R, T> {
     /**
      * Used for determining where in the action menu this action gets displayed
      */
@@ -42,7 +42,7 @@ interface ActionItemInternal<R, T> extends BaseActionItem<R, T> {
     /**
      * Condition whether or not the action is available.
      */
-    availability?: ((selectedEntities: R[]) => boolean) | Observable<boolean> | boolean;
+    availability?: Observable<boolean> | boolean;
 }
 
 /**

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -68,7 +68,11 @@ export class ActionMenuComponent<R, T> {
     @Input() set actions(actions: ActionItem<R, T>[]) {
         this.refreshActions(actions);
     }
-    private _actions: ActionItemInternal<R, T>[] = [];
+
+    /**
+     * Access modifier is public in order to access this property in unit tests
+     */
+    _actions: ActionItemInternal<R, T>[] = [];
 
     private _actionDisplayConfig: ActionDisplayConfig = getDefaultActionDisplayConfig();
     /**

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -231,13 +231,13 @@ export class ActionMenuComponent<R, T> {
     /**
      * Returns the actions to be shown
      */
-    getAvailableActions(actions: ActionItemInternal<R, T>[]): ActionItemInternal<R, T>[] {
-        return actions
+    getAvailableActions(actions: ActionItemInternal<R, T>[] | ActionItem<R, T>[]): ActionItemInternal<R, T>[] {
+        return (actions as ActionItemInternal<R, T>[])
             .filter((action) => this.isActionAvailable(action) && (!action.children || action.children.length !== 0))
             .map((action) => {
                 const actionCopy = { ...action, children: action.children ? [...action.children] : null };
                 if (actionCopy.children) {
-                    actionCopy.children = this.getAvailableActions(actionCopy.children) as ActionItem<R, T>[];
+                    actionCopy.children = (this.getAvailableActions(actionCopy.children) as any) as ActionItem<R, T>[];
                 }
                 return actionCopy;
             });
@@ -367,7 +367,10 @@ export class ActionMenuComponent<R, T> {
 
     private getStaticDropdownActions(): ActionItemInternal<R, T>[] | object {
         return this.staticFeaturedActions.concat([
-            { textKey: 'vcd.cc.action.menu.other.actions', children: this.staticActions as ActionItem<R, T>[] },
+            {
+                textKey: 'vcd.cc.action.menu.other.actions',
+                children: (this.staticActions as any) as ActionItem<R, T>[],
+            },
         ]);
     }
 
@@ -387,7 +390,7 @@ export class ActionMenuComponent<R, T> {
      * Extracts the nested actions that are marked as featured and returns them as part of a flat list
      */
     private getFlattenedActionList(
-        actions: ActionItemInternal<R, T>[],
+        actions: ActionItemInternal<R, T>[] | ActionItem<R, T>[],
         actionType: ActionType
     ): ActionItemInternal<R, T>[] {
         let featuredActions: ActionItemInternal<R, T>[] = [];

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -34,7 +34,7 @@ export function getDefaultActionDisplayConfig(cfg: ActionDisplayConfig = {}): Ac
  * We internally convert the callbacks to booleans to avoid calling the callbacks all the time from template. However, we don't want to
  * allow callers to assign boolean variables to availability as there is no way to know when those variables can get updated from outside.
  */
-export interface ActionItemInternal<R, T> extends BaseActionItem<R, T> {
+interface ActionItemInternal<R, T> extends BaseActionItem<R, T> {
     /**
      * Used for determining where in the action menu this action gets displayed
      */

--- a/projects/components/src/common/interfaces/action-item.interface.ts
+++ b/projects/components/src/common/interfaces/action-item.interface.ts
@@ -6,7 +6,7 @@
 /**
  * List of different type of action buckets
  */
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 
 export enum ActionType {
     /**

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -545,7 +545,6 @@ describe('DatagridComponent', () => {
                         this.hostComponent.actions = [
                             {
                                 textKey: 'Add',
-                                availability: () => true,
                                 handler: () => null,
                                 actionType: ActionType.STATIC_FEATURED,
                             },
@@ -965,7 +964,6 @@ describe('DatagridComponent', () => {
                     {
                         textKey: 'static.action',
                         handler: () => null,
-                        availability: () => true,
                         actionType: ActionType.STATIC,
                     },
                 ];
@@ -985,7 +983,6 @@ describe('DatagridComponent', () => {
                     {
                         textKey: 'static.action',
                         handler: () => null,
-                        availability: () => true,
                         actionType: ActionType.STATIC,
                     },
                 ];
@@ -1026,7 +1023,6 @@ describe('DatagridComponent', () => {
                     {
                         textKey: 'static.action',
                         handler: () => null,
-                        availability: () => false,
                         actionType: ActionType.STATIC,
                     },
                 ];

--- a/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.ts
+++ b/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.ts
@@ -44,7 +44,6 @@ export class ActionMenuSearchDebounceExampleComponent<R extends Record, T extend
         {
             textKey: 'Static Featured 1',
             handler: () => console.log('Static Featured 1'),
-            availability: () => true,
             actionType: ActionType.STATIC_FEATURED,
             isTranslatable: false,
         },
@@ -52,7 +51,6 @@ export class ActionMenuSearchDebounceExampleComponent<R extends Record, T extend
             textKey: 'Static 1',
             handler: (rec: R[], data: T) => console.log('Static 1 with custom handler data: ', JSON.stringify(data)),
             handlerData: { foo: 'foo', bar: 'bar' } as T,
-            availability: () => true,
             actionType: ActionType.STATIC,
             isTranslatable: false,
         },

--- a/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
@@ -42,7 +42,6 @@ export class ActionMenuSearchExampleComponent<R extends Record, T extends Handle
         {
             textKey: 'Static Featured 1',
             handler: () => console.log('Static Featured 1'),
-            availability: () => true,
             actionType: ActionType.STATIC_FEATURED,
             isTranslatable: false,
         },
@@ -50,7 +49,6 @@ export class ActionMenuSearchExampleComponent<R extends Record, T extends Handle
             textKey: 'Static 1',
             handler: (rec: R[], data: T) => console.log('Static 1 with custom handler data: ', JSON.stringify(data)),
             handlerData: { foo: 'foo', bar: 'bar' } as T,
-            availability: () => true,
             actionType: ActionType.STATIC,
             isTranslatable: false,
         },

--- a/projects/examples/src/app/components/action-menu/with-separators/action-menu-with-separators.example.component.html
+++ b/projects/examples/src/app/components/action-menu/with-separators/action-menu-with-separators.example.component.html
@@ -12,6 +12,7 @@
         [actions]="actions"
         [actionDisplayConfig]="actionDisplayConfig"
         [dropdownTriggerBtnText]="'vcd.cc.action.menu.actions'"
+        [selectedEntities]="[{}]"
     >
     </vcd-action-menu>
 </div>

--- a/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.ts
@@ -20,6 +20,7 @@ import {
     SubscriptionTracker,
     TextIcon,
 } from '@vcd/ui-components';
+import { of } from 'rxjs';
 
 interface Record {
     value: string;
@@ -57,13 +58,17 @@ export class DatagridActionMenuTrackingExampleComponent<R extends Record> implem
 
     contextualActionPosition: ContextualActionPosition = ContextualActionPosition.TOP;
 
+    formGroup: FormGroup;
+
+    isActionMenuAvailable = false;
+
     private readonly staticActions: ActionItem<R, unknown>[] = [
         {
             textKey: 'Add',
             handler: () => {
                 console.log('TODO Add!');
             },
-            availability: () => this.formGroup.controls.enableActions.value,
+            availability: of(this.formGroup.controls.enableActions.value),
             class: 'add',
             actionType: ActionType.STATIC_FEATURED,
             isTranslatable: false,
@@ -87,10 +92,6 @@ export class DatagridActionMenuTrackingExampleComponent<R extends Record> implem
 
     CheckBoxStyling = CheckBoxStyling;
 
-    formGroup: FormGroup;
-
-    isActionMenuAvailable = false;
-
     numberOfAvailableActions = 0;
 
     private subscriptionTracker = new SubscriptionTracker(this);
@@ -102,6 +103,7 @@ export class DatagridActionMenuTrackingExampleComponent<R extends Record> implem
             ['contextualActions']: [true],
             ['staticActions']: [true],
         });
+        this.setActions();
     }
 
     ngOnInit(): void {

--- a/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-activity-reporter.example.component.ts
@@ -50,14 +50,12 @@ export class DatagridActivityReporterExampleComponent {
         {
             textKey: 'Start normal activity',
             isTranslatable: false,
-            availability: () => true,
             actionType: ActionType.STATIC_FEATURED,
             handler: () => this.promiseWithSuccess,
         },
         {
             textKey: 'Start activity with error',
             isTranslatable: false,
-            availability: () => true,
             actionType: ActionType.STATIC_FEATURED,
             handler: () => this.promiseWithError,
         },

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -86,7 +86,6 @@ export class DatagridLinkExampleComponent<R extends Record> {
             handler: () => {
                 console.log('Adding stuff!');
             },
-            availability: () => true,
             class: 'add',
             actionType: ActionType.STATIC_FEATURED,
             isTranslatable: false,
@@ -97,7 +96,6 @@ export class DatagridLinkExampleComponent<R extends Record> {
                 console.log('Custom handler data ' + JSON.stringify(data));
             },
             handlerData: { foo: 'foo', bar: 'bar' },
-            availability: () => true,
             class: 'b',
             icon: 'pause',
             actionType: ActionType.STATIC,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Callbacks with selected entities are only meant for contextual actions and users were using them for static actions also. So now with this change, when a user tries to assign values to the availability of static actions other than observables, they get an error.

## What manual testing did you do?
- Fixed the components of examples project which are wrongly using the availability callbacks
- Started the examples app and made sure that the examples render as before
- Copy pasted the code to node modules of vcd ui and noticed that the code in fact shows an error when a callback is assigned to availability
of static actions

## Screenshots (if applicable)
![Screen Shot 2021-04-07 at 8 14 37 AM](https://user-images.githubusercontent.com/10735165/113866997-fd37db80-977b-11eb-924c-ff2bba8a825d.png)
![Screen Shot 2021-04-07 at 8 13 20 AM](https://user-images.githubusercontent.com/10735165/113867000-fdd07200-977b-11eb-9073-0e9910fe4c72.png)

## Does this PR introduce a breaking change?

-   [X] Yes
-   [ ] No

Any existing static actions in VCD ui that use callbacks for their availability are now going to break. As a follow up to this task, I am going to fix all those places in the VCD ui
