### PR TITLE
Add unit test to ensure datagridSelection returns same reference

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,15 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New unit tests to ensure datagridSelection returns same reference
 
 ## [2.0.0-dev.15]
 ### Changed
 - Quick search sections can now have icons.
 ### Fixed
 - A bug in the number with unit where if unlimited was disabled but the user types "-1", the whole form would become disabled
+
 ## [2.0.0-dev.14]
 ### Added
 - Quick-search widget object
+
 ## [2.0.0-dev.13]
 ### Changed
 - BREAKING: ActionDisplayConfig of ActionMenuComponent accepts featuredCount property only when the actions are displayed

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -282,6 +282,133 @@ describe('DatagridComponent', () => {
                 });
             });
 
+            describe('datagridSelection getter', () => {
+                describe('when selectionType is set to multi', () => {
+                    beforeEach(function (this: HasFinderAndGrid): void {
+                        this.hostComponent.selectionType = GridSelectionType.Multi;
+                        this.finder.detectChanges();
+                    });
+
+                    it('returns same reference when there is no selection', fakeAsync(function (
+                        this: HasFinderAndGrid
+                    ): void {
+                        const selection = this.hostComponent.grid.datagridSelection;
+                        tick();
+                        this.finder.detectChanges();
+                        expect(this.hostComponent.grid.datagridSelection).toEqual([]);
+                        expect(this.hostComponent.grid.datagridSelection).toBe(selection);
+                    }));
+                    it('returns same reference when there is a selection that was not changed', fakeAsync(function (
+                        this: HasFinderAndGrid
+                    ): void {
+                        this.clrGridWidget.getSelectionLabelForRow(0).click();
+                        tick();
+                        this.finder.detectChanges();
+                        const selection = this.hostComponent.grid.datagridSelection;
+                        tick();
+                        this.finder.detectChanges();
+                        expect(this.hostComponent.grid.datagridSelection).toBe(selection);
+                    }));
+                    it('returns new reference when there is a selection that was changed', fakeAsync(function (
+                        this: HasFinderAndGrid
+                    ): void {
+                        // Select an item
+                        this.clrGridWidget.getSelectionLabelForRow(0).click();
+                        tick();
+                        this.finder.detectChanges();
+                        const selection = this.hostComponent.grid.datagridSelection;
+                        // Deselect the item
+                        this.clrGridWidget.getSelectionLabelForRow(0).click();
+                        tick();
+                        this.finder.detectChanges();
+                        // Select the same item
+                        this.clrGridWidget.getSelectionLabelForRow(0).click();
+                        tick();
+                        this.finder.detectChanges();
+                        expect(this.hostComponent.grid.datagridSelection).toEqual(selection);
+                        expect(this.hostComponent.grid.datagridSelection[0]).toBe(selection[0]);
+                        expect(this.hostComponent.grid.datagridSelection).not.toBe(selection);
+                        tick();
+                    }));
+                });
+
+                describe('when selectionType is set to single', () => {
+                    beforeEach(function (this: HasFinderAndGrid): void {
+                        this.hostComponent.selectionType = GridSelectionType.Single;
+                        this.finder.detectChanges();
+                    });
+
+                    it('returns same reference when there is no selection', fakeAsync(function (
+                        this: HasFinderAndGrid
+                    ): void {
+                        const selection = this.hostComponent.grid.datagridSelection;
+                        tick();
+                        this.finder.detectChanges();
+                        expect(this.hostComponent.grid.datagridSelection).toEqual([]);
+                        expect(this.hostComponent.grid.datagridSelection).toBe(selection);
+                    }));
+
+                    it('returns same reference when there is a selection that was not changed', fakeAsync(function (
+                        this: HasFinderAndGrid
+                    ): void {
+                        this.clrGridWidget.getSelectionLabelForRow(0).click();
+                        tick();
+                        this.finder.detectChanges();
+                        const selection = this.hostComponent.grid.datagridSelection;
+                        tick();
+                        this.finder.detectChanges();
+                        expect(this.hostComponent.grid.datagridSelection).toBe(selection);
+                    }));
+
+                    it('returns new reference when there is a selection that not changed', fakeAsync(function (
+                        this: HasFinderAndGrid
+                    ): void {
+                        // Select an item
+                        this.clrGridWidget.getSelectionLabelForRow(0).click();
+                        tick();
+                        this.finder.detectChanges();
+                        const selection = this.hostComponent.grid.datagridSelection;
+                        // Select another item
+                        this.clrGridWidget.getSelectionLabelForRow(1).click();
+                        tick();
+                        this.finder.detectChanges();
+                        // Select the first item again
+                        this.clrGridWidget.getSelectionLabelForRow(0).click();
+                        tick();
+                        this.finder.detectChanges();
+                        expect(this.hostComponent.grid.datagridSelection).toEqual(selection);
+                        expect(this.hostComponent.grid.datagridSelection[0]).toBe(selection[0]);
+                        expect(this.hostComponent.grid.datagridSelection).not.toBe(selection);
+                    }));
+                });
+
+                it('returns same reference when selectionType is not set', fakeAsync(function (
+                    this: HasFinderAndGrid
+                ): void {
+                    tick();
+                    this.finder.detectChanges();
+                    const selection = this.hostComponent.grid.datagridSelection;
+                    tick();
+                    this.finder.detectChanges();
+                    expect(this.hostComponent.grid.datagridSelection).toEqual([]);
+                    expect(this.hostComponent.grid.datagridSelection).toBe(selection);
+                }));
+
+                it('returns an empty array when selectionType is set to none', fakeAsync(function (
+                    this: HasFinderAndGrid
+                ): void {
+                    this.hostComponent.selectionType = GridSelectionType.None;
+                    this.finder.detectChanges();
+                    tick();
+                    this.finder.detectChanges();
+                    const selection = this.hostComponent.grid.datagridSelection;
+                    tick();
+                    this.finder.detectChanges();
+                    expect(this.hostComponent.grid.datagridSelection).toEqual([]);
+                    expect(this.hostComponent.grid.datagridSelection).toBe(selection);
+                }));
+            });
+
             describe('@Output() selectionChanged', () => {
                 it('emits multiple rows when set to multi selection', async function (this: HasFinderAndGrid): Promise<
                     void
@@ -1329,7 +1456,6 @@ describe('DatagridComponent', () => {
                 [clrDatagridCssClass]="clrDatagridCssClass"
                 [clrDatarowCssClassGetter]="clrDatarowCssClassGetter"
                 [selectionType]="selectionType"
-                (datagridSelectionChange)="selectionChanged($event)"
                 [paginationDropdownText]="paginationText"
                 [pagination]="pagination"
                 [actions]="actions"
@@ -1343,6 +1469,7 @@ describe('DatagridComponent', () => {
                 [emptyGridPlaceholder]="placeholder"
                 [detailPane]="detailPane"
                 [(datagridSelection)]="datagridSelection"
+                (datagridSelectionChange)="selectionChanged($event)"
                 [preserveSelection]="preserveSelection"
             >
             </vcd-datagrid>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [x] Other... Please describe:

## What does this change do?

If there is no change in the datagrid selection the getter method `datagridSelection`
should return the same array reference. This is needed for performance optimization
so that angular will not trigger any unnecessary change detections and calculations
in the case when the array reference has been changed, but it contains the same data
(for example empty arrays are never equal []!==[])

Ensuring `datagridSelection` returns the same array reference when there is no real selection change
during angular detect changes cycles was done some time ago, but unit tests
were not written. This CLN just adds unit tests for that.


## What manual testing did you do?

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
