### PR TITLE
ActionDisplayConfig of ActionMenuComponent accepts featuredCount only when the actions are displayed inline

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.0.0-dev.13]
+### Changed
+- BREAKING: ActionDisplayConfig of ActionMenuComponent accepts featuredCount property only when the actions are displayed
+inline
+
 ## [2.0.0-dev.12]
 ### Changed
 - Responsive input directive now allocates 1/4th of the container space for input field labels on large modals

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.12",
+    "version": "2.0.0-dev.13",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.spec.ts
+++ b/projects/components/src/action-menu/action-menu.component.spec.ts
@@ -11,7 +11,7 @@ import {
     ActionItem,
     ActionStyling,
     ActionType,
-    ContextualActionDropdownDisplayConfig,
+    ContextualActionInlineDisplayConfig,
     TextIcon,
 } from '../common/interfaces/index';
 import { WidgetFinder, WidgetObject } from '../utils/test/widget-object';
@@ -73,7 +73,7 @@ describe('ActionMenuComponent', () => {
             this.actionMenu.actionDisplayConfig = { ...ACTION_DISPLAY_CONFIG };
             this.finder.detectChanges();
             const actionDisplayConfig = this.actionMenu.actionDisplayConfig;
-            expect((actionDisplayConfig.contextual as ContextualActionDropdownDisplayConfig).featuredCount).toEqual(2);
+            expect((actionDisplayConfig.contextual as ContextualActionInlineDisplayConfig).featuredCount).toEqual(2);
             expect(actionDisplayConfig.contextual.styling).toEqual(ActionStyling.DROPDOWN);
             expect(actionDisplayConfig.contextual.buttonContents).toEqual(TextIcon.ICON);
             expect(actionDisplayConfig.staticActionStyling).toEqual(ActionStyling.DROPDOWN);
@@ -156,12 +156,13 @@ describe('ActionMenuComponent', () => {
             });
         });
         it('does not return an action list with more items than featuredCount', function (this: HasFinderAndActionMenu): void {
-            const ACTION_DISPLAY_CONFIG_WITH_ONE_FEATURED = {
-                contextual: { ...ACTION_DISPLAY_CONFIG.contextual },
+            this.actionMenu.actionDisplayConfig = {
+                contextual: {
+                    featuredCount: 1,
+                    styling: ActionStyling.INLINE,
+                },
                 staticActionStyling: ACTION_DISPLAY_CONFIG.staticActionStyling,
             };
-            ACTION_DISPLAY_CONFIG_WITH_ONE_FEATURED.contextual.featuredCount = 1;
-            this.actionMenu.actionDisplayConfig = ACTION_DISPLAY_CONFIG_WITH_ONE_FEATURED;
             this.finder.detectChanges();
             const availableContextualFeaturedActions = this.actionMenu.contextualFeaturedActions;
             expect(CONTEXTUAL_FEATURED_ACTIONS.length).toEqual(3);

--- a/projects/components/src/action-menu/action-menu.component.ts
+++ b/projects/components/src/action-menu/action-menu.component.ts
@@ -21,7 +21,6 @@ import { CommonUtil } from '../utils';
 export function getDefaultActionDisplayConfig(cfg: ActionDisplayConfig = {}): ActionDisplayConfig {
     const defaults = {
         contextual: {
-            featuredCount: 0,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },
@@ -363,7 +362,7 @@ export class ActionMenuComponent<R, T> {
         const flattenedFeaturedActionList = this.getFlattenedActionList(this._actions, ActionType.CONTEXTUAL_FEATURED);
         const availableFeaturedActions = this.getAvailableActions(flattenedFeaturedActionList);
         const featuredCount =
-            this.actionDisplayConfig.contextual.styling === ActionStyling.DROPDOWN &&
+            this.actionDisplayConfig.contextual.styling === ActionStyling.INLINE &&
             this.actionDisplayConfig.contextual.featuredCount;
         return featuredCount ? availableFeaturedActions.slice(0, featuredCount) : availableFeaturedActions;
     }

--- a/projects/components/src/common/interfaces/action-item.interface.ts
+++ b/projects/components/src/common/interfaces/action-item.interface.ts
@@ -151,14 +151,6 @@ export enum TextIcon {
  */
 export interface ContextualActionDropdownDisplayConfig {
     /**
-     * How many buttons should display on the featured section.
-     *
-     * Used when you want to set a limit on the number of featured buttons shown.
-     *
-     * If featuredCount is not set, it will default to all featured actions.
-     */
-    featuredCount?: number;
-    /**
      * To display actions in a dropdown
      */
     styling: ActionStyling.DROPDOWN;
@@ -174,6 +166,14 @@ export interface ContextualActionDropdownDisplayConfig {
  * {@link ActionDisplayConfig.contextual}
  */
 export interface ContextualActionInlineDisplayConfig {
+    /**
+     * How many buttons should display on the featured section.
+     *
+     * Used when you want to set a limit on the number of featured buttons shown.
+     *
+     * If featuredCount is not set, it will default to all featured actions.
+     */
+    featuredCount?: number;
     /**
      * To display actions in a inline horizontal ribbon
      */

--- a/projects/components/src/datagrid/interfaces/datagrid-action-display.interface.ts
+++ b/projects/components/src/datagrid/interfaces/datagrid-action-display.interface.ts
@@ -57,8 +57,7 @@ export function getDefaultDatagridActionDisplayConfig(
 ): DatagridActionDisplayConfig {
     const defaults = {
         contextual: {
-            styling: ActionStyling.DROPDOWN,
-            featuredCount: 2,
+            styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
             position: DatagridContextualActionPosition.TOP,
         },

--- a/projects/examples/src/app/components/action-menu/contextual-actions/action-menu-contextual-actions-example.component.html
+++ b/projects/examples/src/app/components/action-menu/contextual-actions/action-menu-contextual-actions-example.component.html
@@ -30,7 +30,7 @@
     <h4 class="example-heading">Featured count</h4>
     <p>
         When displayed inline, The number of contextual featured actions to be shown is customizable using the
-        ActionDisplayConfig.contextual.featuredCount property. In the example below, although there are 2 featured
+        ActionDisplayConfig.contextual.featuredCount property. In the example below, although there are 3 featured
         actions, only one is displayed outside the dropdown because, the featured count is set to 1
     </p>
     <vcd-action-menu

--- a/projects/examples/src/app/components/action-menu/contextual-actions/action-menu-contextual-actions-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/contextual-actions/action-menu-contextual-actions-example.component.ts
@@ -77,13 +77,13 @@ export class ActionMenuContextualActionsExampleComponent {
     };
     dropdownActionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 2,
             styling: ActionStyling.DROPDOWN,
             buttonContents: TextIcon.TEXT,
         },
     };
     featuredCountActionDisplayConfig: ActionDisplayConfig = {
         contextual: {
+            featuredCount: 1,
             styling: ActionStyling.INLINE,
             buttonContents: TextIcon.TEXT,
         },

--- a/projects/examples/src/app/components/action-menu/with-separators/action-menu-with-separators.example.component.ts
+++ b/projects/examples/src/app/components/action-menu/with-separators/action-menu-with-separators.example.component.ts
@@ -36,7 +36,6 @@ export class ActionMenuWithSeparatorsExampleComponent {
     ];
     actionDisplayConfig: ActionDisplayConfig = {
         contextual: {
-            featuredCount: 0,
             styling: ActionStyling.DROPDOWN,
             buttonContents: TextIcon.TEXT,
         },

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -12,6 +12,7 @@ import {
     DatagridActionDisplayConfig,
     DatagridComponent,
     DatagridContextualActionPosition,
+    getDefaultDatagridActionDisplayConfig,
     GridColumn,
     GridDataFetchResult,
     GridSelectionType,
@@ -153,23 +154,22 @@ export class DatagridLinkExampleComponent<R extends Record> {
         },
     ];
 
-    actionDisplayConfig: DatagridActionDisplayConfig = {
-        contextual: {
-            styling: ActionStyling.INLINE,
-            buttonContents: TextIcon.TEXT,
-            position: DatagridContextualActionPosition.TOP,
-        },
-        staticActionStyling: ActionStyling.INLINE,
-    };
+    actionDisplayConfig: DatagridActionDisplayConfig = getDefaultDatagridActionDisplayConfig();
 
     selectionType = GridSelectionType.Single;
 
     changeActionLocation(): void {
         if (this.actionDisplayConfig.contextual.position === DatagridContextualActionPosition.TOP) {
-            this.actionDisplayConfig.contextual.position = DatagridContextualActionPosition.ROW;
+            this.actionDisplayConfig = {
+                contextual: {
+                    ...getDefaultDatagridActionDisplayConfig().contextual,
+                    position: DatagridContextualActionPosition.ROW,
+                },
+                staticActionStyling: getDefaultDatagridActionDisplayConfig().staticActionStyling,
+            };
             this.selectionType = GridSelectionType.None;
         } else {
-            this.actionDisplayConfig.contextual.position = DatagridContextualActionPosition.TOP;
+            this.actionDisplayConfig = getDefaultDatagridActionDisplayConfig();
             this.selectionType = GridSelectionType.Single;
         }
     }
@@ -188,7 +188,6 @@ export class DatagridLinkExampleComponent<R extends Record> {
 
     changeContextualActionStyling(): void {
         this.actionDisplayConfig = {
-            ...this.actionDisplayConfig,
             contextual: {
                 ...this.actionDisplayConfig.contextual,
                 styling:
@@ -196,6 +195,7 @@ export class DatagridLinkExampleComponent<R extends Record> {
                         ? (ActionStyling.INLINE as any)
                         : ActionStyling.DROPDOWN,
             },
+            staticActionStyling: this.actionDisplayConfig.staticActionStyling,
         };
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
ActionDisplayConfig of ActionMenuComponent does not accept featuredCount when actions are displayed in a dropdown as there is no way to display featured actions separately in a dropdown

## What manual testing did you do?
**Testing Done:**
Tested the following examples to make sure that the contextual actions are rendered without any errors:
ActionMenuContextualActionsExampleComponent
ActionMenuStaticAndContextualActionsExampleComponent

Tested the DatagridLinkExampleComponent to make sure that the actions are displayed in the following configurations:
In rows and as inline bars
In rows and as dropdowns
On top and as inline bar

## Screenshots (if applicable)

https://user-images.githubusercontent.com/10735165/115462891-30a54c00-a1f9-11eb-9a3d-85d53fcc77fb.mov

## Does this PR introduce a breaking change?

-   [X] Yes
-   [ ] No

The places where the featured count is being passed for dropdown display configuration, now have to be corrected by deleting that property
