### PR TITLE
Optimize ActionMenuComponent for less processing on input change

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0-dev.16]
 ### Added
 - New unit tests to ensure datagridSelection returns same reference
+### Changed
+- Optimize ActionMenuComponent for less processing on input change
 
 ## [2.0.0-dev.15]
 ### Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.15",
+    "version": "2.0.0-dev.16",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.spec.ts
+++ b/projects/components/src/action-menu/action-menu.component.spec.ts
@@ -350,20 +350,115 @@ describe('ActionMenuComponent', () => {
     });
 
     describe('actionsUpdate', () => {
-        it('emits event when actions input has changed', function (this: HasFinderAndActionMenu): void {
-            const spy = createSpy('actionsUpdate');
-            this.actionMenu.actionsUpdate.subscribe(spy);
-            this.actionMenu.actions = [];
-            this.finder.detectChanges();
-            expect(spy).toHaveBeenCalledTimes(1);
+        describe('with regards to actions input', () => {
+            it('emits event when actions input is provided with non empty array', function (this: HasFinderAndActionMenu): void {
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.actions = [...CONTEXTUAL_ACTIONS];
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
+
+            it('does not emit event when actions input is provided with an empty array', function (this: HasFinderAndActionMenu): void {
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.actions = [];
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(0);
+            });
+
+            it('does not emit twice when actions input has changed with the same array', function (this: HasFinderAndActionMenu): void {
+                const actions = [...CONTEXTUAL_ACTIONS];
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.actions = actions;
+                this.finder.detectChanges();
+                this.actionMenu.actions = actions;
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
+
+            it('does not emit event when actions input is null which is handled as an empty array', function (this: HasFinderAndActionMenu): void {
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.actions = [];
+                this.finder.detectChanges();
+                this.actionMenu.actions = null;
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(0);
+            });
+
+            it('does not emit twice when actions input has changed with an array containing same item references', function (this: HasFinderAndActionMenu): void {
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.actions = [...CONTEXTUAL_ACTIONS];
+                this.finder.detectChanges();
+                this.actionMenu.actions = [...CONTEXTUAL_ACTIONS];
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
+
+            it('emits event when actions input has changed with an array containing same items but different references', function (this: HasFinderAndActionMenu): void {
+                const action = CONTEXTUAL_ACTIONS[0];
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.actions = [action];
+                this.finder.detectChanges();
+                this.actionMenu.actions = [{ ...action }];
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(2);
+            });
         });
-        it('emits event when selectedEntities input has changed', function (this: HasFinderAndActionMenu): void {
-            const spy = createSpy('actionsUpdate');
-            this.actionMenu.actionsUpdate.subscribe(spy);
-            this.actionMenu.actions = [];
-            this.actionMenu.selectedEntities = [];
-            this.finder.detectChanges();
-            expect(spy).toHaveBeenCalledTimes(2);
+
+        describe('with regards to selectedEntities input', () => {
+            it('emits event when selectedEntities input is provided with non empty array', function (this: HasFinderAndActionMenu): void {
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.selectedEntities = [{ value: 'foo', paused: false }];
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
+
+            it('does not emit event when selectedEntities input is provided with an empty array', function (this: HasFinderAndActionMenu): void {
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.selectedEntities = [];
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(0);
+            });
+
+            it('does not emit twice when selectedEntities input has changed with the same array', function (this: HasFinderAndActionMenu): void {
+                const selectedEntities = [{ value: 'foo', paused: false }];
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.selectedEntities = selectedEntities;
+                this.finder.detectChanges();
+                this.actionMenu.selectedEntities = selectedEntities;
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
+
+            it('does not emit twice when selectedEntities input has changed with an array containing same item references', function (this: HasFinderAndActionMenu): void {
+                const selectedEntity = { value: 'foo', paused: false };
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.selectedEntities = [selectedEntity];
+                this.finder.detectChanges();
+                this.actionMenu.selectedEntities = [selectedEntity];
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
+
+            it('emits event when selectedEntities input has changed with an array containing same items but different references', function (this: HasFinderAndActionMenu): void {
+                const selectedEntity = { value: 'foo', paused: false };
+                const spy = createSpy('actionsUpdate');
+                this.actionMenu.actionsUpdate.subscribe(spy);
+                this.actionMenu.selectedEntities = [selectedEntity];
+                this.finder.detectChanges();
+                this.actionMenu.selectedEntities = [{ ...selectedEntity }];
+                this.finder.detectChanges();
+                expect(spy).toHaveBeenCalledTimes(2);
+            });
         });
     });
 
@@ -399,7 +494,7 @@ interface Blah {
 type HandlerData = Record[] | Blah;
 
 @Component({
-    template: ` <vcd-action-menu> </vcd-action-menu> `,
+    template: ` <vcd-action-menu></vcd-action-menu> `,
 })
 class TestHostComponent<R extends Record> {}
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [x] Other... Please describe: Optimization

## What does this change do?
Currently on any reference input change for `actions` and `selectedEntities`
the component is doing redundant computations and emits `actionsUpdate`
even though there is no actual change.

This input reference change can be as simple as just another empty array `[]`.
There are other cases when the `selectedEntities` are wrongly provided by a getter:
get selectedEntities() {
  return [this.currentSelection];
}
in these cases also there is no actual change, but angular will call the getter
from the template on every digest cycle, the getter will return a new reference
which will lead to performing all those calculations, emitting `actionsUpdate`
and all the subsequent calculations in the corresponding subscribers.

Although it is not good to use a function (the getter in this case) within a template
we are developing a library and cannot control every aspect of how
this library is going to be called that's why we'd like to make it as rigid as possible

For that purpose, this CLN is introducing a shallowEqual comparison for those
two inputs: `actions` and `selectedEntities` and this does quite much of
optimizations

## What manual testing did you do?

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
