### PR TITLE
Add example to show 'display configurations' for contextual actions in data grid

### DIFF
--- a/projects/examples/src/components/datagrid/datagrid-action-display-config.example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-action-display-config.example.component.html
@@ -1,0 +1,49 @@
+<h4>Contextual action display configuration:</h4>
+<form [formGroup]="contextualFormGroup" class="clr-form-horizontal">
+    <vcd-form-select
+        [label]="'Styling'"
+        [description]="'Display actions inline or in a dropdown'"
+        [options]="stylingOptions"
+        [formControlName]="'styling'"
+    >
+    </vcd-form-select>
+
+    <vcd-form-select
+        [label]="'Button Contents'"
+        [description]="'Content of action buttons'"
+        [options]="buttonContentsOptions"
+        [formControlName]="'buttonContents'"
+    >
+    </vcd-form-select>
+
+    <vcd-form-select
+        [label]="'Position'"
+        [description]="'Where in the datagrid should the contextual actions be displayed'"
+        [options]="positionOptions"
+        [formControlName]="'position'"
+    >
+    </vcd-form-select>
+
+    <vcd-form-input
+        [label]="'Featured action count'"
+        [description]="
+            'How many of the contextual actions that are marked as featured should be displayed in featured section'
+        "
+        [type]="'number'"
+        [formControlName]="'featuredCount'"
+    >
+    </vcd-form-input>
+</form>
+
+<vcd-datagrid
+    [gridData]="gridData"
+    (gridRefresh)="refresh($event)"
+    [columns]="columns"
+    [actions]="actions"
+    [actionDisplayConfig]="actionDisplayConfig"
+    [selectionType]="selectionType"
+></vcd-datagrid>
+
+<h4>The contextual action display configuration selected:</h4>
+
+<pre><code>{{ actionDisplayConfig | json }}</code></pre>

--- a/projects/examples/src/components/datagrid/datagrid-action-display-config.example.component.scss
+++ b/projects/examples/src/components/datagrid/datagrid-action-display-config.example.component.scss
@@ -1,0 +1,5 @@
+vcd-datagrid ::ng-deep .inline-actions-container {
+    & .first-dropdown-toggle {
+        margin-top: 0 !important;
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-action-display-config.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-action-display-config.example.component.ts
@@ -1,0 +1,179 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import {
+    ActionItem,
+    ActionStyling,
+    ActionType,
+    DatagridActionDisplayConfig,
+    DatagridComponent,
+    DatagridContextualActionPosition,
+    GridColumn,
+    GridDataFetchResult,
+    GridSelectionType,
+    GridState,
+    SelectOption,
+    TextIcon,
+} from '@vcd/ui-components';
+
+@Component({
+    selector: 'vcd-datagrid-action-display-config-example',
+    templateUrl: 'datagrid-action-display-config.example.component.html',
+    styleUrls: ['datagrid-action-display-config.example.component.scss'],
+})
+export class DatagridActionDisplayConfigExampleComponent implements OnInit {
+    @ViewChild(DatagridComponent, { static: true }) dg: DatagridComponent<any>;
+
+    gridData: GridDataFetchResult<any> = {
+        items: [],
+    };
+
+    columns: GridColumn<any>[] = [
+        {
+            displayName: 'Some Value',
+            renderer: 'value',
+        },
+    ];
+
+    actions: ActionItem<unknown, unknown>[] = [
+        {
+            textKey: 'Contextual 1',
+            handler: () => {
+                console.log('Contextual action output');
+            },
+            isTranslatable: false,
+            icon: 'cloud',
+        },
+        {
+            textKey: 'Featured 1',
+            handler: () => null,
+            isTranslatable: false,
+            icon: 'user',
+            actionType: ActionType.CONTEXTUAL_FEATURED,
+        },
+        {
+            textKey: 'Nested actions',
+            children: [
+                {
+                    textKey: 'Featured 2',
+                    actionType: ActionType.CONTEXTUAL_FEATURED,
+                    handler: () => null,
+                    isTranslatable: false,
+                    icon: 'cog',
+                },
+                {
+                    textKey: 'Featured 3',
+                    actionType: ActionType.CONTEXTUAL_FEATURED,
+                    handler: () => null,
+                    isTranslatable: false,
+                    icon: 'folder',
+                },
+                {
+                    textKey: 'Contextual 2',
+                    handler: () => null,
+                    isTranslatable: false,
+                    icon: 'home',
+                },
+            ],
+            isTranslatable: false,
+        },
+    ];
+
+    actionDisplayConfig: DatagridActionDisplayConfig = {
+        contextual: {
+            styling: ActionStyling.INLINE,
+            featuredCount: 2,
+            buttonContents: TextIcon.TEXT,
+            position: DatagridContextualActionPosition.TOP,
+        },
+    };
+
+    selectionType = GridSelectionType.Single;
+
+    contextualFormGroup = this.fb.group({
+        ['styling']: [ActionStyling.INLINE],
+        ['buttonContents']: [TextIcon.TEXT],
+        ['position']: [DatagridContextualActionPosition.TOP],
+        ['featuredCount']: [2],
+    });
+
+    stylingOptions: SelectOption[] = [
+        {
+            value: ActionStyling.INLINE,
+            display: 'Inline',
+        },
+        {
+            value: ActionStyling.DROPDOWN,
+            display: 'Dropdown',
+        },
+    ];
+
+    buttonContentsOptions: SelectOption[] = [
+        {
+            value: TextIcon.ICON,
+            display: 'Icon',
+        },
+        {
+            value: TextIcon.TEXT,
+            display: 'Text',
+        },
+        {
+            value: TextIcon.ICON_AND_TEXT,
+            display: 'Icon and Text',
+        },
+    ];
+
+    positionOptions: SelectOption[] = [
+        {
+            value: DatagridContextualActionPosition.TOP,
+            display: 'Top',
+        },
+        {
+            value: DatagridContextualActionPosition.ROW,
+            display: 'In row',
+        },
+    ];
+
+    constructor(private fb: FormBuilder) {}
+
+    refresh(eventData: GridState<any>): void {
+        this.gridData = {
+            items: [
+                { value: 'a', paused: false },
+                { value: 'b', paused: true },
+            ],
+            totalItems: 2,
+        };
+    }
+
+    ngOnInit(): void {
+        this.updateFeaturedCountControl(this.actionDisplayConfig.contextual);
+
+        this.contextualFormGroup.valueChanges.subscribe((formValue) => {
+            this.updateFeaturedCountControl(formValue);
+            this.updateGridSelectionType(formValue);
+
+            this.actionDisplayConfig = {
+                contextual: { ...this.contextualFormGroup.value },
+            };
+        });
+    }
+
+    updateFeaturedCountControl(value) {
+        if (value.styling === ActionStyling.INLINE) {
+            this.contextualFormGroup.get('featuredCount').enable({ onlySelf: true, emitEvent: false });
+        } else {
+            this.contextualFormGroup.get('featuredCount').disable({ onlySelf: true, emitEvent: false });
+        }
+        this.contextualFormGroup.updateValueAndValidity({ onlySelf: true, emitEvent: false });
+    }
+
+    updateGridSelectionType(value) {
+        this.selectionType =
+            value.position === DatagridContextualActionPosition.ROW ? GridSelectionType.None : GridSelectionType.Single;
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-action-display-config.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-action-display-config.example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { VcdComponentsModule } from '@vcd/ui-components';
+import { DatagridActionDisplayConfigExampleComponent } from './datagrid-action-display-config.example.component';
+
+@NgModule({
+    declarations: [DatagridActionDisplayConfigExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
+    exports: [DatagridActionDisplayConfigExampleComponent],
+    entryComponents: [DatagridActionDisplayConfigExampleComponent],
+})
+export class DatagridActionDisplayConfigExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-link.example.component.ts
@@ -35,27 +35,10 @@ type HandlerData = Record[] | Blah;
 /**
  * Shows linked buttons on the top of the datagrid.
  * Has examples of both buttons that are global and contextual.
- *
- * Enable the delete button to hide it and disable the delete button to show it in disable mode. This is because the
- * inactive display mode of a button can be set as following:
- *  - Hidden - availability is false and disabled is false
- *  - Shown as Disabled - availability is false and disabled is true
- * Please refer to the delete action object configuration in the actions object list configuration.
  */
 @Component({
     selector: 'vcd-datagrid-link-example',
     template: `
-        <button (click)="changeActionLocation()" class="btn btn-primary">
-            Display contextual actions {{ actionDisplayConfig.contextual.position === 'ROW' ? 'on top' : 'in row' }}
-        </button>
-        <button
-            *ngIf="actionDisplayConfig.contextual.position === 'ROW'"
-            (click)="changeContextualActionStyling()"
-            class="btn btn-primary"
-        >
-            Display contextual actions {{ actionDisplayConfig.contextual.styling === 'INLINE' ? 'dropdown' : 'inline' }}
-        </button>
-        <br />
         <vcd-datagrid
             [gridData]="gridData"
             (gridRefresh)="refresh($event)"
@@ -158,22 +141,6 @@ export class DatagridLinkExampleComponent<R extends Record> {
 
     selectionType = GridSelectionType.Single;
 
-    changeActionLocation(): void {
-        if (this.actionDisplayConfig.contextual.position === DatagridContextualActionPosition.TOP) {
-            this.actionDisplayConfig = {
-                contextual: {
-                    ...getDefaultDatagridActionDisplayConfig().contextual,
-                    position: DatagridContextualActionPosition.ROW,
-                },
-                staticActionStyling: getDefaultDatagridActionDisplayConfig().staticActionStyling,
-            };
-            this.selectionType = GridSelectionType.None;
-        } else {
-            this.actionDisplayConfig = getDefaultDatagridActionDisplayConfig();
-            this.selectionType = GridSelectionType.Single;
-        }
-    }
-
     refresh(eventData: GridState<R>): void {
         this.gridData = {
             items: [
@@ -183,19 +150,6 @@ export class DatagridLinkExampleComponent<R extends Record> {
                 { value: 'b', paused: false },
             ],
             totalItems: 2,
-        };
-    }
-
-    changeContextualActionStyling(): void {
-        this.actionDisplayConfig = {
-            contextual: {
-                ...this.actionDisplayConfig.contextual,
-                styling:
-                    this.actionDisplayConfig.contextual.styling === ActionStyling.DROPDOWN
-                        ? (ActionStyling.INLINE as any)
-                        : ActionStyling.DROPDOWN,
-            },
-            staticActionStyling: this.actionDisplayConfig.staticActionStyling,
         };
     }
 }

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -6,6 +6,8 @@
 import { NgModule } from '@angular/core';
 import { DatagridComponent } from '@vcd/ui-components';
 import { Documentation } from '@vmw/ng-live-docs';
+import { DatagridActionDisplayConfigExampleComponent } from './datagrid-action-display-config.example.component';
+import { DatagridActionDisplayConfigExampleModule } from './datagrid-action-display-config.example.module';
 import { DatagridActionMenuTrackingExampleComponent } from './datagrid-action-menu-tracking-example.component';
 import { DatagridActionMenuTrackerExampleModule } from './datagrid-action-menu-tracking.example.module';
 import { DatagridActivityReporterExampleComponent } from './datagrid-activity-reporter.example.component';
@@ -105,14 +107,20 @@ Documentation.registerDocumentationEntry({
         {
             component: DatagridLinkExampleComponent,
             forComponent: null,
-            title: 'Links from Datagrid Example',
+            title: 'Datagrid with actions',
             urlSegment: 'datagrid-link',
         },
         {
             component: DatagridActionMenuTrackingExampleComponent,
             forComponent: null,
-            title: 'Action menu availability tracking',
+            title: 'Hiding of actions',
             urlSegment: 'action-menu-availability-tracking',
+        },
+        {
+            component: DatagridActionDisplayConfigExampleComponent,
+            forComponent: null,
+            title: 'Display config of contextual actions',
+            urlSegment: 'datagrid-action-display-config',
         },
         {
             component: DatagridFilterExampleComponent,
@@ -181,6 +189,7 @@ Documentation.registerDocumentationEntry({
         DatagridLoadingPlaceholderExampleModule,
         DatagridDetailPaneExampleModule,
         DatagridColumnWidthExampleModule,
+        DatagridActionDisplayConfigExampleModule,
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [X] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
To make it clear for the users of our library about different options
available to display actions and also show them the input object that
has to be passed to datagrid to customize the actions displayed

## What manual testing did you do?
Started the local dev server of examples app and verified that the
example does the following:
- Changes the contextual actions displayed based on the display options
selected
- The actionDisplayConfig object is printed at the bottom of the example

## Screenshots (if applicable)

https://user-images.githubusercontent.com/10735165/118649442-8269d380-b7b1-11eb-9bab-35cfe96f253b.mov

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
