### PR TITLE
Reworks quick search filters + loading indicator

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -22,6 +22,10 @@ HTML
 because changing the getter to take `T | T[]` to match the setter would cause callers to do type checking even though
 we guarantee it will be an array.
 
+### Changed
+- BREAKING: Reworked Quick Search Filters
+- Quick search now has a single loading indicator.
+
 ## [2.0.0-dev.16]
 ### Added
 - New unit tests to ensure datagridSelection returns same reference

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0-dev.20]
 ### Changed
 - BREAKING: Reworked Quick Search Filters
 - Quick search now has a single loading indicator.

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- BREAKING: Reworked Quick Search Filters
+- Quick search now has a single loading indicator.
+
 ## [2.0.0-dev.19]
 ### Added
 - `vcd-form-select` now accepts `@Input`s `hint` and `description`
@@ -21,10 +25,6 @@ HTML
 - BREAKING: `ActionMenuComponent`'s `get selectedEntities(): T[]` was replaced with `getSelectedEntitites(): T[]`
 because changing the getter to take `T | T[]` to match the setter would cause callers to do type checking even though
 we guarantee it will be an array.
-
-### Changed
-- BREAKING: Reworked Quick Search Filters
-- Quick search now has a single loading indicator.
 
 ## [2.0.0-dev.16]
 ### Added

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.19",
+    "version": "2.0.0-dev.20",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-search-provider/action-search.provider.ts
+++ b/projects/components/src/action-search-provider/action-search.provider.ts
@@ -65,6 +65,10 @@ export class ActionSearchProvider<R, T> extends QuickSearchProviderDefaults impl
         this.isReadyToSearchPromise = this.readyToSearchPromiseFactory();
     }
 
+    canHandleFilter(): boolean {
+        return true;
+    }
+
     private readyToSearchPromiseFactory(): Promise<null> {
         return new Promise<null>((resolve, reject) => {
             this.resolveIsReadyToSearch = resolve;

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -63,7 +63,9 @@
     <div>
         <ng-container *ngFor="let filter of _filters">
             <span class="filter-bubble label" *ngFor="let option of filterValues.get(filter.id)">
-                <span vcdShowClippedText>{{ filter.bubbleI18nKey | translate: { option: option.display } }}</span>
+                <span [vcdShowClippedText]="{ disabled: !open }">{{
+                    filter.bubbleI18nKey | translate: { option: option.display }
+                }}</span>
                 <button
                     type="button"
                     class="btn btn-icon btn-link remove-col-button"

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -22,12 +22,18 @@
     <div class="filter-container" *ngIf="_filters.length > 0">
         <p>Filter By</p>
         <ng-container *ngFor="let filter of _filters">
-            <clr-dropdown [clrCloseMenuOnItemClick]="false" *ngIf="filter.options.length > 1">
+            <clr-dropdown
+                [clrCloseMenuOnItemClick]="false"
+                *ngIf="filter.options.length > 1"
+                (keydown.arrowup)="$event.stopPropagation()"
+                (keydown.arrowdown)="$event.stopPropagation()"
+                (keydown.enter)="$event.stopPropagation()"
+            >
                 <button
                     class="dropdown-toggle btn btn-link"
                     type="button"
                     clrDropdownTrigger
-                    [attr.data-ui]="'filter:' + filter.id"
+                    [attr.data-ui]="DataUi.filterButton(filter.id)"
                 >
                     {{ filter.dropdownText }}
                     <clr-icon shape="caret down"></clr-icon>
@@ -45,7 +51,7 @@
                                 (click)="$event.stopPropagation()"
                                 [ngModel]="getFilterOptionValue(filter.id, option.key)"
                                 (ngModelChange)="updateFilterValue(filter.id, option)"
-                                [attr.data-ui]="'filter-dropdown-item'"
+                                [attr.data-ui]="DataUi.filterDropdownItem"
                             />
                             <label (click)="$event.stopPropagation()">{{ option.display }}</label>
                         </clr-checkbox-wrapper>
@@ -56,8 +62,8 @@
     </div>
     <div>
         <ng-container *ngFor="let filter of _filters">
-            <span class="x-button label" *ngFor="let option of filterValues.get(filter.id)">
-                <p vcdShowClippedText>{{ filter.bubbleI18nKey | translate: { option: option.display } }}</p>
+            <span class="filter-bubble label" *ngFor="let option of filterValues.get(filter.id)">
+                <span vcdShowClippedText>{{ filter.bubbleI18nKey | translate: { option: option.display } }}</span>
                 <button
                     type="button"
                     class="btn btn-icon btn-link remove-col-button"
@@ -100,7 +106,15 @@
 
 <ng-template #quickSearchInterior>
     <div class="search-input-container" data-ui="search-input-container">
-        <clr-icon shape="search" size="20"></clr-icon>
+        <div class="search-icon-container">
+            <clr-icon shape="search" size="20" *ngIf="!isLoading"></clr-icon>
+            <clr-spinner
+                [clrSmall]="true"
+                [clrInline]="true"
+                [attr.data-ui]="DataUi.spinner"
+                *ngIf="isLoading"
+            ></clr-spinner>
+        </div>
         <input
             #searchInput
             type="text"
@@ -117,12 +131,6 @@
     <ng-container *ngTemplateOutlet="filtersSection"> </ng-container>
     <ng-content select=".top-of-results"></ng-content>
     <div class="search-result-container">
-        <div class="loading-alert">
-            <ng-container *ngIf="isLoading">
-                <clr-spinner [clrSmall]="true" [clrInline]="true" [attr.data-ui]="DataUi.spinner"></clr-spinner>
-                {{ 'vcd.cc.loading' | translate }}
-            </ng-container>
-        </div>
         <section class="no-results" [attr.data-ui]="DataUi.noResults" *ngIf="hasNoResults && !isLoading">
             {{ 'vcd.cc.quickSearch.noResults' | translate }}
         </section>

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -1,33 +1,84 @@
 <ng-template #sectionTitle let-searchSection>
-    <clr-icon *ngIf="searchSection.icon" [attr.shape]="searchSection.icon" size="20"> </clr-icon>
-    <div *ngIf="searchSection.hasPartialResult; let partial; else: partial">
-        {{
-            'vcd.cc.quickSearch.partialResultTitle'
-                | translate
-                    : {
-                          title: searchSection.provider.sectionName,
-                          lastItem: partial.lastItem,
-                          totalItems: partial.totalItems
-                      }
-        }}
+    <div class="section-title-wrapper">
+        <clr-icon *ngIf="searchSection.icon" [attr.shape]="searchSection.icon" size="20"> </clr-icon>
+        <div *ngIf="searchSection.hasPartialResult; let partial; else: partial">
+            {{
+                'vcd.cc.quickSearch.partialResultTitle'
+                    | translate
+                        : {
+                              title: searchSection.provider.sectionName,
+                              lastItem: partial.lastItem,
+                              totalItems: partial.totalItems
+                          }
+            }}
+        </div>
+        <ng-template #partial>
+            {{ searchSection.provider.sectionName }}
+        </ng-template>
     </div>
-    <ng-template #partial>
-        {{ searchSection.provider.sectionName }}
-    </ng-template>
+</ng-template>
+
+<ng-template #filtersSection>
+    <div class="filter-container" *ngIf="_filters.length > 0">
+        <p>Filter By</p>
+        <ng-container *ngFor="let filter of _filters">
+            <clr-dropdown [clrCloseMenuOnItemClick]="false" *ngIf="filter.options.length > 1">
+                <button
+                    class="dropdown-toggle btn btn-link"
+                    type="button"
+                    clrDropdownTrigger
+                    [attr.data-ui]="'filter:' + filter.id"
+                >
+                    {{ filter.dropdownText }}
+                    <clr-icon shape="caret down"></clr-icon>
+                </button>
+                <clr-dropdown-menu clrPosition="bottom" *clrIfOpen #dropdownMenu>
+                    <li
+                        clrDropdownItem
+                        *ngFor="let option of filter.options"
+                        (click)="updateFilterValue(filter.id, option)"
+                    >
+                        <clr-checkbox-wrapper class="column-checkbox">
+                            <input
+                                type="checkbox"
+                                clrCheckbox
+                                (click)="$event.stopPropagation()"
+                                [ngModel]="getFilterOptionValue(filter.id, option.key)"
+                                (ngModelChange)="updateFilterValue(filter.id, option)"
+                                [attr.data-ui]="'filter-dropdown-item'"
+                            />
+                            <label (click)="$event.stopPropagation()">{{ option.display }}</label>
+                        </clr-checkbox-wrapper>
+                    </li>
+                </clr-dropdown-menu>
+            </clr-dropdown>
+        </ng-container>
+    </div>
+    <div>
+        <ng-container *ngFor="let filter of _filters">
+            <span class="x-button label" *ngFor="let option of filterValues.get(filter.id)">
+                <p vcdShowClippedText>{{ filter.bubbleI18nKey | translate: { option: option.display } }}</p>
+                <button
+                    type="button"
+                    class="btn btn-icon btn-link remove-col-button"
+                    aria-label="home"
+                    (click)="updateFilterValue(filter.id, option)"
+                >
+                    <clr-icon shape="close" class="badge badge-info"> </clr-icon>
+                </button>
+            </span>
+        </ng-container>
+    </div>
 </ng-template>
 
 <ng-template let-searchSection #searchSectionTemplate>
-    <div *ngIf="searchSection.isLoading">
-        <div class="spinner spinner-inline" [attr.data-ui]="DataUi.spinner"></div>
-        {{ 'vcd.cc.loading' | translate }}
-    </div>
-    <ul *ngIf="!searchSection.isLoading" class="list-unstyled compact">
+    <ul class="list-unstyled compact">
         <li
             class="search-result-item"
             role="button"
             *ngFor="let item of searchSection.result?.items"
             (click)="itemClicked(item)"
-            [ngClass]="item == selectedItem && !this.currentFilterOptionSelection ? 'selected' : ''"
+            [ngClass]="item == selectedItem ? 'selected' : ''"
             [attr.data-ui]="DataUi.searchResultItems"
         >
             {{ item.displayText }}
@@ -58,26 +109,21 @@
             [(ngModel)]="searchCriteria"
             [attr.data-ui]="DataUi.searchInput"
         />
-        <div class="dropdown open filters-autofill" *ngIf="filterBeingEdited" #filtersOptions>
-            <div class="dropdown-menu">
-                <li
-                    class="dropdown-item"
-                    [ngClass]="this.currentFilterOptionSelection.display === option.display ? 'selected' : ''"
-                    *ngFor="let option of filterBeingEditedOptions; trackBy: filterOptionTrackBy"
-                    (click)="autofillSelectedFilterOption(option.display)"
-                >
-                    {{ option.display }}
-                </li>
-            </div>
-        </div>
         <button class="btn btn-link pin-button" (click)="togglePinned()">
             <clr-icon shape="pin" size="20" [ngClass]="isPinned ? 'is-solid' : ''"> </clr-icon>
         </button>
     </div>
     <clr-control-helper class="input-helper">{{ helper }}</clr-control-helper>
+    <ng-container *ngTemplateOutlet="filtersSection"> </ng-container>
     <ng-content select=".top-of-results"></ng-content>
     <div class="search-result-container">
-        <section class="no-results" [attr.data-ui]="DataUi.noResults" *ngIf="hasNoResults">
+        <div class="loading-alert">
+            <ng-container *ngIf="isLoading">
+                <clr-spinner [clrSmall]="true" [clrInline]="true" [attr.data-ui]="DataUi.spinner"></clr-spinner>
+                {{ 'vcd.cc.loading' | translate }}
+            </ng-container>
+        </div>
+        <section class="no-results" [attr.data-ui]="DataUi.noResults" *ngIf="hasNoResults && !isLoading">
             {{ 'vcd.cc.quickSearch.noResults' | translate }}
         </section>
         <section
@@ -85,15 +131,18 @@
             class="search-result-section section-index-0-{{ i + 1 }}"
             data-ui="search-result-section"
         >
-            <h5
-                *ngIf="searchSection.shouldShowText"
-                class="search-result-section-title"
-                [attr.data-ui]="DataUi.searchResultSectionTitles"
-            >
-                <ng-container *ngTemplateOutlet="sectionTitle; context: { $implicit: searchSection }"> </ng-container>
-            </h5>
-            <ng-container *ngTemplateOutlet="searchSectionTemplate; context: { $implicit: searchSection }">
-            </ng-container>
+            <div *ngIf="!searchSection.isLoading">
+                <h5
+                    *ngIf="searchSection.shouldShowText"
+                    class="search-result-section-title"
+                    [attr.data-ui]="DataUi.searchResultSectionTitles"
+                >
+                    <ng-container *ngTemplateOutlet="sectionTitle; context: { $implicit: searchSection }">
+                    </ng-container>
+                </h5>
+                <ng-container *ngTemplateOutlet="searchSectionTemplate; context: { $implicit: searchSection }">
+                </ng-container>
+            </div>
         </section>
         <div *ngFor="let parentSearchSection of groupedSearchSections; let n = index; trackBy: groupSectionTrackBy">
             <h5
@@ -107,16 +156,18 @@
                 *ngFor="let searchSection of parentSearchSection.subSections; let i = index; trackBy: sectionTrackBy"
                 class="sub-section"
             >
-                <p
-                    *ngIf="searchSection.shouldShowText"
-                    class="p2 search-result-section-title search-result-section section-index-{{ n }}-{{ i }}"
-                    [attr.data-ui]="DataUi.searchResultSectionTitles"
-                >
-                    <ng-container *ngTemplateOutlet="sectionTitle; context: { $implicit: searchSection }">
+                <div *ngIf="!searchSection.isLoading">
+                    <p
+                        *ngIf="searchSection.shouldShowText"
+                        class="p2 search-result-section-title search-result-section section-index-{{ n }}-{{ i }}"
+                        [attr.data-ui]="DataUi.searchResultSectionTitles"
+                    >
+                        <ng-container *ngTemplateOutlet="sectionTitle; context: { $implicit: searchSection }">
+                        </ng-container>
+                    </p>
+                    <ng-container *ngTemplateOutlet="searchSectionTemplate; context: { $implicit: searchSection }">
                     </ng-container>
-                </p>
-                <ng-container *ngTemplateOutlet="searchSectionTemplate; context: { $implicit: searchSection }">
-                </ng-container>
+                </div>
             </section>
         </div>
     </div>
@@ -146,7 +197,3 @@
         <ng-container *ngTemplateOutlet="quickSearchInterior"> </ng-container>
     </div>
 </clr-modal>
-
-<div style="display: flex">
-    <div class="clr-input measurement-div" #measurementDiv>{{ searchCriteria }}</div>
-</div>

--- a/projects/components/src/quick-search/quick-search.component.scss
+++ b/projects/components/src/quick-search/quick-search.component.scss
@@ -102,3 +102,61 @@ clr-control-helper.input-helper {
     margin-left: 25px;
     margin-top: 0;
 }
+
+.loading-alert {
+    height: 25px;
+
+    ::ng-deep .alert-items {
+        display: block;
+    }
+}
+.section-title-wrapper {
+    display: flex;
+
+    clr-icon {
+        margin-right: 5px;
+    }
+}
+
+.filter-container {
+    display: flex;
+    clr-dropdown {
+        position: static;
+    }
+
+    .filter-text {
+        margin-right: 10px;
+    }
+
+    p {
+        margin-top: auto;
+        margin-bottom: auto;
+        margin-right: 10px;
+    }
+}
+
+.x-button {
+    padding-left: 0.4rem;
+    padding-right: 0.1rem;
+    p {
+        max-width: 10rem;
+        margin-top: 0px;
+    }
+
+    .btn-link {
+        margin: 0px;
+    }
+
+    clr-icon {
+        color: var(--clr-badge-info-color, white);
+    }
+}
+
+button.btn-link.remove-col-button {
+    margin: 0;
+    padding-right: 5px;
+    padding-left: 5px;
+    clr-icon {
+        margin-right: 0px;
+    }
+}

--- a/projects/components/src/quick-search/quick-search.component.scss
+++ b/projects/components/src/quick-search/quick-search.component.scss
@@ -22,7 +22,7 @@
         margin-top: 30px;
         display: flex;
 
-        clr-icon {
+        .search-icon-container {
             margin-top: 2px;
             margin-right: 4px;
         }
@@ -103,13 +103,11 @@ clr-control-helper.input-helper {
     margin-top: 0;
 }
 
-.loading-alert {
-    height: 25px;
-
-    ::ng-deep .alert-items {
-        display: block;
-    }
+.search-icon-container {
+    width: 20px;
+    height: 20px;
 }
+
 .section-title-wrapper {
     display: flex;
 
@@ -135,13 +133,9 @@ clr-control-helper.input-helper {
     }
 }
 
-.x-button {
+.filter-bubble {
     padding-left: 0.4rem;
     padding-right: 0.1rem;
-    p {
-        max-width: 10rem;
-        margin-top: 0px;
-    }
 
     .btn-link {
         margin: 0px;

--- a/projects/components/src/quick-search/quick-search.component.spec.ts
+++ b/projects/components/src/quick-search/quick-search.component.spec.ts
@@ -392,7 +392,6 @@ describe('QuickSearchComponent', () => {
                 this.quickSearch.getInput().type('c');
                 expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text())).toEqual([
                     'section',
-                    debounceSearchProvider.sectionName,
                 ]);
                 tick(100);
                 this.finder.detectChanges();
@@ -833,7 +832,12 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.filters = [
                 {
                     id: 'type',
-                    options: [{ display: 'simple' }],
+                    options: [
+                        { display: 'simple', key: 'simple' },
+                        { display: 'simple2', key: 'simple2' },
+                    ],
+                    dropdownText: 'dropdown',
+                    bubbleI18nKey: 'bubble-key',
                 },
             ];
             this.quickSearchData.anotherSimpleProvider.sectionName = 'another section';
@@ -843,7 +847,8 @@ describe('QuickSearchComponent', () => {
 
             // When the type filter is present,, the list of providers is filtered based on it.
             // In this case, the type:simple filter is set and anotherSimpleProvider is removed.
-            this.quickSearch.getInput().type('copy type:simple');
+            this.quickSearch.getFilterButton('type').click();
+            this.quickSearch.getFilterDropdownOptions(0).click();
             expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(1);
             expect(this.quickSearch.getSearchResultItems().text()).toEqual('copy');
         });

--- a/projects/components/src/quick-search/quick-search.component.spec.ts
+++ b/projects/components/src/quick-search/quick-search.component.spec.ts
@@ -298,7 +298,7 @@ describe('QuickSearchComponent', () => {
             expect(searchHandlerSpy).toHaveBeenCalledWith('copy');
         });
 
-        it('display a single "No results found" when there are no results', function (this: Test): void {
+        it('display a single "No results found" when there are no results', fakeAsync(function (this: Test): void {
             // Register one more provider
             this.quickSearchData.simpleProvider.sectionName = 'new section';
             this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.simpleProvider);
@@ -308,10 +308,13 @@ describe('QuickSearchComponent', () => {
             // Set search
             this.quickSearch.getInput().type('no match');
             //
+
+            tick();
+            this.finder.detectChanges();
             const noResults = TestBed.inject(TranslationService).translate('vcd.cc.quickSearch.noResults', []);
             expect(this.quickSearch.getSearchResultItems().toArray().length).toBe(0);
             expect(this.quickSearch.getNoResults().map((item) => item.text())).toEqual([noResults]);
-        });
+        }));
 
         describe('partial search result', () => {
             it('does not display partial information if total is less than the number of items', function (this: Test): void {

--- a/projects/components/src/quick-search/quick-search.component.ts
+++ b/projects/components/src/quick-search/quick-search.component.ts
@@ -245,6 +245,7 @@ export class QuickSearchComponent {
 
     private _searchCriteria: string = '';
     private lastSearchCriteria: string = '';
+    private searchesRunning = 0;
 
     private _open = false;
 
@@ -374,6 +375,7 @@ export class QuickSearchComponent {
             return;
         }
         this.isLoading = true;
+        this.searchesRunning += 1;
         flatSections.forEach((searchSection) => (searchSection.isLoading = true));
 
         // Go through the available search sections, i.e. the registered search providers and request for results
@@ -409,7 +411,10 @@ export class QuickSearchComponent {
                 }
             })
         ).then(() => {
-            this.isLoading = false;
+            this.searchesRunning -= 1;
+            if (this.searchesRunning === 0) {
+                this.isLoading = false;
+            }
         });
     }
 

--- a/projects/components/src/quick-search/quick-search.component.ts
+++ b/projects/components/src/quick-search/quick-search.component.ts
@@ -38,8 +38,22 @@ interface SearchSection {
  * A filter that can be applied to quick search to filter results.
  */
 export interface QuickSearchFilter {
+    /**
+     * The unique ID of this filter.
+     */
     id: string;
+    /**
+     * The options that are displayed in the dropdown.
+     */
     options: QuickSearchFilterOption[];
+    /**
+     * The text displayed on the button to open the dropdown.
+     */
+    dropdownText: string;
+    /**
+     * The i18n key for the selection bubble of this filter. Is passed one parameter {display} which is the value selected.
+     */
+    bubbleI18nKey: string;
 }
 
 /**
@@ -50,6 +64,11 @@ export interface QuickSearchFilterOption {
      * The displayed title of this option.
      */
     display: string;
+
+    /**
+     * The key of this quick search filter option.
+     */
+    key: string;
     /**
      * Any optional data that is associated with this option.
      */
@@ -60,7 +79,13 @@ export interface QuickSearchFilterOption {
  * A filter that has a value typed in.
  */
 export interface ActiveQuickSearchFilter extends QuickSearchFilter {
+    /**
+     * The key value of the selected option.
+     */
     value: string;
+    /**
+     * Any date assocated with this filter option.
+     */
     data: any;
 }
 
@@ -169,7 +194,14 @@ export class QuickSearchComponent {
      * If two filters of different IDs are used in the search, the filters should act like and's. If two filters of the same ID
      * are present in the search, the filter should act like an or.
      */
-    @Input() filters: QuickSearchFilter[] = [];
+    @Input() set filters(filters: QuickSearchFilter[]) {
+        this._filters = filters;
+        filters.forEach((filter) => {
+            this.filterValues.set(filter.id, []);
+        });
+    }
+    _filters: QuickSearchFilter[] = [];
+    filterValues: Map<string, QuickSearchFilterOption[]> = new Map();
 
     /**
      * Outputs an event when the user changes the pinning status of this component.
@@ -190,6 +222,8 @@ export class QuickSearchComponent {
 
     isPinned = false;
     hasNoResults = false;
+    isLoading = false;
+    activeFilters: ActiveQuickSearchFilter[] = [];
 
     DataUi = DataUi;
 
@@ -207,47 +241,16 @@ export class QuickSearchComponent {
     set searchCriteria(value: string) {
         this._searchCriteria = value;
         this.doSearch();
-        this.filterBeingEdited = this.getLastFilter();
-        this.filterBeingEditedOptions = this.getFilterOptionsMatchSearch(this.filterBeingEdited?.options);
-        if (!this.filterBeingEdited) {
-            this.currentFilterOptionSelection = null;
-        } else {
-            this.currentFilterOptionSelection = this.filterBeingEditedOptions[0];
-        }
-
-        // The filterOptionsDropdown is not rendered immediately after the search criteria is set. It takes a moment
-        // for this change to propagate through Angular. As such, we need to setTimeout to be able to shift the element.
-        setTimeout(() => {
-            if (this.filterOptionsDropdown) {
-                this.filterOptionsDropdown.nativeElement.style.left =
-                    this.measurementDiv.nativeElement.offsetWidth + 50 + 'px';
-            }
-        });
     }
 
-    /**
-     * Represents the current filter that the user is typing into.
-     */
-    filterBeingEdited: QuickSearchFilter = null;
-
-    /**
-     * The options for the current filter being edited
-     */
-    filterBeingEditedOptions: QuickSearchFilterOption[];
-
-    private _searchCriteria: string;
+    private _searchCriteria: string = '';
+    private lastSearchCriteria: string = '';
 
     private _open = false;
 
     @ViewChild('searchInput', { static: false, read: ElementRef }) searchInput: ElementRef;
 
-    @ViewChild('filtersOptions', { static: false }) filterOptionsDropdown: ElementRef;
-
-    @ViewChild('measurementDiv', { static: false }) measurementDiv: ElementRef;
-
     private searchId = 0;
-
-    private currentActiveFilters: ActiveQuickSearchFilter[] = [];
 
     /**
      * The search sections are provided by the {@link QuickSearchService} upon opening the Quick Search.
@@ -265,10 +268,6 @@ export class QuickSearchComponent {
      * The selected result in the results section.
      */
     selectedItem: QuickSearchResultItem;
-    /**
-     * The current selected dropdown in the filter options dropdown.
-     */
-    currentFilterOptionSelection: QuickSearchFilterOption = null;
 
     itemClicked(item: QuickSearchResultItem): void {
         this.handleItem(item, true);
@@ -285,11 +284,6 @@ export class QuickSearchComponent {
     }
 
     onEnterKey(event): void {
-        if (this.currentFilterOptionSelection) {
-            this.autofillSelectedFilterOption(this.currentFilterOptionSelection.display);
-            this.searchInput.nativeElement.focus();
-            return;
-        }
         if (!this.selectedItem) {
             return;
         }
@@ -304,28 +298,24 @@ export class QuickSearchComponent {
         return [...this.ungroupedSearchSections, ...allSections];
     }
 
-    private getLastFilter(): QuickSearchFilter {
-        if (!this.searchCriteria) {
-            return null;
-        }
-        const parts = this.searchCriteria.split(' ');
-        const finalFilter = parts[parts.length - 1];
-        return this.filters.find((filter) => finalFilter.match(filter.id + ':'));
+    getFilterOptionValue(filterId: string, optionKey: string): boolean {
+        return !!this.filterValues.get(filterId).find((option) => option.key === optionKey);
     }
 
-    private getFilterOptionsMatchSearch(options: QuickSearchFilterOption[]): QuickSearchFilterOption[] {
-        if (!options) {
-            return [];
+    updateFilterValue(id: string, value: QuickSearchFilterOption): void {
+        if (value === undefined) {
+            return;
         }
-        const parts = this.searchCriteria.split(':');
-        const searchTerm = parts[parts.length - 1];
-        return options.filter((option) => option.display.startsWith(searchTerm));
-    }
-
-    autofillSelectedFilterOption(option: string) {
-        const parts = this.searchCriteria.split(':');
-        parts.pop();
-        this.searchCriteria = parts.join(':') + ':' + option + ' ';
+        const isActive = this.getFilterOptionValue(id, value.key);
+        if (isActive) {
+            this.filterValues.set(
+                id,
+                this.filterValues.get(id).filter((option) => option.key !== value.key)
+            );
+        } else {
+            this.filterValues.get(id).push(value);
+        }
+        this.doSearch();
     }
 
     togglePinned(): void {
@@ -338,29 +328,56 @@ export class QuickSearchComponent {
         });
     }
 
-    private doSearch(): void {
+    doSearch(force?: boolean): void {
+        if (!this.open && !force) {
+            return;
+        }
+
+        const activeFilters = [];
+        this.filterValues.forEach((valueList, id) => {
+            valueList.forEach((value) => {
+                activeFilters.push({
+                    id,
+                    value: value.key,
+                    data: value.data,
+                });
+            });
+        });
+        if (this.activeFilters.length !== activeFilters.length) {
+            this.activeFilters = activeFilters;
+        } else if (this.searchCriteria === this.lastSearchCriteria) {
+            this.lastSearchCriteria = this.searchCriteria;
+            if (!force) {
+                return;
+            }
+        }
+        this.lastSearchCriteria = this.searchCriteria;
+        this.updateActiveSections(activeFilters);
+
         // Remember which is the current search. This will help us not to show results from an old search
         const searchId = ++this.searchId;
 
         this.selectedItem = null;
 
-        const { searchTerm, filters } = this.parseSearchCriteria(this.searchCriteria);
-
-        if (filters !== this.currentActiveFilters) {
-            this.updateActiveSections(filters);
-            this.currentActiveFilters = filters;
-        }
+        const searchTerm = this.searchCriteria;
 
         // Mark each sections in loading state. This flag is needed when trying to select the first item
         // while the search is still in progress
-        this.getFlattenedSearchSections().forEach((searchSection) => (searchSection.isLoading = true));
+        const flatSections = this.getFlattenedSearchSections();
 
+        if (flatSections.length === 0) {
+            return;
+        }
+        this.isLoading = true;
+        flatSections.forEach((searchSection) => (searchSection.isLoading = true));
+
+        let numberLoaded = 0;
         // Go through the available search sections, i.e. the registered search providers and request for results
-        this.getFlattenedSearchSections().forEach(async (searchSection) => {
+        flatSections.forEach(async (searchSection) => {
             let searchResult: QuickSearchResults;
             // Only request for data if the search is not empty
-            if ((searchTerm && searchTerm.length > 0) || filters.length > 0) {
-                const result = searchSection.provider.search(searchTerm, filters);
+            if (searchTerm && searchTerm.length > 0) {
+                const result = searchSection.provider.search(searchTerm, activeFilters);
 
                 // Some of the results may be provided later, so mark the section as loading
                 if (result instanceof Promise) {
@@ -380,6 +397,11 @@ export class QuickSearchComponent {
             searchSection.result = searchResult;
             searchSection.hasPartialResult = this.hasPartialResult(searchSection);
             searchSection.isLoading = false;
+            numberLoaded = numberLoaded + 1;
+
+            if (numberLoaded === flatSections.length) {
+                this.isLoading = false;
+            }
             this.hasNoResults = this.checkHasNoResults();
             searchSection.shouldShowText = this.showSectionTitle(searchSection);
             if (!this.selectedItem) {
@@ -412,26 +434,18 @@ export class QuickSearchComponent {
 
     private selectNext(down: boolean): void {
         // If there is no selection then just select the first available item
-        if (this.currentFilterOptionSelection) {
-            this.currentFilterOptionSelection = this.genericSelectNext(
-                down,
-                this.currentFilterOptionSelection,
-                this.filterBeingEditedOptions
-            );
-        } else {
-            if (!this.selectedItem) {
-                this.selectFirst(false);
-                return;
-            }
-            this.selectedItem = this.genericSelectNext(
-                down,
-                this.selectedItem,
-                this.getFlattenedSearchSections().reduce((acc, v) => [...acc, ...(v.result?.items || [])], [])
-            );
+        if (!this.selectedItem) {
+            this.selectFirst(false);
+            return;
+        }
+        this.selectedItem = this.genericSelectNext(
+            down,
+            this.selectedItem,
+            this.getFlattenedSearchSections().reduce((acc, v) => [...acc, ...(v.result?.items || [])], [])
+        );
 
-            if (this.selectedItem === null) {
-                this.selectFirst(false);
-            }
+        if (this.selectedItem === null) {
+            this.selectFirst(false);
         }
         // Call the change detector otherwise the selection on the screen may not refreshed quickly enough if the
         // user just presses and holds down the arrow key
@@ -491,7 +505,7 @@ export class QuickSearchComponent {
                 this.searchInput.nativeElement.focus();
                 this.searchInput.nativeElement.select();
             }, 0);
-            this.doSearch();
+            this.doSearch(true);
         }
 
         this._open = open;
@@ -504,7 +518,7 @@ export class QuickSearchComponent {
             provider,
             result: null,
             isLoading: true,
-            shouldShowText: true,
+            shouldShowText: false,
             hasPartialResult: undefined,
             icon: provider.icon,
         }));
@@ -515,7 +529,7 @@ export class QuickSearchComponent {
                     provider,
                     result: null,
                     isLoading: true,
-                    shouldShowText: true,
+                    shouldShowText: false,
                     hasPartialResult: undefined,
                     icon: provider.icon,
                 })),
@@ -542,19 +556,14 @@ export class QuickSearchComponent {
     }
 
     private showSectionTitle(searchSection: SearchSection): boolean {
-        // Do not show when there is no search criteria
-        if (!this.searchCriteria) {
-            return false;
-        }
-
         // Do not show when there is no section name
         if (!searchSection.provider.sectionName) {
             return false;
         }
 
-        // Show when it is loading
+        // Don't show when it is loading
         if (searchSection.isLoading) {
-            return true;
+            return false;
         }
 
         // Do not show when the provider has no results
@@ -566,7 +575,7 @@ export class QuickSearchComponent {
     }
 
     showParentSectionTitle(parentSection: GroupedSearchSections): boolean {
-        return parentSection.subSections.some((section) => section.shouldShowText);
+        return parentSection.subSections.some((section) => section.shouldShowText && !section.isLoading);
     }
 
     checkHasNoResults(): boolean {
@@ -594,53 +603,6 @@ export class QuickSearchComponent {
         return null;
     }
 
-    /**
-     * Parses the given search criteria to remove all filters and separate them.
-     *
-     * @example this.parseSearchCriteria('searchTerm filter:value other:value') =>
-     * {
-     *    searchTerm: 'searchTerm',
-     *    filters: [{ id: 'filter', value: 'value', ...}, { id: 'other', value: 'value'}]
-     * }
-     */
-    private parseSearchCriteria(
-        searchCriteria: string
-    ): {
-        searchTerm: string;
-        filters: ActiveQuickSearchFilter[];
-    } {
-        const activeFilters: ActiveQuickSearchFilter[] = [];
-        let removedFiltersSearch = searchCriteria;
-        if (removedFiltersSearch) {
-            for (const filter of this.filters) {
-                while (removedFiltersSearch.includes(filter.id + ':')) {
-                    const parts = removedFiltersSearch.split(filter.id + ':');
-                    const beginning = parts.shift();
-                    const end = parts.join(filter.id + ':');
-                    const parts2 = end.split(' ');
-                    const filterValue = parts2.shift();
-                    const rest = parts2.join(' ');
-                    activeFilters.push({
-                        id: filter.id,
-                        options: filter.options,
-                        value: filterValue,
-                        data: filter.options.find((option) => option.display === filterValue)?.data,
-                    });
-                    removedFiltersSearch = (beginning + rest).trim();
-                }
-            }
-        }
-
-        if (removedFiltersSearch) {
-            removedFiltersSearch = removedFiltersSearch.trim();
-        }
-
-        return {
-            filters: activeFilters,
-            searchTerm: removedFiltersSearch,
-        };
-    }
-
     groupSectionTrackBy(_index: number, groupedSection: GroupedSearchSections): string {
         return groupedSection.headerTitle;
     }
@@ -650,6 +612,10 @@ export class QuickSearchComponent {
     }
 
     filterOptionTrackBy(_index: number, filterOption: QuickSearchFilterOption): string {
-        return filterOption.display;
+        return filterOption.key;
+    }
+
+    filterTrackBy(_index: number, filterOption: QuickSearchFilter): string {
+        return filterOption.id;
     }
 }

--- a/projects/components/src/quick-search/quick-search.dataui.ts
+++ b/projects/components/src/quick-search/quick-search.dataui.ts
@@ -10,4 +10,8 @@ export const DataUi = {
     noResults: 'no-results',
     searchInput: 'search-input,',
     searchResultAlerts: 'search-result-alerts',
+    filterDropdownItem: 'filter-dropdown-item',
+    filterButton(id: string) {
+        return `filter-btn:${id}`;
+    },
 };

--- a/projects/components/src/quick-search/quick-search.module.ts
+++ b/projects/components/src/quick-search/quick-search.module.ts
@@ -8,11 +8,19 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
+import { ShowClippedTextDirectiveModule } from '../lib/directives/show-clipped-text.directive.module';
 import { DrawerComponent } from './drawer/drawer.component';
 import { QuickSearchComponent } from './quick-search.component';
 
 @NgModule({
-    imports: [CommonModule, ClarityModule, FormsModule, ReactiveFormsModule, I18nModule],
+    imports: [
+        CommonModule,
+        ClarityModule,
+        FormsModule,
+        ReactiveFormsModule,
+        I18nModule,
+        ShowClippedTextDirectiveModule,
+    ],
     declarations: [QuickSearchComponent, DrawerComponent],
     exports: [QuickSearchComponent],
 })

--- a/projects/components/src/quick-search/quick-search.wo.ts
+++ b/projects/components/src/quick-search/quick-search.wo.ts
@@ -72,11 +72,11 @@ export class QuickSearchWo<T> extends BaseWidgetObject<T> {
     getBottomOfResults = this.factory.css('.bottom-of-results');
 
     getFilterButton(id: string) {
-        return this.el.get({ dataUiSelector: 'filter:' + id }).unwrap();
+        return this.el.get({ dataUiSelector: DataUi.filterButton(id) }).unwrap();
     }
 
     getFilterDropdownOptions(index: number) {
-        return this.el.get({ dataUiSelector: 'filter-dropdown-item', index }).unwrap();
+        return this.el.get({ dataUiSelector: DataUi.filterDropdownItem, index }).unwrap();
     }
 
     /**

--- a/projects/components/src/quick-search/quick-search.wo.ts
+++ b/projects/components/src/quick-search/quick-search.wo.ts
@@ -71,6 +71,14 @@ export class QuickSearchWo<T> extends BaseWidgetObject<T> {
      */
     getBottomOfResults = this.factory.css('.bottom-of-results');
 
+    getFilterButton(id: string) {
+        return this.el.get({ dataUiSelector: 'filter:' + id }).unwrap();
+    }
+
+    getFilterDropdownOptions(index: number) {
+        return this.el.get({ dataUiSelector: 'filter-dropdown-item', index }).unwrap();
+    }
+
     /**
      * Gives the icon next to each section title.
      */

--- a/projects/examples/src/components/quick-search/filters/quick-search-filters.example.component.ts
+++ b/projects/examples/src/components/quick-search/filters/quick-search-filters.example.component.ts
@@ -26,15 +26,22 @@ export class QuickSearchFiltersExampleComponent implements OnInit {
         {
             id: 'type',
             options: [
-                { display: 'actions1' },
-                { display: 'actions2' },
-                { display: 'actions3' },
-                { display: 'actions4' },
+                { display: 'actions1', key: 'actions1' },
+                { display: 'actions2', key: 'actions2' },
+                { display: 'actions3', key: 'actions3' },
+                { display: 'actions4', key: 'actions4' },
             ],
+            dropdownText: 'test',
+            bubbleI18nKey: 'hello',
         },
         {
             id: 'is',
-            options: [{ display: 'real' }, { display: 'fake' }],
+            options: [
+                { display: 'real', key: 'real' },
+                { display: 'fake', key: 'fake' },
+            ],
+            dropdownText: 'test',
+            bubbleI18nKey: 'hello',
         },
     ];
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

1. Entirely changes the way quick search filters are displayed. There is now a series of dropdown buttons where you can select filter types and then they display as bubbles below the dropdowns. See screenshots for examples. 
2. Changes how loading works. There is now only one loading indicator and sections do not show up until they are done loading.
3. Fixes a bug where the section title might appear on a different line than the section icon.

## What manual testing did you do?
1. Loaded into VCD_UI 
2. Searched for a term
3. Applies a filter
4. Observed results 
5. Applied another filter of a different type
6. Observed results
7. removed a filter using the bubble
8. Observed results 

## Screenshots (if applicable)

![filters](https://user-images.githubusercontent.com/7528512/118029554-46a6b800-b332-11eb-89c7-9c9a85a6b812.gif)

(filters only appear if there's more than one option)
<img width="698" alt="Screen Shot 2021-05-11 at 4 24 53 PM" src="https://user-images.githubusercontent.com/7528512/118002360-89a66280-b315-11eb-8eda-400284b252d1.png">


## Does this PR introduce a breaking change?

-   [X] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
