### PR TITLE
Fix pinned quick search appearing above modals

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixes
+- Fix pinned quick search appearing above modals
+
 ## [2.0.0-dev.20]
 ### Changed
 - BREAKING: Reworked Quick Search Filters

--- a/projects/components/src/quick-search/drawer/drawer.component.scss
+++ b/projects/components/src/quick-search/drawer/drawer.component.scss
@@ -12,9 +12,9 @@ $scrollbarColor: white;
     right: 0;
     left: 0;
     overflow: hidden;
+    z-index: $zindex;
 
     .left-area {
-        z-index: $zindex;
         position: absolute;
         top: 0;
         bottom: 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Pinned quick search was appear above modals. This caused a few visual errors. This adjusts the z-index of the quick search pinned container to be below modals.

## What manual testing did you do?

1. Loaded components into VCD_UI
2. Opened quick search and pinned
3. Opened a modal and observed the modal being above quick search
4. Tried to click quick search and observed nothing happening.

## Screenshots (if applicable)

<img width="1792" alt="Screen Shot 2021-04-26 at 11 34 45 AM" src="https://user-images.githubusercontent.com/7528512/116111882-0b935c00-a685-11eb-9735-ec252d80af3b.png">

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
