### PR TITLE
Makes the data-exporter keyboard accessible

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The data exporter is now accessible from the keyboard.
+
 ## [2.0.0-dev.9]
 ### Changed
 - BREAKING: Changed the interface action availability such that the availability of static actions does not accept call backs

--- a/projects/components/src/data-exporter/data-exporter.component.html
+++ b/projects/components/src/data-exporter/data-exporter.component.html
@@ -44,48 +44,58 @@
                             <input type="checkbox" clrCheckbox [formControl]="this.selectAllControl" />
                             <label [attr.data-ui]="DataUi.selectAllToggleLabel">{{ exportAllText | lazyString }}</label>
                         </clr-checkbox-wrapper>
-                        <clr-dropdown *ngIf="!this.selectAllControl.value">
+                        <clr-dropdown [clrCloseMenuOnItemClick]="false">
                             <clr-icon
                                 [attr.shape]="isDropdownOpen ? 'caret up' : 'caret down'"
                                 size="24"
                                 clrDropdownTrigger
                                 class="dropdown-button"
                                 [attr.data-ui]="DataUi.columnCheckboxArrow"
+                                *ngIf="!this.selectAllControl.value"
                             ></clr-icon>
-                            <clr-dropdown-menu clrPosition="bottom" *clrIfOpen="forceDropdownOpen">
-                                <ul class="list-unstyled column-selection" [formGroup]="formGroup">
-                                    <li *ngFor="let col of columns" class="dropdown-item">
-                                        <clr-checkbox-wrapper class="column-checkbox">
-                                            <input type="checkbox" clrCheckbox [formControlName]="col.fieldName" />
-                                            <label [attr.data-ui]="DataUi.columnSelectionMenuOptions">{{
-                                                this.friendlyFieldsControl.value
-                                                    ? getDisplayNameForColumn(col)
-                                                    : col.fieldName
-                                            }}</label>
-                                        </clr-checkbox-wrapper>
-                                    </li>
-                                </ul>
+                            <clr-dropdown-menu clrPosition="bottom" [formGroup]="formGroup" *clrIfOpen #dropdownMenu>
+                                <li
+                                    clrDropdownItem
+                                    *ngFor="let col of columns"
+                                    (click)="selectColumn(col)"
+                                    [attr.data-ui]="DataUi.columnSelectionMenuOptions"
+                                >
+                                    <clr-checkbox-wrapper class="column-checkbox">
+                                        <input
+                                            type="checkbox"
+                                            clrCheckbox
+                                            [formControlName]="col.fieldName"
+                                            (click)="$event.stopPropagation()"
+                                        />
+                                        <label (click)="$event.stopPropagation()">{{
+                                            this.friendlyFieldsControl.value
+                                                ? getDisplayNameForColumn(col)
+                                                : col.fieldName
+                                        }}</label>
+                                    </clr-checkbox-wrapper>
+                                </li>
                             </clr-dropdown-menu>
                         </clr-dropdown>
                     </div>
                 </li>
             </ul>
-            <div [ngStyle]="{ visibility: shouldShowBubbles ? 'visible' : 'hidden' }" class="column-container">
-                <span
-                    class="label"
-                    *ngFor="let column of selectedColumns"
-                    [attr.data-ui]="DataUi.columnSelectionBubbles"
+            <span
+                class="x-button label"
+                *ngFor="let column of selectedColumns"
+                [attr.data-ui]="DataUi.columnSelectionBubbles"
+                [ngStyle]="{ visibility: shouldShowBubbles ? 'visible' : 'hidden' }"
+            >
+                {{ this.friendlyFieldsControl.value ? getDisplayNameForColumn(column) : column.fieldName }}
+                <button
+                    type="button"
+                    class="btn btn-icon btn-link remove-col-button"
+                    aria-label="home"
+                    (click)="selectColumn(column, false)"
+                    [attr.data-ui]="DataUi.columnBubblesX"
                 >
-                    {{ this.friendlyFieldsControl.value ? getDisplayNameForColumn(column) : column.fieldName }}
-                    <clr-icon
-                        [attr.data-ui]="DataUi.columnBubblesX"
-                        shape="close"
-                        class="badge badge-info"
-                        (click)="selectColumn(column, false)"
-                    >
-                    </clr-icon>
-                </span>
-            </div>
+                    <clr-icon shape="close" class="badge badge-info"> </clr-icon>
+                </button>
+            </span>
         </div>
         <div class="progress-divider"></div>
         <ng-container *ngIf="isRequestPending">{{ exportStage | lazyString }}</ng-container>

--- a/projects/components/src/data-exporter/data-exporter.component.scss
+++ b/projects/components/src/data-exporter/data-exporter.component.scss
@@ -39,3 +39,14 @@ clr-dropdown-menu {
     height: 200px;
     overflow: auto;
 }
+
+.x-button.label {
+    padding: 0 0.1rem 0.02rem;
+}
+
+button.btn-link.remove-col-button {
+    margin: 0;
+    clr-icon {
+        margin-right: 0px;
+    }
+}

--- a/projects/components/src/data-exporter/data-exporter.component.spec.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component, ViewChild } from '@angular/core';
-import { fakeAsync, TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
 import { TestElement } from '../utils';
@@ -136,6 +136,7 @@ describe('VcdExportTableComponent', () => {
             expect(actual).toEqual(['Name', 'Description']);
             exporter.getColumnCheckboxes({ index: 1 }).click();
             expect(exporter.getColumnBubbles().text()).toBe('Name');
+            tick();
         }));
 
         it('allows the user to remove selected columns from the bubbles below the combo', function (this: TestHostFinder): void {

--- a/projects/components/src/data-exporter/data-exporter.component.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.ts
@@ -102,10 +102,13 @@ export class DataExporterComponent implements OnInit, OnDestroy {
         if (!columnDropdown) {
             return;
         }
+        this._columnDropdown = columnDropdown;
         this.subscriptionTracker.subscribe(columnDropdown.toggleService.openChange, (opened) => {
             this.isDropdownOpen = opened;
         });
     }
+
+    private _columnDropdown: ClrDropdown;
 
     _columns: ExportColumn[] = [];
 
@@ -233,8 +236,6 @@ export class DataExporterComponent implements OnInit, OnDestroy {
     private _open = false;
     private subscriptionTracker = new SubscriptionTracker(this);
 
-    forceDropdownOpen = false;
-
     /**
      * Fires when {@link _open} changes. Its parameter indicates the new state.
      */
@@ -327,8 +328,15 @@ export class DataExporterComponent implements OnInit, OnDestroy {
     /**
      * Sets the selected value of the given column.
      */
-    selectColumn(column: ExportColumn, selected: boolean): void {
+    selectColumn(column: ExportColumn, selected: boolean = !this.getColumnSelection(column)): void {
         this.formGroup.controls[column.fieldName].setValue(selected);
+    }
+
+    /**
+     * Gives the selection status of the given column.
+     */
+    getColumnSelection(column: ExportColumn): boolean {
+        return this.formGroup.controls[column.fieldName].value;
     }
 
     ngOnInit(): void {
@@ -343,8 +351,7 @@ export class DataExporterComponent implements OnInit, OnDestroy {
                     this.formGroup.controls[column.fieldName].setValue(true);
                 }
             } else {
-                this.forceDropdownOpen = true;
-                this.isDropdownOpen = true;
+                this._columnDropdown.toggleService.toggleWithEvent(new Event('click'));
             }
         });
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

The data exporter was not accessible from the keyboard. Specifically, the exported columns could not be changed using the keyboard.

## What manual testing did you do?

1. Click export data
2. Tab to select all columns
3. Press enter
4. Down arrow
5. Press enter
6. Observe column is deselected
7. Tab
8. Observe focus on X bubble.
9. Press enter
10. Observe column has been deselected.
11. Tab to export button
12. Press enter
13. Observe downloaded data

## Screenshots (if applicable)

![data-exporter-access](https://user-images.githubusercontent.com/7528512/114455753-17255400-9baa-11eb-9f93-6a2e18e0abe0.gif)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No