### PR TITLE
Add optional icons next to quick search titles

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-dev.15]
+### Changed
+- Quick search sections can now have icons.
 ### Fixed
 - A bug in the number with unit where if unlimited was disabled but the user types "-1", the whole form would become disabled
 ## [2.0.0-dev.14]

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.14",
+    "version": "2.0.0-dev.15",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -23,7 +23,7 @@ vcd.cc.friendly.names.hint=User friendly column headers or object field names?
 vcd.cc.export.all=Export All Columns
 vcd.cc.exporter.downloading=Downloading...
 vcd.cc.exporter.writing=Writing File...
-vcd.cc.quickSearch.partialResultNotation=({lastItem} of {totalItems})
+vcd.cc.quickSearch.partialResultTitle={title} ({lastItem} of {totalItems})
 vcd.cc.quickSearch.refineQuery=The search shows a maximum of {max} results. Refine your query to improve the accuracy.
 vcd.cc.quickSearch.noResults=No results found.
 

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -1,3 +1,21 @@
+<ng-template #sectionTitle let-searchSection>
+    <clr-icon *ngIf="searchSection.icon" [attr.shape]="searchSection.icon" size="20"> </clr-icon>
+    <div *ngIf="searchSection.hasPartialResult; let partial; else: partial">
+        {{
+            'vcd.cc.quickSearch.partialResultTitle'
+                | translate
+                    : {
+                          title: searchSection.provider.sectionName,
+                          lastItem: partial.lastItem,
+                          totalItems: partial.totalItems
+                      }
+        }}
+    </div>
+    <ng-template #partial>
+        {{ searchSection.provider.sectionName }}
+    </ng-template>
+</ng-template>
+
 <ng-template let-searchSection #searchSectionTemplate>
     <div *ngIf="searchSection.isLoading">
         <div class="spinner spinner-inline" [attr.data-ui]="DataUi.spinner"></div>
@@ -72,10 +90,7 @@
                 class="search-result-section-title"
                 [attr.data-ui]="DataUi.searchResultSectionTitles"
             >
-                {{ searchSection.provider.sectionName }}
-                <span *ngIf="searchSection.hasPartialResult; let partial" class="partial-result">
-                    {{ 'vcd.cc.quickSearch.partialResultNotation' | translate: partial }}
-                </span>
+                <ng-container *ngTemplateOutlet="sectionTitle; context: { $implicit: searchSection }"> </ng-container>
             </h5>
             <ng-container *ngTemplateOutlet="searchSectionTemplate; context: { $implicit: searchSection }">
             </ng-container>
@@ -97,10 +112,8 @@
                     class="p2 search-result-section-title search-result-section section-index-{{ n }}-{{ i }}"
                     [attr.data-ui]="DataUi.searchResultSectionTitles"
                 >
-                    {{ searchSection.provider.sectionName }}
-                    <span *ngIf="searchSection.hasPartialResult; let partial" class="partial-result">
-                        {{ 'vcd.cc.quickSearch.partialResultNotation' | translate: partial }}
-                    </span>
+                    <ng-container *ngTemplateOutlet="sectionTitle; context: { $implicit: searchSection }">
+                    </ng-container>
                 </p>
                 <ng-container *ngTemplateOutlet="searchSectionTemplate; context: { $implicit: searchSection }">
                 </ng-container>

--- a/projects/components/src/quick-search/quick-search.component.scss
+++ b/projects/components/src/quick-search/quick-search.component.scss
@@ -46,10 +46,6 @@
             margin-top: 0;
         }
 
-        .partial-result {
-            color: var(--clr-color-neutral-500);
-        }
-
         .no-results {
             color: var(--clr-color-neutral-500);
             font-style: italic;

--- a/projects/components/src/quick-search/quick-search.component.ts
+++ b/projects/components/src/quick-search/quick-search.component.ts
@@ -31,6 +31,7 @@ interface SearchSection {
     isLoading: boolean;
     shouldShowText: boolean;
     hasPartialResult: PartialResult;
+    icon?: string;
 }
 
 /**
@@ -505,6 +506,7 @@ export class QuickSearchComponent {
             isLoading: true,
             shouldShowText: true,
             hasPartialResult: undefined,
+            icon: provider.icon,
         }));
         this.groupedSearchSections = this.searchService.getRegisteredNestedProviders(activeFilters).map((section) => {
             return {
@@ -515,6 +517,7 @@ export class QuickSearchComponent {
                     isLoading: true,
                     shouldShowText: true,
                     hasPartialResult: undefined,
+                    icon: provider.icon,
                 })),
             };
         });

--- a/projects/components/src/quick-search/quick-search.provider.ts
+++ b/projects/components/src/quick-search/quick-search.provider.ts
@@ -72,6 +72,11 @@ export interface QuickSearchProvider {
      * Says whether this provider can return results with the given filter applied.
      */
     canHandleFilter?(filter: ActiveQuickSearchFilter): boolean;
+
+    /**
+     * The icon that is displayed next to the search section title. This is the shape property put into the clr-icon.
+     */
+    icon?: string;
 }
 
 export abstract class QuickSearchProviderDefaults implements QuickSearchProvider {

--- a/projects/components/src/quick-search/quick-search.wo.ts
+++ b/projects/components/src/quick-search/quick-search.wo.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { BaseWidgetObject } from '../utils/test/widget-object/widget-object';
+import { BaseWidgetObject, FindElementOptions } from '../utils/test/widget-object/widget-object';
 import { DataUi } from './quick-search.dataui';
 
 const QUICK_SEARCH_CURRENT_RESULT = '.selected';
@@ -24,10 +24,12 @@ export class QuickSearchWo<T> extends BaseWidgetObject<T> {
      */
     getInput = this.factory.dataUi(DataUi.searchInput);
 
+    _getSearchResultSectionTitles = this.internalFactory.dataUi(DataUi.searchResultSectionTitles);
+
     /**
      * Returns the titles of all sections appearing in the search results
      */
-    getSearchResultSectionTitles = this.factory.dataUi(DataUi.searchResultSectionTitles);
+    getSearchResultSectionTitles = this.factory.unwrap(this._getSearchResultSectionTitles);
 
     /**
      * Returns each search result item in each section
@@ -68,4 +70,10 @@ export class QuickSearchWo<T> extends BaseWidgetObject<T> {
      * Returns the element that represents the bottom of the search results
      */
     getBottomOfResults = this.factory.css('.bottom-of-results');
+
+    /**
+     * Gives the icon next to each section title.
+     */
+    getTitleIcons = (options?: FindElementOptions) =>
+        this._getSearchResultSectionTitles(options).get('clr-icon').unwrap();
 }

--- a/projects/components/src/utils/test/widget-object/angular/angular-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/angular/angular-widget-object-element.ts
@@ -172,6 +172,13 @@ export class TestElement implements Iterable<TestElement> {
     }
 
     /**
+     * Gives all attributes on this element.
+     */
+    attributes(): NamedNodeMap {
+        return this.firstNativeElement.attributes;
+    }
+
+    /**
      * Says if this element is enabled.
      */
     enabled(): boolean {

--- a/projects/examples/src/components/quick-search/nested-providers/quick-search-nested-providers.example.component.ts
+++ b/projects/examples/src/components/quick-search/nested-providers/quick-search-nested-providers.example.component.ts
@@ -20,10 +20,10 @@ import {
 export class QuickSearchNestedProvidersExampleComponent implements OnInit {
     spotlightOpen: boolean;
 
-    private actionsSearchProvider = new ActionsSearchProvider('actions1');
-    private actionsSearchProvider2 = new ActionsSearchProvider('actions2');
-    private actionsSearchProvider3 = new ActionsSearchProvider('actions3');
-    private actionsSearchProvider4 = new ActionsSearchProvider('actions4');
+    private actionsSearchProvider = new ActionsSearchProvider('actions1', false, 'home');
+    private actionsSearchProvider2 = new ActionsSearchProvider('actions2', false, 'organization');
+    private actionsSearchProvider3 = new ActionsSearchProvider('actions3', false);
+    private actionsSearchProvider4 = new ActionsSearchProvider('actions4', false, 'clipboard');
 
     constructor(private searchRegistrar: QuickSearchRegistrarService) {}
 
@@ -56,7 +56,7 @@ export class ActionsSearchProvider extends QuickSearchProviderDefaults {
 
     private actions: QuickSearchResultItem[];
 
-    constructor(public id: string, public shouldDebounceInput = false) {
+    constructor(public id: string, public shouldDebounceInput = false, public icon?: string) {
         super(shouldDebounceInput);
 
         // Build actions


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Adds icons next to quick search section titles.

## What manual testing did you do?
1. Linked to VCD, searched for "a" and observed the following results:
2. 
![quick-search-icons](https://user-images.githubusercontent.com/7528512/115063899-31b54100-9eba-11eb-8c5c-daeb91270c4f.gif)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No