### PR TITLE
Removes calls to grid.organizer.resize()

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -1029,12 +1029,6 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
             this.changeDetectorRef.detectChanges();
         }
 
-        this.datagrid.items.change.subscribe(() => {
-            if (this.datagrid.items.displayed.length > 0) {
-                (this.datagrid as any).organizer.resize();
-            }
-        });
-
         this.columnsUpdated.subscribe(() => {
             this.datagrid.columns.reset(this.datagrid.columns.toArray());
         });


### PR DESCRIPTION
Signed-off-by: Ryan Bradford <bradfordr@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [X] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

In Clarity 3, there was a bug where when Ivy was disabled, filtering the grid could cause the rows to disappear. The workaround was to call grid.organizer.resize(). This is no longer needed, as Clarity 4 fixes this bug.

## What manual testing did you do?

Navigated to organizations page, applied filter, removed filter, observed rows

## Screenshots (if applicable)

![orgs-list](https://user-images.githubusercontent.com/7528512/115411729-ba392780-a1c1-11eb-9d00-f93b45aeaf5c.gif)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

## Other information
