### PR TITLE
Fixed bug in Cypress findWidget

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -45,6 +45,9 @@ Same as 4.0.1-dev.1 . Created because we'll use major versions that match Angula
 ### No Changes
 - This version is identical to dev.27 and rc.0
 
+### Fixed
+- A bug where findWidget in Cypress searched from the root rather than from the current widget
+
 ## [2.0.0-rc.0]
 
 ### No Changes

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- A bug where findWidget in Cypress searched from the root rather than from the current widget
 
 ## [12.0.1-dev.1]
 Same as 4.0.1-dev.1 . Created because we'll use major versions that match Angular and Clarity's versions
@@ -44,9 +46,6 @@ Same as 4.0.1-dev.1 . Created because we'll use major versions that match Angula
 
 ### No Changes
 - This version is identical to dev.27 and rc.0
-
-### Fixed
-- A bug where findWidget in Cypress searched from the root rather than from the current widget
 
 ## [2.0.0-rc.0]
 

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
@@ -4,14 +4,14 @@
  */
 
 import { IdGenerator } from '../../../id-generator/id-generator';
-import { BaseWidgetObject, FindableWidget, FindElementOptions } from '../widget-object';
+import { BaseWidgetObject, ElementActions, FindableWidget, FindElementOptions } from '../widget-object';
 import { CypressWidgetObjectElement } from './cypress-widget-object-element';
 
 declare const cy;
-const idGenerator = new IdGenerator('cy-id');
+export const cypressWidgetIdGenerator = new IdGenerator('cy-id');
 
 export interface FindCypressWidgetOptions extends FindElementOptions {
-    ancestor?: string;
+    ancestor?: string | ElementActions;
     options?: { timeout: number };
 }
 
@@ -36,11 +36,18 @@ export class CypressWidgetObjectFinder<T> {
         widgetConstructor: FindableWidget<T, W>,
         findOptions?: FindCypressWidgetOptions
     ): W {
-        const id = idGenerator.generate();
+        const id = cypressWidgetIdGenerator.generate();
 
-        const ancestor = findOptions?.ancestor
-            ? cy.get(findOptions?.ancestor, { timeout: findOptions?.options?.timeout })
-            : cy.get('body', { timeout: findOptions?.options?.timeout });
+        let ancestor: any;
+        if (findOptions?.ancestor) {
+            if (typeof findOptions.ancestor == 'string') {
+                ancestor = cy.get(findOptions?.ancestor, { timeout: findOptions?.options?.timeout });
+            } else {
+                ancestor = findOptions?.ancestor;
+            }
+        } else {
+            ancestor = cy.get('body', { timeout: findOptions?.options?.timeout });
+        }
         const parentWidget = new CypressWidgetObjectElement(ancestor, false, undefined);
         let query = widgetConstructor.tagName;
         if (findOptions?.cssSelector) {

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
@@ -8,7 +8,7 @@ import { BaseWidgetObject, ElementActions, FindableWidget, FindElementOptions } 
 import { CypressWidgetObjectElement } from './cypress-widget-object-element';
 
 declare const cy;
-export const cypressWidgetIdGenerator = new IdGenerator('cy-id');
+const cypressWidgetIdGenerator = new IdGenerator('cy-id');
 
 export interface FindCypressWidgetOptions extends FindElementOptions {
     ancestor?: string | ElementActions;

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
@@ -109,11 +109,11 @@ describe('CypressWidgetObjectElement', () => {
             const findSpy = spyOn(cy, 'find').and.callThrough();
             const widget = new CypressWidgetObjectElement(cy, true, '1');
             widget.findWidget(FakeWidget, {});
-            expect(getSpy).toHaveBeenCalledWith('@1', { timeout: undefined });
+            expect(getSpy).toHaveBeenCalledWith('@1');
             expect(findSpy).toHaveBeenCalledWith(FakeWidget.tagName, undefined);
         });
 
-        fit('uses the current element to find the widget', () => {
+        it('uses the current element to find the widget', () => {
             spyOn(cy, 'get').and.callFake(() => new MockCy());
             const findSpy = spyOn(cy, 'find').and.callFake(() => new MockCy());
             const widget = new CypressWidgetObjectElement(cy, true, '1');

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
@@ -112,6 +112,17 @@ describe('CypressWidgetObjectElement', () => {
             expect(getSpy).toHaveBeenCalledWith('@1', { timeout: undefined });
             expect(findSpy).toHaveBeenCalledWith(FakeWidget.tagName, undefined);
         });
+
+        fit('uses the current element to find the widget', () => {
+            spyOn(cy, 'get').and.callFake(() => new MockCy());
+            const findSpy = spyOn(cy, 'find').and.callFake(() => new MockCy());
+            const widget = new CypressWidgetObjectElement(cy, true, '1');
+            const find2 = widget.get('a').parents('a');
+            const findSpy2 = spyOn(find2.unwrap(), 'find').and.returnValue(new MockCy());
+            find2.findWidget(FakeWidget, {});
+            expect(findSpy).toHaveBeenCalledTimes(0);
+            expect(findSpy2).toHaveBeenCalledWith(FakeWidget.tagName, undefined);
+        });
     });
 
     describe('parents', () => {

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
@@ -10,7 +10,7 @@ import {
     FindElementOptions,
     WidgetObjectElement,
 } from '../widget-object';
-import { cypressWidgetIdGenerator, CypressWidgetObjectFinder, FindCypressWidgetOptions } from './cypress-widget-finder';
+import { CypressWidgetObjectFinder, FindCypressWidgetOptions } from './cypress-widget-finder';
 
 declare const cy;
 

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
@@ -10,7 +10,7 @@ import {
     FindElementOptions,
     WidgetObjectElement,
 } from '../widget-object';
-import { CypressWidgetObjectFinder, FindCypressWidgetOptions } from './cypress-widget-finder';
+import { cypressWidgetIdGenerator, CypressWidgetObjectFinder, FindCypressWidgetOptions } from './cypress-widget-finder';
 
 declare const cy;
 
@@ -25,6 +25,12 @@ declare const cy;
  * we could not load the Cypress types in our library.
  */
 export class CypressWidgetObjectElement<T extends ElementActions> implements WidgetObjectElement<T> {
+    /**
+     *
+     * @param chainable the chainable that represents the current element.
+     * @param isRoot if the current element refers to the same element that the alias refers to.
+     * @param alias refers to the alias of the root element of this current element.
+     */
     constructor(private chainable: T, private isRoot: boolean, private alias: string) {}
 
     /**
@@ -119,7 +125,7 @@ export class CypressWidgetObjectElement<T extends ElementActions> implements Wid
      * @inheritdoc
      */
     findWidget<W extends BaseWidgetObject<T>>(widget: FindableWidget<T, W>, findOptions: FindCypressWidgetOptions): W {
-        return new CypressWidgetObjectFinder<T>().find(widget, { ancestor: '@' + this.alias, ...findOptions });
+        return new CypressWidgetObjectFinder<T>().find(widget, { ancestor: this.getBase(), ...findOptions });
     }
 
     /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Calls to WidgetObjectElement.findWidget weren't always chained off the correct result. If you first make a call to `.get` and then findWidget, it would find the widget in whatever the parent element is. This is because we were finding with `this.alias` which refers to the root element. 

## What manual testing did you do?

1. Assured the new test passes now and fails before the change.
2. Sent the code to Bryan and had him load it. Verified he could find one specific widget from a specific row in a grid with many rows.

## Screenshots (if applicable)

<img width="1792" alt="Screen Shot 2021-04-26 at 3 18 12 PM" src="https://user-images.githubusercontent.com/7528512/116144918-989cdc00-a6aa-11eb-9bec-dbe481df7b37.png">

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

## Other information
