### PR TITLE
Fixes bugs with the number with unit form

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fix the styling of Number with unit input component such that the inputs inside the component take the available
-container width
+
+## [2.0.0-dev.10]
 
 ### Fixed
+- Fix the styling of Number with unit input component such that the inputs inside the component take the available
+container width
 - The data exporter is now accessible from the keyboard.
+- A bug where clearing the form would not work properly if the unlimitedValue was 0
+- A bug where if the default value of the form was unlimited, the component would not select a unit and fail to work.
+- A bug where if the user types in the unlimitedValue, the form did not check the checkbox on blur
 
 ## [2.0.0-dev.9]
 ### Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.9",
+    "version": "2.0.0-dev.10",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -24,6 +24,7 @@
                     [attr.size]="size"
                     [attr.aria-required]="showAsterisk"
                     [attr.aria-describedby]="showErrors ? errorsId : descriptionId"
+                    (blur)="updateUnlimitedCheckbox()"
                 />
                 <ng-container [ngSwitch]="unitOptions.length">
                     <ng-container *ngSwitchCase="0">

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component } from '@angular/core';
-import { fakeAsync, TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ClarityModule } from '@clr/angular';
@@ -137,6 +137,32 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             numberWithUnitInput.clickUnlimitedCheckbox();
             expect(numberWithUnitInput.isInputValueFocused).toBe(true, 'Input element should have focus');
         });
+
+        it('will choose a unit when unchecked for initial value unlimited', () => {
+            const numberWithUnitInputUnlimited = finder.find({
+                woConstructor: NumberWithUnitFormInputWidgetObject,
+                className: 'initially-unlimited',
+            });
+            expect(numberWithUnitInputUnlimited.displayValue).toEqual(ts.translate('vcd.cc.unlimited'));
+            numberWithUnitInputUnlimited.clickUnlimitedCheckbox();
+            expect(numberWithUnitInputUnlimited.selectedUnitDisplayValue).toEqual('MHz');
+        });
+
+        it('selects unlimited when the unlimited value is typed', fakeAsync(() => {
+            expect(numberWithUnitInput.displayValue).toEqual('');
+            numberWithUnitInput.typeInput('-1');
+            tick();
+            numberWithUnitInput.detectChanges();
+            expect(numberWithUnitInput.isInputValueFocused).toBe(true);
+            expect(numberWithUnitInput.displayValue).toEqual(
+                ts.translate(Hertz.Mhz.getValueWithUnitTranslationKey(), [-1])
+            );
+            numberWithUnitInput.blurInput();
+            tick();
+            numberWithUnitInput.detectChanges();
+            expect(numberWithUnitInput.isInputValueFocused).toBe(false);
+            expect(numberWithUnitInput.displayValue).toEqual(ts.translate('vcd.cc.unlimited'));
+        }));
     });
 
     describe('unitOptions', () => {
@@ -229,6 +255,17 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             numberWithUnitInput.detectChanges();
             expect(numberWithUnitInput.isInputFieldDisabled).toEqual(true);
             expect(numberWithUnitInput.isUnitDropdownDisabled).toEqual(true);
+        });
+
+        it('gives a null value when cleared', () => {
+            numberWithUnitInput.component.unlimitedValue = 0;
+            numberWithUnitInput.component.unitOptions = [Hertz.Mhz];
+            finder.detectChanges();
+            numberWithUnitInput.setInputValueUnit(Hertz.Mhz);
+            numberWithUnitInput.selectUnit(Hertz.Mhz);
+            numberWithUnitInput.textInputValue = null;
+            // Gave 0 before this fix
+            expect(numberWithUnitInput.formControl.value).toEqual(null);
         });
     });
 

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -239,6 +239,11 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
         this.unlimitedControlValue = unlimitedChecked;
         this.textInputValue = unlimitedChecked ? '' : this.lastRealValue?.toString() || '';
 
+        // If there is no unit currently selected, we need to writeValue to recalculate everything.
+        if (!this.unitsControlValue && !unlimitedChecked) {
+            this.writeValue(this.getValue());
+        }
+
         if (!unlimitedChecked) {
             // Usability requirements imply the focus to be on the input element when 'unlimited checkbox' is
             // deselected in order to be easier for the user to modify the value.
@@ -333,6 +338,15 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
         }
     }
 
+    /**
+     * Toggles the unlimited checkbox if the formValue is the unlimited value.
+     */
+    updateUnlimitedCheckbox() {
+        if (this.getValue() === this.unlimitedValue && !this.unlimitedControlValue) {
+            this.onUnlimitedCheckboxChange(true);
+        }
+    }
+
     private computeBestUnitAndValue(value: number): void {
         // Nothing to do when setting to unlimited
         if (this.isUnlimitedValue(value)) {
@@ -360,7 +374,7 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
 
         const value = this.textInputValue;
 
-        if (value === '') {
+        if (value === '' || value === null) {
             return null;
         }
 

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.widget-object.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.widget-object.ts
@@ -111,4 +111,16 @@ export class NumberWithUnitFormInputWidgetObject extends WidgetObject<NumberWith
     get singleUnitDisplayText(): string {
         return this.getText('.single-option');
     }
+
+    typeInput(value: string): void {
+        this.inputElement.value = value;
+        this.inputElement.dispatchEvent(new Event('input'));
+        this.inputElement.focus();
+        this.detectChanges();
+    }
+
+    blurInput(): void {
+        this.inputElement.dispatchEvent(new Event('blur'));
+        this.detectChanges();
+    }
 }

--- a/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.ts
+++ b/projects/examples/src/components/form-input/number-with-unit-form-input.example.component.ts
@@ -19,7 +19,7 @@ import {
     styleUrls: ['./number-with-unit-form-input.example.component.scss'],
     templateUrl: './number-with-unit-form-input.example.component.html',
 })
-export class NumberWithUnitFormInputExampleComponent implements AfterViewInit, OnDestroy {
+export class NumberWithUnitFormInputExampleComponent implements OnDestroy {
     formGroup: FormGroup;
     hertzOptions: Unit[] = [Hertz.Mhz, Hertz.Ghz];
     cpuSpeedFormControlValueUnit: Unit = Hertz.Mhz;
@@ -53,7 +53,7 @@ export class NumberWithUnitFormInputExampleComponent implements AfterViewInit, O
             readonly: new FormControl(false),
             disabled: new FormControl(false),
             memory: new FormControl(1024 * 2, [Validators.required, memoryValidator]),
-            cpuLimit: new FormControl(1500, [cpuValidator]),
+            cpuLimit: new FormControl(-1, [cpuValidator]),
         });
 
         this.subscriptionTracker.subscribe(this.formGroup.controls.disabled.valueChanges, (value) => {
@@ -65,10 +65,6 @@ export class NumberWithUnitFormInputExampleComponent implements AfterViewInit, O
                 this.formGroup.controls.memory.enable();
             }
         });
-    }
-
-    ngAfterViewInit(): void {
-        this.formGroup.controls.cpuLimit.setValue(-1);
     }
 
     ngOnDestroy(): void {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

1. Fixes a bug where if the unlimitedValue was 0, it was impossible to set the form as required. This is because null was passed through in `getValue()` outputting 0, which was the same as the unlimtedValue.
2. Fixes a bug where if the default value was unlimited, a unit was never calculated causing errors. 
3. Changes it so if the user types in the unlimited value, when the input is blurred, the checkbox will be checked.

## What manual testing did you do?
1. Typed in the unlimited value, blurred the input, observed the checkbox get checked
2. Set the unlimitedValue to 0 and observed a required error when I cleared the form.
3. Set the default to unlimited through the form control and observed a calculated unit on unselected the unlimited box.

## GIf

![number-with-unit](https://user-images.githubusercontent.com/7528512/114759542-4a8fec00-9d2c-11eb-8f05-55d13175f9e6.gif)


## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

## Other information
