### PR TITLE
Adds description and hint to form-select

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.0.0-dev.19]
+### Added
+- `vcd-form-select` now accepts `@Input`s `hint` and `description`
+
 ## [2.0.0-dev.18]
 ### Fixed
 - Replaced the call to `get selectedEntities()` getter with `getSelectedEntities()` method in the `ActionMenuComponent`

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.18",
+    "version": "2.0.0-dev.19",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -7,7 +7,7 @@
             {{ selectedOption.isTranslatable ? (selectedOption.display | translate) : selectedOption.display }}
         </span>
         <div class="clr-control-container" [ngClass]="{ 'clr-error': showErrors }">
-            <div class="clr-select-wrapper" *ngIf="!isReadOnly">
+            <div class="clr-select-wrapper" [ngClass]="{ 'showing-hint': !!hint }" *ngIf="!isReadOnly">
                 <select
                     [id]="id"
                     [attr.aria-required]="showAsterisk"
@@ -23,10 +23,20 @@
 
             <ng-content select="aside"></ng-content>
 
+            <clr-signpost *ngIf="hint && !showErrors">
+                <clr-signpost-content [clrPosition]="hintPosition" *clrIfOpen>
+                    <p>{{ hint }}</p>
+                </clr-signpost-content>
+            </clr-signpost>
+
             <span class="clr-subtext" *ngIf="showErrors" [id]="errorsId">
                 <div *ngFor="let key of errorKeys">
                     <div>{{ key | translate: [formControl.value] }}</div>
                 </div>
+            </span>
+
+            <span class="clr-subtext" *ngIf="!showErrors && description" [id]="descriptionId">
+                {{ description }}
             </span>
         </div>
     </div>

--- a/projects/components/src/form/form-select/form-select.component.scss
+++ b/projects/components/src/form/form-select/form-select.component.scss
@@ -17,3 +17,13 @@
 label {
     white-space: normal;
 }
+
+clr-signpost-content {
+    white-space: pre;
+}
+
+clr-signpost {
+    // Offset margin right on the button rendered by the signpost so there's
+    // no extra room after the signpost
+    margin-right: -12px;
+}

--- a/projects/components/src/form/form-select/form-select.component.ts
+++ b/projects/components/src/form/form-select/form-select.component.ts
@@ -22,6 +22,16 @@ export class FormSelectComponent extends BaseFormControl {
      */
     @Input() options: SelectOption[] = [];
 
+    /**
+     * The direction for displaying the hint
+     */
+    @Input() hintPosition = 'top-left';
+
+    /**
+     * Hint to display in the content of a signpost
+     */
+    @Input() hint: string;
+
     constructor(@Self() @Optional() ngControl: NgControl) {
         super(ngControl);
     }

--- a/projects/examples/src/components/form-input/form-select.example.component.html
+++ b/projects/examples/src/components/form-input/form-select.example.component.html
@@ -1,7 +1,11 @@
 <form [formGroup]="formGroup" class="clr-form-horizontal">
+    The select element supports hints with new lines. See the source code for the required HTML
+
     <vcd-form-select
         [showAsterisk]="true"
         [label]="'Select Input'"
+        [description]="'Select Input description.'"
+        [hint]="'Select Input hint\n\nAdd new lines as needed'"
         [options]="options"
         [formControlName]="'selectInput'"
     >


### PR DESCRIPTION
It also allows hints that contain newlines to be displayed
as actual new lines, such as in `<pre>` blocks.

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Feature
`@Input`s for description and hints like 
-   [x] Version bump

## What does this change do?

## What manual testing did you do?
* Go to http://localhost:4200/formSelect/example/form-select
* Verify that the hint displays with new lines displayed as real line breaks
* Verify that the description displays below

Also loaded vcd_ui and tested in on a vcd-form-select
* Initially, the hint dropdown ends up on a new line because `vcd.scss` is trying to display the select as full width pushing the signpost trigger to a new line
* Hint is back on the same line after using the following CSS override ```.clr-control-container .clr-select-wrapper.showing-hint {
    width: calc(100% - 2em);
}```

To test this locally, you can add the following to [styles.scss](https://github.com/vmware/vmware-cloud-director-ui-components/blob/master/projects/examples/src/styles.scss)

```scss
// This will cause the select element to be 100% width and push the hint trigger to a new line, reproducing the same problem as in vcd_ui
.clr-control-container div {
    width: 100%;
    select {
        width: 100%;
    }
}

// This will fix it so the trigger is on the same line
.clr-control-container .clr-select-wrapper.showing-hint {
    width: calc(100% - 2em);
}
```
## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/549331/117866280-f3b2ff00-b264-11eb-8643-8e52dde90df5.png)

## Does this PR introduce a breaking change?

-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
