### PR TITLE
Configure quick search filters through service

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-dev.21]
+
+### Changed
+- BREAKING: Quick search filters are now set through the service.
+- BREAKING: Pinning is now handled through the search service.
+
+### Added
+- You can now use the quick search service to select a filter and test if the modal is pinned.
 
 ### Fixes
 - Fix pinned quick search appearing above modals
-
 ## [2.0.0-dev.20]
 ### Changed
 - BREAKING: Reworked Quick Search Filters

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.20",
+    "version": "2.0.0-dev.21",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -19,9 +19,9 @@
 </ng-template>
 
 <ng-template #filtersSection>
-    <div class="filter-container" *ngIf="_filters.length > 0">
+    <div class="filter-container" *ngIf="this.searchService.filters.length > 0">
         <p>Filter By</p>
-        <ng-container *ngFor="let filter of _filters">
+        <ng-container *ngFor="let filter of this.searchService.filters">
             <clr-dropdown
                 [clrCloseMenuOnItemClick]="false"
                 *ngIf="filter.options.length > 1"
@@ -61,7 +61,7 @@
         </ng-container>
     </div>
     <div>
-        <ng-container *ngFor="let filter of _filters">
+        <ng-container *ngFor="let filter of this.searchService.filters">
             <span class="filter-bubble label" *ngFor="let option of filterValues.get(filter.id)">
                 <span [vcdShowClippedText]="{ disabled: !open }">{{
                     filter.bubbleI18nKey | translate: { option: option.display }
@@ -126,7 +126,7 @@
             [attr.data-ui]="DataUi.searchInput"
         />
         <button class="btn btn-link pin-button" (click)="togglePinned()">
-            <clr-icon shape="pin" size="20" [ngClass]="isPinned ? 'is-solid' : ''"> </clr-icon>
+            <clr-icon shape="pin" size="20" [ngClass]="this.searchService.isPinned ? 'is-solid' : ''"> </clr-icon>
         </button>
     </div>
     <clr-control-helper class="input-helper">{{ helper }}</clr-control-helper>
@@ -201,7 +201,7 @@
     (keydown.arrowup)="onArrowUp($event)"
     (keydown.arrowdown)="onArrowDown($event)"
     (keydown.enter)="onEnterKey($event)"
-    *ngIf="!isPinned; else drawerComponent"
+    *ngIf="!searchService.isPinned; else drawerComponent"
 >
     <div class="modal-body" [attr.data-ui]="DataUi.modalBody">
         <ng-container *ngTemplateOutlet="quickSearchInterior"> </ng-container>

--- a/projects/components/src/quick-search/quick-search.component.spec.ts
+++ b/projects/components/src/quick-search/quick-search.component.spec.ts
@@ -832,7 +832,7 @@ describe('QuickSearchComponent', () => {
         });
 
         it('adds a filter icon that shows providers only of that type', function (this: Test): void {
-            this.finder.hostComponent.filters = [
+            this.quickSearchData.spotlightSearchService.registerFilters([
                 {
                     id: 'type',
                     options: [
@@ -842,7 +842,7 @@ describe('QuickSearchComponent', () => {
                     dropdownText: 'dropdown',
                     bubbleI18nKey: 'bubble-key',
                 },
-            ];
+            ]);
             this.quickSearchData.anotherSimpleProvider.sectionName = 'another section';
             this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.anotherSimpleProvider);
             this.quickSearch.getInput().type('copy');
@@ -855,6 +855,30 @@ describe('QuickSearchComponent', () => {
             expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(1);
             expect(this.quickSearch.getSearchResultItems().text()).toEqual('copy');
         });
+
+        it('can set filter values through the QuickSearchService', function (this: Test): void {
+            this.quickSearchData.spotlightSearchService.registerFilters([
+                {
+                    id: 'type',
+                    options: [
+                        { display: 'simple', key: 'simple' },
+                        { display: 'simple2', key: 'simple2' },
+                    ],
+                    dropdownText: 'dropdown',
+                    bubbleI18nKey: 'bubble-key',
+                },
+            ]);
+            this.quickSearchData.anotherSimpleProvider.sectionName = 'another section';
+            this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.anotherSimpleProvider);
+            this.quickSearch.getInput().type('copy');
+            expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(1);
+
+            // When the type filter is present, the list of providers is filtered based on it.
+            // In this case, the type:simple filter is set and anotherSimpleProvider is removed.
+            this.quickSearchData.spotlightSearchService.selectFilter('type', ['simple']);
+            expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(1);
+            expect(this.quickSearch.getSearchResultItems().text()).toEqual('copy');
+        });
     });
 });
 @Component({
@@ -863,7 +887,6 @@ describe('QuickSearchComponent', () => {
             [(open)]="spotlightOpen"
             (resultActivated)="resultActivated($event)"
             [placeholder]="placeholder"
-            [filters]="filters"
         >
             <div data-ui="top-results" class="top-of-results" *ngIf="isTopOfResultsShown">Top of results</div>
             <div data-ui="bottom-results" class="bottom-of-results" *ngIf="isBottomOfResultsShown">
@@ -877,7 +900,6 @@ export class HostSpotlightSearchComponent {
     public spotlightOpen = false;
     public isTopOfResultsShown = false;
     public isBottomOfResultsShown = false;
-    public filters: QuickSearchFilter[] = [];
 
     resultActivated(event: ResultActivatedEvent): void {}
 }

--- a/projects/examples/src/assets/our-translations.json
+++ b/projects/examples/src/assets/our-translations.json
@@ -11,7 +11,9 @@
         "grouped.actions3": "Grouped Actions 3",
         "grouped.actions4": "Grouped Actions 4",
         "grouped.actions.with.single.child": "Grouped actions with single child",
-        "contextual.actions": "Contextual actions"
+        "contextual.actions": "Contextual actions",
+        "result.filter.identifier": "Result: {option}",
+        "provider.filter.identifier": "Provider: {option}"
     },
     "de": {
         "select.all": "Wählen Sie Alle",

--- a/projects/examples/src/components/quick-search/filters/quick-search-filters.example.component.html
+++ b/projects/examples/src/components/quick-search/filters/quick-search-filters.example.component.html
@@ -8,9 +8,19 @@ is all handled from the provider side.
 If two filters of the same name are present, they should be joined by "or". If two filters of different names are
 present, they should be joined by "and".
 <br /><br />
-In this example, there are two filters present: "type" and "is". Type will filter the results by provider ID, and is a
-dynamic filter that will filter the results on if they are real action.
-<br /><br />
-Users are able to navigate through the filters both by typing and by using the mouse. Typing (name): will bring up a
-dropdown that allows the user to either scroll through using the keyboard or by clicking.
-<vcd-quick-search [(open)]="spotlightOpen" [filters]="filters"> </vcd-quick-search>
+In this example, there are two filters present:
+<ul>
+    <li>
+        "Provider": this filter can filter the results by provider ID. Meaning users can filter the results so they only
+        see items from one specific provider.
+    </li>
+    <li>
+        "Result": this filter can filter the results by their text. In this example, if the "fake" filter is selected,
+        only results containing "dummy" will be shown.
+    </li>
+</ul>
+<br />
+The users are able to select these filters through the dropdowns. Click either dropdown to open the filter options, and
+select an option. The selected option is then shown as a bubble that can be deleted using the close button. The text for
+this bubble is provided as a translation key that takes one parameter "option" which is the text of the option selected.
+<vcd-quick-search [(open)]="spotlightOpen"> </vcd-quick-search>

--- a/projects/examples/src/components/quick-search/filters/quick-search-filters.example.component.ts
+++ b/projects/examples/src/components/quick-search/filters/quick-search-filters.example.component.ts
@@ -11,6 +11,7 @@ import {
     QuickSearchRegistrarService,
     QuickSearchResultItem,
     QuickSearchResultsType,
+    QuickSearchService,
 } from '@vcd/ui-components';
 
 @Component({
@@ -31,17 +32,17 @@ export class QuickSearchFiltersExampleComponent implements OnInit {
                 { display: 'actions3', key: 'actions3' },
                 { display: 'actions4', key: 'actions4' },
             ],
-            dropdownText: 'test',
-            bubbleI18nKey: 'hello',
+            dropdownText: 'Provider Filter',
+            bubbleI18nKey: 'provider.filter.identifier',
         },
         {
-            id: 'is',
+            id: 'result-filter',
             options: [
-                { display: 'real', key: 'real' },
-                { display: 'fake', key: 'fake' },
+                { display: 'Real', key: 'real' },
+                { display: 'Fake', key: 'fake' },
             ],
-            dropdownText: 'test',
-            bubbleI18nKey: 'hello',
+            dropdownText: 'Result Filter',
+            bubbleI18nKey: 'result.filter.identifier',
         },
     ];
 
@@ -50,9 +51,10 @@ export class QuickSearchFiltersExampleComponent implements OnInit {
     private actionsSearchProvider3 = new ActionsSearchProvider('actions3');
     private actionsSearchProvider4 = new ActionsSearchProvider('actions4');
 
-    constructor(private searchRegistrar: QuickSearchRegistrarService) {}
+    constructor(private searchRegistrar: QuickSearchRegistrarService, private searchService: QuickSearchService) {}
 
     ngOnInit(): void {
+        this.searchService.registerFilters(this.filters);
         this.searchRegistrar.register(this.actionsSearchProvider);
         this.searchRegistrar.register(this.actionsSearchProvider2);
         this.searchRegistrar.register(this.actionsSearchProvider3);
@@ -64,7 +66,7 @@ const actions: string[] = ['copy', 'paste', 'move', 'dummy', 'other-dummy'];
 
 function buildFilter(criteria: string, filters: ActiveQuickSearchFilter[]): (item: QuickSearchResultItem) => boolean {
     criteria = criteria ? criteria.toLowerCase() : '';
-    const isFilter = filters.find((filter) => filter.id === 'is');
+    const isFilter = filters.find((filter) => filter.id === 'result-filter');
     return (item: QuickSearchResultItem) =>
         item.displayText.toLowerCase().includes(criteria) &&
         (!isFilter ||
@@ -107,6 +109,6 @@ export class ActionsSearchProvider extends QuickSearchProviderDefaults {
     }
 
     canHandleFilter(filter: ActiveQuickSearchFilter): boolean {
-        return super.canHandleFilter(filter) || filter.id === 'is';
+        return super.canHandleFilter(filter) || filter.id === 'result-filter';
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [X] Feature
-   [ ] Code style update (formatting, local variables)
-   [X] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Filters are now configured through the search service rather than through quick search itself. In addition, the search service now has methods to select a filter value and to test if the modal is pinned or not.

## What manual testing did you do?
1. Loaded into VCD_UI
2. Set organizations page to automatically select a filter only if not pinned
3. Navigated to orgs page, observed added filter
4. Navigated away and deselected filter
5. Pinned modal
6. Navigated to orgs page
7. Observed filter NOT selected

## Screenshots (if applicable)

![auto-filters](https://user-images.githubusercontent.com/7528512/118174664-1f68ed00-b3fd-11eb-9dad-f9b8cbe0ce6b.gif)

![examples](https://user-images.githubusercontent.com/7528512/118314698-7c7aa680-b4c2-11eb-9fc7-8ec731ab023c.gif)


## Does this PR introduce a breaking change?

-   [X] Yes
-   [ ] No

We felt like filters should be configured through the service rather than through the components itself. This is like how providers are already configured. Clients should rework their code to not bind to the `@Input() filters` and instead use the `registerFilters` method.

## Other information
