### PR TITLE
Fixes bug with selecting unlimited in the number with unit

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- A bug in the number with unit where if unlimited was disabled but the user types "-1", the whole form would become disabled
 ## [2.0.0-dev.14]
 ### Added
 - Quick-search widget object

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -65,6 +65,16 @@ const [MIN, MAX] = [1000, 10000];
             class="no-given-units"
         >
         </vcd-number-with-unit-form-input>
+        <vcd-number-with-unit-form-input
+            [formControl]="cpuLimit"
+            [label]="'cpu.limit' | translate"
+            [unitOptions]="hertzOptions"
+            [inputValueUnit]="formControlValueUnit"
+            [showUnlimitedOption]="false"
+            [description]="'sizingPolicies.form.cpuLimit.description' | translate"
+            class="no-unlimited"
+        >
+        </vcd-number-with-unit-form-input>
     `,
 })
 export class TestHostComponent {
@@ -148,7 +158,7 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             expect(numberWithUnitInputUnlimited.selectedUnitDisplayValue).toEqual('MHz');
         });
 
-        it('selects unlimited when the unlimited value is typed', fakeAsync(() => {
+        it('selects unlimited when the unlimited value is typed if unlimited is enabled', fakeAsync(() => {
             expect(numberWithUnitInput.displayValue).toEqual('');
             numberWithUnitInput.typeInput('-1');
             tick();
@@ -161,7 +171,27 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             tick();
             numberWithUnitInput.detectChanges();
             expect(numberWithUnitInput.isInputValueFocused).toBe(false);
+            expect(numberWithUnitInput.isInputFieldDisabled).toBe(true);
             expect(numberWithUnitInput.displayValue).toEqual(ts.translate('vcd.cc.unlimited'));
+        }));
+
+        it('does not select unlimited when the unlimited value is typed if unlimited is disabled', fakeAsync(() => {
+            const noUnlimited = finder.find({
+                woConstructor: NumberWithUnitFormInputWidgetObject,
+                className: 'no-unlimited',
+            });
+            expect(noUnlimited.displayValue).toEqual('');
+            noUnlimited.typeInput('-1');
+            tick();
+            noUnlimited.detectChanges();
+            expect(noUnlimited.isInputValueFocused).toBe(true);
+            expect(noUnlimited.displayValue).toEqual(ts.translate(Hertz.Mhz.getValueWithUnitTranslationKey(), [-1]));
+            noUnlimited.blurInput();
+            tick();
+            noUnlimited.detectChanges();
+            expect(noUnlimited.isInputValueFocused).toBe(true);
+            expect(noUnlimited.isInputFieldDisabled).toBe(false);
+            expect(noUnlimited.displayValue).toEqual(ts.translate(Hertz.Mhz.getValueWithUnitTranslationKey(), [-1]));
         }));
     });
 

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -342,7 +342,7 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
      * Toggles the unlimited checkbox if the formValue is the unlimited value.
      */
     updateUnlimitedCheckbox() {
-        if (this.getValue() === this.unlimitedValue && !this.unlimitedControlValue) {
+        if (this.getValue() === this.unlimitedValue && !this.unlimitedControlValue && this.showUnlimitedOption) {
             this.onUnlimitedCheckboxChange(true);
         }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

If the number with unit showUnlimitedValue was set to false and the user typed in "-1", the form would try and select the unlimited option. This would cause the form to appear disabled and be unusable.

## What manual testing did you do?

1. In the examples app, typed "-1" and blurred the input, observed it still working.

## Screenshots (if applicable)

![unlimited](https://user-images.githubusercontent.com/7528512/115582484-030ee000-a297-11eb-8fde-db05435fa280.gif)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

## Other information
