### PR TITLE
Make labels on large modals take 1/4th of container space 

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.0.0-dev.12]
 ### Changed
+- Responsive input directive now allocates 1/4th of the container space for input field labels on large modals
 - Make the buttonContents property as optional for inline display configuration of contextual actions
 - Make the position property as optional for display configuration of contextual actions in datagrid
 

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.11",
+    "version": "2.0.0-dev.12",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/lib/directives/responsive-input/responsive-input.directive.spec.ts
+++ b/projects/components/src/lib/directives/responsive-input/responsive-input.directive.spec.ts
@@ -13,7 +13,7 @@ interface Test {
 }
 
 describe('ResponsiveInputDirective', () => {
-    beforeEach(async function(this: Test): Promise<void> {
+    beforeEach(async function (this: Test): Promise<void> {
         await TestBed.configureTestingModule({
             declarations: [TestHostComponent],
             imports: [ResponsiveInputDirectiveModule],
@@ -21,38 +21,38 @@ describe('ResponsiveInputDirective', () => {
         this.fixture = TestBed.createComponent(TestHostComponent);
     });
 
-    it('adds clr-row to input wrapper', function(this: Test): void {
+    it('adds clr-row to input wrapper', function (this: Test): void {
         this.fixture.detectChanges();
         const helper = new TestHelper(this.fixture);
         expect(helper.rootHasClass('clr-row')).toBe(true, 'clr-row was not added to form control');
     });
 
-    it('adds clr-col-12 and clr-col-md-2 to label', function(this: Test): void {
+    it('adds clr-col-12 and clr-col-md-3 to label', function (this: Test): void {
         this.fixture.detectChanges();
         const helper = new TestHelper(this.fixture);
         expect(helper.labelHasClass('clr-col-12')).toBe(true, 'clr-col-12 was not added to control label');
-        expect(helper.labelHasClass('clr-col-md-2')).toBe(true, 'clr-md-2 was not added to control label');
+        expect(helper.labelHasClass('clr-col-md-3')).toBe(true, 'clr-md-3 was not added to control label');
     });
 
-    it('adds clr-col-12 and clr-col-md-10 to input', function(this: Test): void {
+    it('adds clr-col-12 and clr-col-md-9 to input', function (this: Test): void {
         this.fixture.detectChanges();
         const helper = new TestHelper(this.fixture);
         expect(helper.inputHasClass('clr-col-12')).toBe(true, 'clr-col-12 was not added to control label');
-        expect(helper.inputHasClass('clr-col-md-10')).toBe(true, 'clr-md-10 was not added to control label');
+        expect(helper.inputHasClass('clr-col-md-9')).toBe(true, 'clr-md-9 was not added to control label');
     });
 
-    it('does not throw an error if label is missing', function(this: Test): void {
+    it('does not throw an error if label is missing', function (this: Test): void {
         this.fixture.componentInstance.showLabel = false;
         expect(() => this.fixture.detectChanges()).not.toThrow();
     });
 
-    it('does not throw an error if input container is missing', function(this: Test): void {
+    it('does not throw an error if input container is missing', function (this: Test): void {
         this.fixture.componentInstance.showInput = false;
         expect(() => this.fixture.detectChanges()).not.toThrow();
     });
 
     describe('disabled', () => {
-        it('does not add classes if disabled', function(this: Test): void {
+        it('does not add classes if disabled', function (this: Test): void {
             this.fixture.componentInstance.disabled = true;
             this.fixture.detectChanges();
             const helper = new TestHelper(this.fixture);

--- a/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
+++ b/projects/components/src/lib/directives/responsive-input/responsive-input.directive.ts
@@ -5,7 +5,7 @@
 
 import { AfterViewChecked, Directive, ElementRef, HostBinding, Input } from '@angular/core';
 
-type ColSize = '2' | '4' | '8' | '10';
+type ColSize = '3' | '4' | '8' | '9';
 
 export interface ResponsiveInputOptions {
     disabled: boolean;
@@ -55,7 +55,7 @@ export class ResponsiveInputDirective implements AfterViewChecked {
         if (newElementWidth) {
             this.elementWidth = newElementWidth;
             const [labelWidth, containerWidth]: ColSize[] =
-                this.elementWidth < this.breakPoint ? ['4', '8'] : ['2', '10'];
+                this.elementWidth < this.breakPoint ? ['4', '8'] : ['3', '9'];
             this.applyClasses('label', labelWidth);
             this.applyClasses('container', containerWidth);
         }
@@ -64,7 +64,7 @@ export class ResponsiveInputDirective implements AfterViewChecked {
     private applyClasses(className: 'label' | 'container', mdSize: ColSize): void {
         const el = this.el.nativeElement.querySelector(`:scope > .clr-control-${className}`);
         if (el) {
-            el.classList.remove('clr-col-12', 'clr-col-md-2', 'clr-col-md-4', 'clr-col-md-8', 'clr-col-md-10');
+            el.classList.remove('clr-col-12', 'clr-col-md-3', 'clr-col-md-4', 'clr-col-md-8', 'clr-col-md-9');
             el.classList.add('clr-col-12', `clr-col-md-${mdSize}`);
         }
     }


### PR DESCRIPTION
This PR also introduces a change to mark button contents as optional for inline display config of contextual actions.

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
On large modals, most of the labels that are not very long are wrapping because of allocating the only 1/6th of the container space. In this change, the `ResponsiveInputDirective` is changed to allocate 1/4th of the space to avoid wrapping of labels.

## What manual testing did you do?
Tested the input labels on large modals in the following screens on Vcd UI: Notice that some of the labels on the left side of the following screenshots are not wrapping to a new line.

## Screenshots (if applicable)
![Screen Shot 2021-04-19 at 6 53 19 PM](https://user-images.githubusercontent.com/10735165/115318417-b2d73700-a14b-11eb-8468-a5b7c261bcd0.png)

![Screen Shot 2021-04-19 at 6 50 10 PM](https://user-images.githubusercontent.com/10735165/115318562-f893ff80-a14b-11eb-8c37-0a4c3a7475b9.png)

![Screen Shot 2021-04-19 at 6 46 26 PM](https://user-images.githubusercontent.com/10735165/115318539-ee720100-a14b-11eb-88d6-56d3125fc7a5.png)

![Screen Shot 2021-04-19 at 6 07 47 PM](https://user-images.githubusercontent.com/10735165/115318618-119cb080-a14c-11eb-9bf7-8cfd5ab31fba.png)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
