### PR TITLE
Fix the styling issues of number with unit input

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix the styling of Number with unit input component such that the inputs inside the component take the available
+container width
 
 ### Fixed
 - The data exporter is now accessible from the keyboard.

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.scss
@@ -1,5 +1,4 @@
 .clr-control-container .clr-input {
-    width: 5rem;
     margin-right: 5px;
 }
 
@@ -23,8 +22,8 @@ input[type='number'] {
     }
 }
 
-.clr-form-control .clr-control-container {
-    width: auto;
+div.clr-select-wrapper {
+    width: auto; // The width is being set to 100% else where making this div grow wider than necessary
     flex: 0 1 auto;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Fix the width occupied by containing inputs of number with unit input
component so that they take up the container with and align with other
inputs.
Number with unit inputs are misaligned right now as mentioned in this bug: https://jira.eng.vmware.com/browse/VDUCC-526

## What manual testing did you do?
- Verified the `Create VM sizing policy` page to make sure that the number with unit inputs are aligned with other inputs
- Went to few other screens that use number with unit component and made sure they are aligned properly. Screenshots are attached below

## Screenshots (if applicable)
### **Before the change:**
![Screen Shot 2021-04-15 at 3 18 51 PM](https://user-images.githubusercontent.com/10735165/114926363-42a07c80-9dfe-11eb-8026-a2ff2c997bb0.png)

### **After the change:**
![Screen Shot 2021-04-15 at 9 23 10 AM](https://user-images.githubusercontent.com/10735165/114926305-2e5c7f80-9dfe-11eb-980a-9c3706c1d6c6.png)

###**Other screens:**
![Screen Shot 2021-04-15 at 3 26 05 PM](https://user-images.githubusercontent.com/10735165/114927711-c870f780-9dff-11eb-9771-75f4eabe5925.png)
![Screen Shot 2021-04-15 at 3 29 09 PM](https://user-images.githubusercontent.com/10735165/114927716-c9098e00-9dff-11eb-8f1d-49a7ec6e3d84.png)
![Screen Shot 2021-04-15 at 3 28 12 PM](https://user-images.githubusercontent.com/10735165/114927717-c9098e00-9dff-11eb-856c-b5294287ac8d.png)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No