### PR TITLE
Improve the action display config interface for datagrid

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0-dev.10]
+## [2.0.0-dev.11]
+### Changed
+- BREAKING: ActionDisplayConfig of ActionMenuComponent does not accept featuredCount when actions are displayed inline
+and ActionDisplayConfig of DatagridComponent now takes a new property called position
 
+## [2.0.0-dev.10]
 ### Fixed
 - Fix the styling of Number with unit input component such that the inputs inside the component take the available
 container width
 - The data exporter is now accessible from the keyboard.
 - A bug where clearing the form would not work properly if the unlimitedValue was 0
 - A bug where if the default value of the form was unlimited, the component would not select a unit and fail to work.
-- A bug where if the user types in the unlimitedValue, the form did not check the checkbox on blur
+- A bug where if the user types in the unlimitedValue, the form did not check the checkbox on blur  
 
 ## [2.0.0-dev.9]
 ### Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.10",
+    "version": "2.0.0-dev.11",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.spec.ts
+++ b/projects/components/src/action-menu/action-menu.component.spec.ts
@@ -6,7 +6,14 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
-import { ActionDisplayConfig, ActionItem, ActionStyling, ActionType, TextIcon } from '../common/interfaces/index';
+import {
+    ActionDisplayConfig,
+    ActionItem,
+    ActionStyling,
+    ActionType,
+    ContextualActionDropdownDisplayConfig,
+    TextIcon,
+} from '../common/interfaces/index';
 import { WidgetFinder, WidgetObject } from '../utils/test/widget-object';
 import { ActionMenuComponent, getDefaultActionDisplayConfig } from './action-menu.component';
 import { VcdActionMenuModule } from './action-menu.module';
@@ -66,7 +73,7 @@ describe('ActionMenuComponent', () => {
             this.actionMenu.actionDisplayConfig = { ...ACTION_DISPLAY_CONFIG };
             this.finder.detectChanges();
             const actionDisplayConfig = this.actionMenu.actionDisplayConfig;
-            expect(actionDisplayConfig.contextual.featuredCount).toEqual(2);
+            expect((actionDisplayConfig.contextual as ContextualActionDropdownDisplayConfig).featuredCount).toEqual(2);
             expect(actionDisplayConfig.contextual.styling).toEqual(ActionStyling.DROPDOWN);
             expect(actionDisplayConfig.contextual.buttonContents).toEqual(TextIcon.ICON);
             expect(actionDisplayConfig.staticActionStyling).toEqual(ActionStyling.DROPDOWN);

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -27,7 +27,10 @@ export function getDefaultActionDisplayConfig(cfg: ActionDisplayConfig = {}): Ac
         },
         staticActionStyling: ActionStyling.INLINE,
     };
-    return { ...defaults, ...cfg };
+    return {
+        contextual: { ...defaults.contextual, ...cfg.contextual },
+        staticActionStyling: cfg.staticActionStyling || defaults.staticActionStyling,
+    };
 }
 
 /**

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -359,9 +359,10 @@ export class ActionMenuComponent<R, T> {
         }
         const flattenedFeaturedActionList = this.getFlattenedActionList(this._actions, ActionType.CONTEXTUAL_FEATURED);
         const availableFeaturedActions = this.getAvailableActions(flattenedFeaturedActionList);
-        return this.actionDisplayConfig.contextual.featuredCount
-            ? availableFeaturedActions.slice(0, this.actionDisplayConfig.contextual.featuredCount)
-            : availableFeaturedActions;
+        const featuredCount =
+            this.actionDisplayConfig.contextual.styling === ActionStyling.DROPDOWN &&
+            this.actionDisplayConfig.contextual.featuredCount;
+        return featuredCount ? availableFeaturedActions.slice(0, featuredCount) : availableFeaturedActions;
     }
 
     private getStaticActions(): ActionItemInternal<R, T>[] {

--- a/projects/components/src/common/interfaces/action-item.interface.ts
+++ b/projects/components/src/common/interfaces/action-item.interface.ts
@@ -157,16 +157,16 @@ export interface ContextualActionDropdownDisplayConfig {
      *
      * If featuredCount is not set, it will default to all featured actions.
      */
-    featuredCount: number;
+    featuredCount?: number;
     /**
-     * How the featured actions should be displayed
+     * To display actions in a dropdown
      */
     styling: ActionStyling.DROPDOWN;
     /**
      * If the title should be the button label, icon, or both
-     * Defaults to ICON if unset.
+     * Defaults to {@link TextIcon.TEXT} when unset
      */
-    buttonContents: TextIcon;
+    buttonContents?: TextIcon;
 }
 
 /**
@@ -175,7 +175,7 @@ export interface ContextualActionDropdownDisplayConfig {
  */
 export interface ContextualActionInlineDisplayConfig {
     /**
-     * How the featured actions should be displayed
+     * To display actions in a inline horizontal ribbon
      */
     styling: ActionStyling.INLINE;
     /**
@@ -191,11 +191,13 @@ export interface ContextualActionInlineDisplayConfig {
 export interface ActionDisplayConfig {
     /**
      * How the contextual actions list shows up on the screen
+     * If this is not specified, this defaults to { featuredCount: 0, styling: ActionStyling.INLINE, buttonContents: TextIcon.TEXT}
      */
     contextual?: ContextualActionDropdownDisplayConfig | ContextualActionInlineDisplayConfig;
 
     /**
      * How the static actions list shows up on the screen
+     * This defaults to ActionStyling.INLINE
      */
     staticActionStyling?: ActionStyling;
 }

--- a/projects/components/src/common/interfaces/action-item.interface.ts
+++ b/projects/components/src/common/interfaces/action-item.interface.ts
@@ -129,39 +129,6 @@ interface ContextualActionItem<R, T> extends BaseActionItem<R, T> {
 export type ActionItem<R, T> = StaticActionItem<R, T> | ContextualActionItem<R, T>;
 
 /**
- * Configuration of actions that are not static/featured
- */
-export interface ActionDisplayConfig {
-    /**
-     * How the contextual actions list shows up on the screen
-     */
-    contextual?: {
-        /**
-         * How many buttons should display on the featured section.
-         *
-         * Used when you want to set a limit on the number of featured buttons shown.
-         *
-         * If featuredCount is not set, it will default to all featured actions.
-         */
-        featuredCount: number;
-        /**
-         * How the featured actions should be displayed
-         */
-        styling: ActionStyling;
-        /**
-         * If the title should be the button label, icon, or both
-         * Defaults to ICON if unset.
-         */
-        buttonContents: TextIcon;
-    };
-
-    /**
-     * How the static actions list shows up on the screen
-     */
-    staticActionStyling?: ActionStyling;
-}
-
-/**
  * Display options for action menu
  */
 export enum ActionStyling {
@@ -176,4 +143,59 @@ export enum TextIcon {
     ICON = 1 << 0,
     TEXT = 1 << 1,
     ICON_AND_TEXT = TextIcon.ICON | TextIcon.TEXT,
+}
+
+/**
+ * This is created separately from {@link ContextualActionInlineDisplayConfig} because, featured count is only required
+ * when contextual actions are displayed as a dropdown
+ */
+export interface ContextualActionDropdownDisplayConfig {
+    /**
+     * How many buttons should display on the featured section.
+     *
+     * Used when you want to set a limit on the number of featured buttons shown.
+     *
+     * If featuredCount is not set, it will default to all featured actions.
+     */
+    featuredCount: number;
+    /**
+     * How the featured actions should be displayed
+     */
+    styling: ActionStyling.DROPDOWN;
+    /**
+     * If the title should be the button label, icon, or both
+     * Defaults to ICON if unset.
+     */
+    buttonContents: TextIcon;
+}
+
+/**
+ * This along with {@link ContextualActionDropdownDisplayConfig} is one of the types of
+ * {@link ActionDisplayConfig.contextual}
+ */
+export interface ContextualActionInlineDisplayConfig {
+    /**
+     * How the featured actions should be displayed
+     */
+    styling: ActionStyling.INLINE;
+    /**
+     * If the title should be the button label, icon, or both
+     * Defaults to ICON if unset.
+     */
+    buttonContents: TextIcon;
+}
+
+/**
+ * Display configuration of actions that are displayed in a action menu
+ */
+export interface ActionDisplayConfig {
+    /**
+     * How the contextual actions list shows up on the screen
+     */
+    contextual?: ContextualActionDropdownDisplayConfig | ContextualActionInlineDisplayConfig;
+
+    /**
+     * How the static actions list shows up on the screen
+     */
+    staticActionStyling?: ActionStyling;
 }

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -26,7 +26,7 @@ import { AngularWidgetObjectFinder } from '../utils/test/widget-object/angular/a
 import { TestElement } from '../utils/test/widget-object/angular/angular-widget-object-element';
 import {
     ActivityIndicatorType,
-    ContextualActionPosition,
+    DatagridContextualActionPosition,
     DatagridComponent,
     DEFAULT_PAGINATION_TRANSLATION_KEY,
     GridDataFetchResult,
@@ -549,7 +549,8 @@ describe('DatagridComponent', () => {
                                 actionType: ActionType.STATIC_FEATURED,
                             },
                         ];
-                        this.hostComponent.actionDisplayConfig.contextual.position = ContextualActionPosition.ROW;
+                        this.hostComponent.actionDisplayConfig.contextual.position =
+                            DatagridContextualActionPosition.ROW;
                         this.finder.detectChanges();
                         this.hostComponent.pagination = {
                             pageSize: 'Magic',
@@ -998,7 +999,7 @@ describe('DatagridComponent', () => {
                 };
                 this.finder.detectChanges();
                 this.hostComponent.selectionType = GridSelectionType.Single;
-                this.hostComponent.actionDisplayConfig.contextual.position = ContextualActionPosition.TOP;
+                this.hostComponent.actionDisplayConfig.contextual.position = DatagridContextualActionPosition.TOP;
                 this.hostComponent.actions = [
                     {
                         textKey: 'contextual.action',
@@ -1057,7 +1058,7 @@ describe('DatagridComponent', () => {
             it('is not available when there are contextual actions to be displayed in the row', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 this.hostComponent.selectionType = GridSelectionType.Single;
-                this.hostComponent.actionDisplayConfig.contextual.position = ContextualActionPosition.ROW;
+                this.hostComponent.actionDisplayConfig.contextual.position = DatagridContextualActionPosition.ROW;
                 this.hostComponent.actions = [
                     {
                         textKey: 'contextual.action',
@@ -1371,7 +1372,7 @@ export class HostWithDatagridComponent {
         contextual: {
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
-            position: ContextualActionPosition.TOP,
+            position: DatagridContextualActionPosition.TOP,
         },
         staticActionStyling: ActionStyling.INLINE,
     };

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -12,7 +12,6 @@ import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { ActivityPromiseResolver } from '../common/activity-reporter/activity-promise-resolver';
 import {
-    ActionDisplayConfig,
     ActionHandlerType,
     ActionItem,
     ActionStyling,
@@ -37,6 +36,7 @@ import {
 } from './datagrid.component';
 import { VcdDatagridModule } from './datagrid.module';
 import { DatagridStringFilter, WildCardPosition } from './filters/datagrid-string-filter.component';
+import { DatagridActionDisplayConfig } from './interfaces/datagrid-action-display.interface';
 import { ColumnComponentRendererSpec, GridColumn, GridColumnHideable } from './interfaces/datagrid-column.interface';
 import { mockData, MockRecord } from './mock-data';
 import { BoldTextRendererComponent } from './renderers/bold-text-renderer.component';
@@ -549,7 +549,7 @@ describe('DatagridComponent', () => {
                                 actionType: ActionType.STATIC_FEATURED,
                             },
                         ];
-                        this.hostComponent.contextualActionPosition = ContextualActionPosition.ROW;
+                        this.hostComponent.actionDisplayConfig.contextual.position = ContextualActionPosition.ROW;
                         this.finder.detectChanges();
                         this.hostComponent.pagination = {
                             pageSize: 'Magic',
@@ -998,7 +998,7 @@ describe('DatagridComponent', () => {
                 };
                 this.finder.detectChanges();
                 this.hostComponent.selectionType = GridSelectionType.Single;
-                this.hostComponent.contextualActionPosition = ContextualActionPosition.TOP;
+                this.hostComponent.actionDisplayConfig.contextual.position = ContextualActionPosition.TOP;
                 this.hostComponent.actions = [
                     {
                         textKey: 'contextual.action',
@@ -1057,7 +1057,7 @@ describe('DatagridComponent', () => {
             it('is not available when there are contextual actions to be displayed in the row', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 this.hostComponent.selectionType = GridSelectionType.Single;
-                this.hostComponent.contextualActionPosition = ContextualActionPosition.ROW;
+                this.hostComponent.actionDisplayConfig.contextual.position = ContextualActionPosition.ROW;
                 this.hostComponent.actions = [
                     {
                         textKey: 'contextual.action',
@@ -1327,7 +1327,6 @@ describe('DatagridComponent', () => {
                 [pagination]="pagination"
                 [actions]="actions"
                 [actionDisplayConfig]="actionDisplayConfig"
-                [contextualActionPosition]="contextualActionPosition"
                 [height]="height"
                 [header]="header"
                 [indicatorType]="indicatorType"
@@ -1368,16 +1367,14 @@ export class HostWithDatagridComponent {
 
     actions: ActionItem<MockRecord, unknown>[] = [];
 
-    actionDisplayConfig: ActionDisplayConfig = {
+    actionDisplayConfig: DatagridActionDisplayConfig = {
         contextual: {
-            featuredCount: 0,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
+            position: ContextualActionPosition.TOP,
         },
         staticActionStyling: ActionStyling.INLINE,
     };
-
-    contextualActionPosition: ContextualActionPosition = ContextualActionPosition.TOP;
 
     details = DatagridDetailsComponent;
 

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -24,16 +24,15 @@ import { LazyString, TranslationService } from '@vcd/i18n';
 import { Observable } from 'rxjs';
 import { ActionMenuComponent } from '../action-menu/action-menu.component';
 import { ActivityReporter } from '../common/activity-reporter';
-import {
-    ActionDisplayConfig,
-    ActionHandlerType,
-    ActionItem,
-    ActionType,
-} from '../common/interfaces/action-item.interface';
+import { ActionHandlerType, ActionItem, ActionType } from '../common/interfaces/action-item.interface';
 import { SubscriptionTracker } from '../common/subscription';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { DatagridFilter } from './filters/datagrid-filter';
 import { ComponentRendererConstructor, ComponentRendererSpec } from './interfaces/component-renderer.interface';
+import {
+    DatagridActionDisplayConfig,
+    getDefaultDatagridActionDisplayConfig,
+} from './interfaces/datagrid-action-display.interface';
 import {
     ColumnRendererSpec,
     FunctionRenderer,
@@ -473,8 +472,7 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
      */
     get shouldDisplayContextualActionsOnTop(): boolean {
         return (
-            this.contextualActionPosition &&
-            this.contextualActionPosition === ContextualActionPosition.TOP &&
+            this.actionDisplayConfig?.contextual?.position === ContextualActionPosition.TOP &&
             this.datagridSelection.length !== 0
         );
     }
@@ -483,7 +481,7 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
      * If the contextual buttons should display in a row.
      */
     get shouldDisplayContextualActionsInRow(): boolean {
-        return this.contextualActionPosition && this.contextualActionPosition === ContextualActionPosition.ROW;
+        return this.actionDisplayConfig?.contextual?.position === ContextualActionPosition.ROW;
     }
 
     /**
@@ -518,15 +516,16 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
      */
     @Output() selectionChanged = this.datagridSelectionChange;
 
+    private _actionDisplayConfig: DatagridActionDisplayConfig = getDefaultDatagridActionDisplayConfig();
     /**
      * How to display the static and contextual actions.
      */
-    @Input() actionDisplayConfig: ActionDisplayConfig;
-
-    /**
-     * Whether to display contextual actions inside the row or on top of the grid
-     */
-    @Input() contextualActionPosition: ContextualActionPosition = ContextualActionPosition.TOP;
+    @Input() set actionDisplayConfig(value: DatagridActionDisplayConfig) {
+        this._actionDisplayConfig = getDefaultDatagridActionDisplayConfig(value);
+    }
+    get actionDisplayConfig(): DatagridActionDisplayConfig {
+        return this._actionDisplayConfig;
+    }
 
     /**
      * Emitted whenever {@link #columns} input is updated

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -43,7 +43,7 @@ import {
 /**
  * An enum that describes where the contextual buttons should display.
  */
-export enum ContextualActionPosition {
+export enum DatagridContextualActionPosition {
     TOP = 'TOP',
     ROW = 'ROW',
 }
@@ -472,7 +472,7 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
      */
     get shouldDisplayContextualActionsOnTop(): boolean {
         return (
-            this.actionDisplayConfig?.contextual?.position === ContextualActionPosition.TOP &&
+            this.actionDisplayConfig?.contextual?.position === DatagridContextualActionPosition.TOP &&
             this.datagridSelection.length !== 0
         );
     }
@@ -481,7 +481,7 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
      * If the contextual buttons should display in a row.
      */
     get shouldDisplayContextualActionsInRow(): boolean {
-        return this.actionDisplayConfig?.contextual?.position === ContextualActionPosition.ROW;
+        return this.actionDisplayConfig?.contextual?.position === DatagridContextualActionPosition.ROW;
     }
 
     /**
@@ -516,13 +516,14 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
      */
     @Output() selectionChanged = this.datagridSelectionChange;
 
-    private _actionDisplayConfig: DatagridActionDisplayConfig = getDefaultDatagridActionDisplayConfig();
     /**
      * How to display the static and contextual actions.
+     * If not set, this will default to the output of {@link getDefaultDatagridActionDisplayConfig}
      */
     @Input() set actionDisplayConfig(value: DatagridActionDisplayConfig) {
         this._actionDisplayConfig = getDefaultDatagridActionDisplayConfig(value);
     }
+    private _actionDisplayConfig: DatagridActionDisplayConfig = getDefaultDatagridActionDisplayConfig();
     get actionDisplayConfig(): DatagridActionDisplayConfig {
         return this._actionDisplayConfig;
     }

--- a/projects/components/src/datagrid/index.ts
+++ b/projects/components/src/datagrid/index.ts
@@ -7,6 +7,7 @@ export * from './datagrid.module';
 export * from './datagrid.component';
 export * from './interfaces/datagrid-column.interface';
 export * from './interfaces/component-renderer.interface';
+export * from './interfaces/datagrid-action-display.interface';
 export * from './renderers/index';
 export * from './filters/datagrid-filter';
 export * from './filters/datagrid-numeric-filter.component';

--- a/projects/components/src/datagrid/interfaces/datagrid-action-display.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-action-display.interface.ts
@@ -1,0 +1,66 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import {
+    ActionStyling,
+    ContextualActionDropdownDisplayConfig,
+    ContextualActionInlineDisplayConfig,
+    TextIcon,
+} from '../../common/interfaces';
+import { ContextualActionPosition } from '../datagrid.component';
+
+/**
+ * Makes the featured count as required when action menu is displayed as a dropdown and also adds the position
+ * at which the actions have to displayed in a datagrid
+ */
+interface DatagridContextualActionDropdownDisplayConfig extends ContextualActionDropdownDisplayConfig {
+    /**
+     * An enum that describes where the contextual buttons should display.
+     */
+    position: ContextualActionPosition;
+}
+
+/**
+ * Makes the featured count as required when action menu is displayed as a inline bar and also adds the position
+ * at which the actions have to displayed in a datagrid
+ */
+interface DatagridContextualActionInlineDisplayConfig extends ContextualActionInlineDisplayConfig {
+    /**
+     * An enum that describes where the contextual buttons should display.
+     */
+    position: ContextualActionPosition;
+}
+
+/**
+ * Display configuration for actions that are displayed in a datagrid
+ */
+export interface DatagridActionDisplayConfig {
+    /**
+     * How the contextual actions list shows up on the screen
+     */
+    contextual?: DatagridContextualActionDropdownDisplayConfig | DatagridContextualActionInlineDisplayConfig;
+
+    /**
+     * How the static actions list shows up on the screen
+     */
+    staticActionStyling?: ActionStyling;
+}
+
+/**
+ * To add default values to configs if they are not provided by the caller in the input config
+ */
+export function getDefaultDatagridActionDisplayConfig(
+    cfg: DatagridActionDisplayConfig = {}
+): DatagridActionDisplayConfig {
+    const defaults = {
+        contextual: {
+            styling: ActionStyling.DROPDOWN,
+            featuredCount: 2,
+            buttonContents: TextIcon.TEXT,
+            position: ContextualActionPosition.TOP,
+        },
+        staticActionStyling: ActionStyling.INLINE,
+    };
+    return { ...defaults, ...cfg };
+}

--- a/projects/components/src/datagrid/interfaces/datagrid-action-display.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-action-display.interface.ts
@@ -8,7 +8,7 @@ import {
     ContextualActionInlineDisplayConfig,
     TextIcon,
 } from '../../common/interfaces';
-import { ContextualActionPosition } from '../datagrid.component';
+import { DatagridContextualActionPosition } from '../datagrid.component';
 
 /**
  * Makes the featured count as required when action menu is displayed as a dropdown and also adds the position
@@ -18,7 +18,7 @@ interface DatagridContextualActionDropdownDisplayConfig extends ContextualAction
     /**
      * An enum that describes where the contextual buttons should display.
      */
-    position: ContextualActionPosition;
+    position: DatagridContextualActionPosition;
 }
 
 /**
@@ -29,7 +29,7 @@ interface DatagridContextualActionInlineDisplayConfig extends ContextualActionIn
     /**
      * An enum that describes where the contextual buttons should display.
      */
-    position: ContextualActionPosition;
+    position: DatagridContextualActionPosition;
 }
 
 /**
@@ -58,7 +58,7 @@ export function getDefaultDatagridActionDisplayConfig(
             styling: ActionStyling.DROPDOWN,
             featuredCount: 2,
             buttonContents: TextIcon.TEXT,
-            position: ContextualActionPosition.TOP,
+            position: DatagridContextualActionPosition.TOP,
         },
         staticActionStyling: ActionStyling.INLINE,
     };

--- a/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-column.interface.ts
@@ -6,7 +6,6 @@
 /**
  * Whether something shows up in the column toggler
  */
-import { TextIcon } from '../../common/interfaces/action-item.interface';
 import { CliptextConfig } from '../../lib/directives/show-clipped-text.directive';
 import { FilterConfig, FilterRendererSpec } from '../filters/datagrid-filter';
 import { ComponentRendererConstructor, ComponentRendererSpec } from './component-renderer.interface';

--- a/projects/components/src/sharing-modal/tabs/sharing-modal-tab.component.html
+++ b/projects/components/src/sharing-modal/tabs/sharing-modal-tab.component.html
@@ -80,7 +80,6 @@
         [columns]="columns"
         [gridData]="gridItems"
         [actions]="actions"
-        [contextualActionPosition]="rowPosition"
         [actionDisplayConfig]="actionDisplayConfig"
         *ngIf="!this.isSelectAll; else placeholderGrid"
         [height]="400"

--- a/projects/components/src/sharing-modal/tabs/sharing-modal-tab.component.ts
+++ b/projects/components/src/sharing-modal/tabs/sharing-modal-tab.component.ts
@@ -13,7 +13,7 @@ import {
     ColumnComponentRendererSpec,
     ComponentRendererConstructor,
     ComponentRendererSpec,
-    ContextualActionPosition,
+    DatagridContextualActionPosition,
     GridColumn,
     GridDataFetchResult,
     GridState,
@@ -229,7 +229,7 @@ export class SharingModalTabComponent<T> implements OnInit, OnDestroy, AfterView
         contextual: {
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.ICON,
-            position: ContextualActionPosition.ROW,
+            position: DatagridContextualActionPosition.ROW,
         },
     };
 

--- a/projects/components/src/sharing-modal/tabs/sharing-modal-tab.component.ts
+++ b/projects/components/src/sharing-modal/tabs/sharing-modal-tab.component.ts
@@ -7,13 +7,7 @@ import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, OnInit, Outpu
 import { ClrDatagridPagination } from '@clr/angular';
 import { LazyString, TranslationService } from '@vcd/i18n';
 import { Observable } from 'rxjs';
-import {
-    ActionDisplayConfig,
-    ActionItem,
-    ActionStyling,
-    ActionType,
-    TextIcon,
-} from '../../common/interfaces/action-item.interface';
+import { ActionItem, ActionStyling, ActionType, TextIcon } from '../../common/interfaces/action-item.interface';
 import { SubscriptionTracker } from '../../common/subscription';
 import {
     ColumnComponentRendererSpec,
@@ -25,6 +19,7 @@ import {
     GridState,
     PaginationConfiguration,
 } from '../../datagrid';
+import { DatagridActionDisplayConfig } from '../../datagrid/interfaces/datagrid-action-display.interface';
 import { CommonUtil } from '../../utils/common-util';
 import { RightsDropdownRendererComponent } from '../renderers/rights-dropdown-renderer';
 import { ComboOption } from '../select-all-checkbox/select-all-toggle.component';
@@ -230,15 +225,13 @@ export class SharingModalTabComponent<T> implements OnInit, OnDestroy, AfterView
         },
     ];
 
-    actionDisplayConfig: ActionDisplayConfig = {
+    actionDisplayConfig: DatagridActionDisplayConfig = {
         contextual: {
-            featuredCount: 1,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.ICON,
+            position: ContextualActionPosition.ROW,
         },
     };
-
-    rowPosition = ContextualActionPosition.ROW;
 
     paginationInfo: PaginationConfiguration = {
         pageSize: 10,

--- a/projects/examples/src/app/components/action-menu/contextual-actions/action-menu-contextual-actions-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/contextual-actions/action-menu-contextual-actions-example.component.ts
@@ -71,7 +71,6 @@ export class ActionMenuContextualActionsExampleComponent {
     ];
     inlineActionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 2,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },
@@ -85,14 +84,12 @@ export class ActionMenuContextualActionsExampleComponent {
     };
     featuredCountActionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 1,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },
     };
     buttonContentsActionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 2,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.ICON,
         },

--- a/projects/examples/src/app/components/action-menu/hide-disable/action-menu-hide-disable-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/hide-disable/action-menu-hide-disable-example.component.ts
@@ -115,7 +115,6 @@ export class ActionMenuHideDisableExampleComponent {
 
     dropdownActionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 2,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },

--- a/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.ts
+++ b/projects/examples/src/app/components/action-menu/search-debounce/action-menu-search-debounce.example.component.ts
@@ -70,7 +70,6 @@ export class ActionMenuSearchDebounceExampleComponent<R extends Record, T extend
 
     actionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 1,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },

--- a/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/search/action-menu-search-example.component.ts
@@ -102,7 +102,6 @@ export class ActionMenuSearchExampleComponent<R extends Record, T extends Handle
 
     actionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 2,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },

--- a/projects/examples/src/app/components/action-menu/static-and-contextual-actions/action-menu-static-and-contextual-actions-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/static-and-contextual-actions/action-menu-static-and-contextual-actions-example.component.ts
@@ -66,7 +66,6 @@ export class ActionMenuStaticAndContextualActionsExampleComponent {
     ];
     inlineActionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 5,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },

--- a/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.html
@@ -28,7 +28,6 @@ This example shows how you can track the action menu availability and get the ac
     [columns]="columns"
     [actions]="actions"
     [actionDisplayConfig]="actionDisplayConfig"
-    [contextualActionPosition]="contextualActionPosition"
     [selectionType]="GridSelectionType.Multi"
 ></vcd-datagrid>
 

--- a/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.ts
@@ -10,9 +10,9 @@ import {
     ActionStyling,
     ActionType,
     CheckBoxStyling,
-    ContextualActionPosition,
     DatagridActionDisplayConfig,
     DatagridComponent,
+    DatagridContextualActionPosition,
     GridColumn,
     GridDataFetchResult,
     GridSelectionType,
@@ -51,7 +51,7 @@ export class DatagridActionMenuTrackingExampleComponent<R extends Record> implem
         contextual: {
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
-            position: ContextualActionPosition.TOP,
+            position: DatagridContextualActionPosition.TOP,
         },
         staticActionStyling: ActionStyling.INLINE,
     };

--- a/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-action-menu-tracking-example.component.ts
@@ -6,12 +6,12 @@
 import { AfterViewInit, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import {
-    ActionDisplayConfig,
     ActionItem,
     ActionStyling,
     ActionType,
     CheckBoxStyling,
     ContextualActionPosition,
+    DatagridActionDisplayConfig,
     DatagridComponent,
     GridColumn,
     GridDataFetchResult,
@@ -47,16 +47,14 @@ export class DatagridActionMenuTrackingExampleComponent<R extends Record> implem
 
     actions: ActionItem<R, unknown>[] = [];
 
-    actionDisplayConfig: ActionDisplayConfig = {
+    actionDisplayConfig: DatagridActionDisplayConfig = {
         contextual: {
-            featuredCount: 3,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
+            position: ContextualActionPosition.TOP,
         },
         staticActionStyling: ActionStyling.INLINE,
     };
-
-    contextualActionPosition: ContextualActionPosition = ContextualActionPosition.TOP;
 
     formGroup: FormGroup;
 

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -9,9 +9,9 @@ import {
     ActionItem,
     ActionStyling,
     ActionType,
-    ContextualActionPosition,
     DatagridActionDisplayConfig,
     DatagridComponent,
+    DatagridContextualActionPosition,
     GridColumn,
     GridDataFetchResult,
     GridSelectionType,
@@ -157,7 +157,7 @@ export class DatagridLinkExampleComponent<R extends Record> {
         contextual: {
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
-            position: ContextualActionPosition.TOP,
+            position: DatagridContextualActionPosition.TOP,
         },
         staticActionStyling: ActionStyling.INLINE,
     };
@@ -165,11 +165,11 @@ export class DatagridLinkExampleComponent<R extends Record> {
     selectionType = GridSelectionType.Single;
 
     changeActionLocation(): void {
-        if (this.actionDisplayConfig.contextual.position === ContextualActionPosition.TOP) {
-            this.actionDisplayConfig.contextual.position = ContextualActionPosition.ROW;
+        if (this.actionDisplayConfig.contextual.position === DatagridContextualActionPosition.TOP) {
+            this.actionDisplayConfig.contextual.position = DatagridContextualActionPosition.ROW;
             this.selectionType = GridSelectionType.None;
         } else {
-            this.actionDisplayConfig.contextual.position = ContextualActionPosition.TOP;
+            this.actionDisplayConfig.contextual.position = DatagridContextualActionPosition.TOP;
             this.selectionType = GridSelectionType.Single;
         }
     }

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -10,6 +10,7 @@ import {
     ActionStyling,
     ActionType,
     ContextualActionPosition,
+    DatagridActionDisplayConfig,
     DatagridComponent,
     GridColumn,
     GridDataFetchResult,
@@ -44,10 +45,10 @@ type HandlerData = Record[] | Blah;
     selector: 'vcd-datagrid-link-example',
     template: `
         <button (click)="changeActionLocation()" class="btn btn-primary">
-            Display contextual actions {{ contextualActionPosition === 'ROW' ? 'on top' : 'in row' }}
+            Display contextual actions {{ actionDisplayConfig.contextual.position === 'ROW' ? 'on top' : 'in row' }}
         </button>
         <button
-            *ngIf="contextualActionPosition === 'ROW'"
+            *ngIf="actionDisplayConfig.contextual.position === 'ROW'"
             (click)="changeContextualActionStyling()"
             class="btn btn-primary"
         >
@@ -60,7 +61,6 @@ type HandlerData = Record[] | Blah;
             [columns]="columns"
             [actions]="actions"
             [actionDisplayConfig]="actionDisplayConfig"
-            [contextualActionPosition]="contextualActionPosition"
             [selectionType]="selectionType"
         ></vcd-datagrid>
     `,
@@ -153,25 +153,23 @@ export class DatagridLinkExampleComponent<R extends Record> {
         },
     ];
 
-    actionDisplayConfig: ActionDisplayConfig = {
+    actionDisplayConfig: DatagridActionDisplayConfig = {
         contextual: {
-            featuredCount: 3,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
+            position: ContextualActionPosition.TOP,
         },
         staticActionStyling: ActionStyling.INLINE,
     };
 
-    contextualActionPosition: ContextualActionPosition = ContextualActionPosition.TOP;
-
     selectionType = GridSelectionType.Single;
 
     changeActionLocation(): void {
-        if (this.contextualActionPosition === ContextualActionPosition.TOP) {
-            this.contextualActionPosition = ContextualActionPosition.ROW;
+        if (this.actionDisplayConfig.contextual.position === ContextualActionPosition.TOP) {
+            this.actionDisplayConfig.contextual.position = ContextualActionPosition.ROW;
             this.selectionType = GridSelectionType.None;
         } else {
-            this.contextualActionPosition = ContextualActionPosition.TOP;
+            this.actionDisplayConfig.contextual.position = ContextualActionPosition.TOP;
             this.selectionType = GridSelectionType.Single;
         }
     }
@@ -195,7 +193,7 @@ export class DatagridLinkExampleComponent<R extends Record> {
                 ...this.actionDisplayConfig.contextual,
                 styling:
                     this.actionDisplayConfig.contextual.styling === ActionStyling.DROPDOWN
-                        ? ActionStyling.INLINE
+                        ? (ActionStyling.INLINE as any)
                         : ActionStyling.DROPDOWN,
             },
         };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
This change does the following:
- ActionDisplayConfig of ActionMenuComponent does not accept `featuredCount` when actions are displayed inline as there is no difference between featured and non-featured actions in this case
- ActionDisplayConfig of contextual actions of DatagridComponent now takes a new property called `position` which is used to display the actions in Datagrid either in a row or on top of a grid. This replaces the `@input contextualActionPosition`

## What manual testing did you do?
Tested the following examples to make sure that the contextual actions are rendered inline without any errors even after removing the `featuredCount` property:
`ActionMenuContextualActionsExampleComponent`
`ActionMenuHideDisableExampleComponent`
`ActionMenuSearchExampleComponent`
`ActionMenuSearchDebounceExampleComponent`
`ActionMenuStaticAndContextualActionsExampleComponent`

Tested the `DatagridLinkExampleComponent` to make sure that the actions are displayed in following configurations:
- In rows and as inline bars
- In rows and as dropdowns
- On top and as inline bar

## Screenshots (if applicable)

https://user-images.githubusercontent.com/10735165/114630846-6bebcc00-9c89-11eb-9dcf-7eadb2fa517b.mov


## Does this PR introduce a breaking change?

-   [X] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
