### PR TITLE
Mark some action display config interface props as optional

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 - Make the buttonContents property as optional for inline display configuration of contextual actions
 - Make the position property as optional for display configuration of contextual actions in datagrid
 

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Make the buttonContents property as optional for inline display configuration of contextual actions
+- Make the position property as optional for display configuration of contextual actions in datagrid
 
 ## [2.0.0-dev.11]
 ### Changed

--- a/projects/components/src/action-menu/action-menu.component.spec.ts
+++ b/projects/components/src/action-menu/action-menu.component.spec.ts
@@ -107,6 +107,15 @@ describe('ActionMenuComponent', () => {
                 );
             }
         );
+        it('default value of buttonContents is TEXT when it is not set', function (this: HasFinderAndActionMenu) {
+            this.actionMenu.actionDisplayConfig = {
+                contextual: {
+                    styling: ActionStyling.INLINE,
+                },
+            };
+            this.finder.detectChanges();
+            expect(this.actionMenu.actionDisplayConfig.contextual.buttonContents).toEqual(TextIcon.TEXT);
+        });
     });
     it('get staticActions returns only the actions that are marked as static', function (this: HasFinderAndActionMenu): void {
         this.actionMenu.actions = [...STATIC_ACTIONS].concat([...CONTEXTUAL_FEATURED_ACTIONS]);

--- a/projects/components/src/common/interfaces/action-item.interface.ts
+++ b/projects/components/src/common/interfaces/action-item.interface.ts
@@ -180,9 +180,9 @@ export interface ContextualActionInlineDisplayConfig {
     styling: ActionStyling.INLINE;
     /**
      * If the title should be the button label, icon, or both
-     * Defaults to ICON if unset.
+     * Defaults to {@link TextIcon.TEXT} when unset
      */
-    buttonContents: TextIcon;
+    buttonContents?: TextIcon;
 }
 
 /**

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -1058,7 +1058,13 @@ describe('DatagridComponent', () => {
             it('is not available when there are contextual actions to be displayed in the row', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
                 this.hostComponent.selectionType = GridSelectionType.Single;
-                this.hostComponent.actionDisplayConfig.contextual.position = DatagridContextualActionPosition.ROW;
+                this.hostComponent.actionDisplayConfig = {
+                    contextual: {
+                        ...this.hostComponent.actionDisplayConfig.contextual,
+                        position: DatagridContextualActionPosition.ROW,
+                    },
+                    staticActionStyling: this.hostComponent.actionDisplayConfig.staticActionStyling,
+                };
                 this.hostComponent.actions = [
                     {
                         textKey: 'contextual.action',

--- a/projects/components/src/datagrid/interfaces/datagrid-action-display.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-action-display.interface.ts
@@ -17,8 +17,9 @@ import { DatagridContextualActionPosition } from '../datagrid.component';
 interface DatagridContextualActionDropdownDisplayConfig extends ContextualActionDropdownDisplayConfig {
     /**
      * An enum that describes where the contextual buttons should display.
+     * If not specified, this defaults to {@link DatagridContextualActionPosition.TOP}
      */
-    position: DatagridContextualActionPosition;
+    position?: DatagridContextualActionPosition;
 }
 
 /**
@@ -28,8 +29,9 @@ interface DatagridContextualActionDropdownDisplayConfig extends ContextualAction
 interface DatagridContextualActionInlineDisplayConfig extends ContextualActionInlineDisplayConfig {
     /**
      * An enum that describes where the contextual buttons should display.
+     * If not specified, this defaults to {@link DatagridContextualActionPosition.TOP}
      */
-    position: DatagridContextualActionPosition;
+    position?: DatagridContextualActionPosition;
 }
 
 /**
@@ -62,5 +64,8 @@ export function getDefaultDatagridActionDisplayConfig(
         },
         staticActionStyling: ActionStyling.INLINE,
     };
-    return { ...defaults, ...cfg };
+    return {
+        contextual: { ...defaults.contextual, ...cfg.contextual },
+        staticActionStyling: cfg.staticActionStyling || defaults.staticActionStyling,
+    };
 }


### PR DESCRIPTION
Signed-off-by: ps37 <prudhvi.af121@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
It does the following:
- Make the buttonContents property optional for inline display configuration of contextual actions
- Make the position property optional for display configuration of contextual actions in data grid

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
