### PR TITLE
Removes internalFactory from WidgetObject

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-dev.24]
+## Changed
+- BREAKING: internalFactory has been removed from WidgetObject. All users of our exposed WidgetObjectElements
+  will need to call unwrap() on the methods returning HTML elements if they want to access `T` functionality
+
 ## [2.0.0-dev.23]
 ### Changed
 - Refactor quick search so the service contains much more logic.

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.23",
+    "version": "2.0.0-dev.24",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/data-exporter/data-exporter.component.spec.ts
+++ b/projects/components/src/data-exporter/data-exporter.component.spec.ts
@@ -66,8 +66,14 @@ describe('DataExporterColumnsWithoutDisplayName', () => {
         const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
         exporter.getToggleSelectAll().click();
         this.finder.detectChanges();
-        const columnBubbles = exporter.getColumnBubbles().map((i) => i.text());
-        const columnCheckboxLabels = exporter.getColumnCheckboxes().map((i) => i.text());
+        const columnBubbles = exporter
+            .getColumnBubbles()
+            .unwrap()
+            .map((i) => i.text());
+        const columnCheckboxLabels = exporter
+            .getColumnCheckboxes()
+            .unwrap()
+            .map((i) => i.text());
         const expects = ['col1', 'col2'];
         expect(columnBubbles).toEqual(expects);
         expect(columnCheckboxLabels).toEqual(expects);
@@ -100,6 +106,7 @@ describe('VcdExportTableComponent', () => {
             expect(
                 exporter
                     .getColumnBubbles()
+                    .unwrap()
                     .toArray()
                     .map((it) => it.text())
             ).toEqual(['Name', 'Description']);
@@ -111,18 +118,19 @@ describe('VcdExportTableComponent', () => {
             expect(
                 exporter
                     .getColumnBubbles()
+                    .unwrap()
                     .toArray()
                     .map((it) => it.text())
             ).toEqual(['Name', 'Description']);
             exporter.getColumnCheckboxes({ index: 0 }).click();
-            expect(exporter.getColumnBubbles().text()).toBe('Description');
+            expect(exporter.getColumnBubbles().unwrap().text()).toBe('Description');
         });
 
         it('allows the user to remove selected columns', function (this: TestHostFinder): void {
             const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
             exporter.getToggleSelectAll().click();
             exporter.getColumnCheckboxes({ index: 0 }).click();
-            expect(exporter.getColumnBubbles().text()).toBe('Description');
+            expect(exporter.getColumnBubbles().unwrap().text()).toBe('Description');
         });
 
         it('allows the user to deselect and reselect columns', fakeAsync(function (this: TestHostFinder): void {
@@ -130,12 +138,15 @@ describe('VcdExportTableComponent', () => {
             const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
             exporter.getToggleSelectAll().click();
             exporter.getColumnCheckboxes({ index: 0 }).click();
-            expect(exporter.getColumnBubbles().text()).toBe('Description');
+            expect(exporter.getColumnBubbles().unwrap().text()).toBe('Description');
             exporter.getColumnCheckboxes({ index: 0 }).click();
-            const actual = exporter.getColumnBubbles().map((it) => it.text());
+            const actual = exporter
+                .getColumnBubbles()
+                .unwrap()
+                .map((it) => it.text());
             expect(actual).toEqual(['Name', 'Description']);
             exporter.getColumnCheckboxes({ index: 1 }).click();
-            expect(exporter.getColumnBubbles().text()).toBe('Name');
+            expect(exporter.getColumnBubbles().unwrap().text()).toBe('Name');
             tick();
         }));
 
@@ -143,10 +154,16 @@ describe('VcdExportTableComponent', () => {
             const exporter = this.finder.find<DataExporterWidgetObject<TestElement>>(DataExporterWidgetObject);
             exporter.getToggleSelectAll().click();
             exporter.getColumnCheckboxArrow().click();
-            const bubblesTextBeforeRemoving = exporter.getColumnBubbles().map((it) => it.text());
+            const bubblesTextBeforeRemoving = exporter
+                .getColumnBubbles()
+                .unwrap()
+                .map((it) => it.text());
             expect(bubblesTextBeforeRemoving).toEqual(['Name', 'Description']);
             exporter.getColumnBubblesX({ index: 0 }).click();
-            const bubblesTextAfterRemoving = exporter.getColumnBubbles().map((it) => it.text());
+            const bubblesTextAfterRemoving = exporter
+                .getColumnBubbles()
+                .unwrap()
+                .map((it) => it.text());
             expect(bubblesTextAfterRemoving).toEqual(['Description']);
         });
     });
@@ -176,7 +193,7 @@ describe('VcdExportTableComponent', () => {
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
                     e.updateProgress(-1);
                     this.finder.detectChanges();
-                    expect(exporter.getProgress().length()).toBe(1, 'Looping bar should have been visible');
+                    expect(exporter.getProgress().unwrap().length()).toBe(1, 'Looping bar should have been visible');
                 });
                 exporter.getExportButton().click();
             });
@@ -188,10 +205,10 @@ describe('VcdExportTableComponent', () => {
                 spyOn(this.finder.hostComponent, 'onExportRequest').and.callFake((e: DataExportRequestEvent) => {
                     e.updateProgress(0);
                     this.finder.detectChanges();
-                    expect(Number(exporter.getProgress().value()) / 100).toBe(0);
+                    expect(Number(exporter.getProgress().unwrap().value()) / 100).toBe(0);
                     e.updateProgress(0.5);
                     this.finder.detectChanges();
-                    expect(Number(exporter.getProgress().value()) / 100).toBe(0.5);
+                    expect(Number(exporter.getProgress().unwrap().value()) / 100).toBe(0.5);
                 });
                 exporter.getExportButton().click();
             });

--- a/projects/components/src/data-exporter/data-exporter.wo.ts
+++ b/projects/components/src/data-exporter/data-exporter.wo.ts
@@ -21,12 +21,10 @@ export class DataExporterWidgetObject<T> extends BaseWidgetObject<T> {
     getCancelButton = this.factory.dataUi(DataUi.cancelButton);
 
     /** The button that initiates the export process */
-    private _getExportButton = this.internalFactory.dataUi(DataUi.exportButton);
-    public getExportButton = this.factory.unwrap(this._getExportButton);
+    getExportButton = this.factory.dataUi(DataUi.exportButton);
 
     /** Gets the export all switch */
-    private _getToggleSelectAll = this.internalFactory.dataUi(DataUi.selectAllToggleLabel);
-    public getToggleSelectAll = this.factory.unwrap(this._getToggleSelectAll);
+    getToggleSelectAll = this.factory.dataUi(DataUi.selectAllToggleLabel);
 
     /** Gets the friendly field names switch  */
     getToggleFriendlyNames = this.factory.dataUi(DataUi.friendlyNamesToggleLabel);
@@ -35,10 +33,9 @@ export class DataExporterWidgetObject<T> extends BaseWidgetObject<T> {
     getProgress = this.factory.dataUi(DataUi.progressInput);
 
     /** The list of labels for the checkboxes with the configured columns */
-    private _getColumnCheckboxes = this.internalFactory.dataUi(DataUi.columnSelectionMenuOptions);
-    public getColumnCheckboxes = this.factory.unwrap(this._getColumnCheckboxes);
+    getColumnCheckboxes = this.factory.dataUi(DataUi.columnSelectionMenuOptions);
 
-    private _getColumnCheckboxByLabel = this.internalFactory.dataUi(DataUi.columnSelectionMenuOptions);
+    getColumnCheckboxByLabel = this.factory.dataUi(DataUi.columnSelectionMenuOptions);
 
     getColumnCheckboxArrow = this.factory.dataUi(DataUi.columnCheckboxArrow);
 
@@ -50,11 +47,11 @@ export class DataExporterWidgetObject<T> extends BaseWidgetObject<T> {
      */
     exportData(columnsToUncheck?: string[]): void {
         if (columnsToUncheck) {
-            this._getToggleSelectAll().click();
+            this.getToggleSelectAll().click();
             for (const column of columnsToUncheck) {
-                this._getColumnCheckboxByLabel({ text: column }).click();
+                this.getColumnCheckboxByLabel({ text: column }).click();
             }
         }
-        this._getExportButton().click();
+        this.getExportButton().click();
     }
 }

--- a/projects/components/src/datagrid/datagrid.component.spec.ts
+++ b/projects/components/src/datagrid/datagrid.component.spec.ts
@@ -86,13 +86,14 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
             it('displays number of columns', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.getColumns().length()).toBe(this.hostComponent.columns.length);
+                expect(this.clrGridWidget.getColumns().unwrap().length()).toBe(this.hostComponent.columns.length);
             });
 
             it('displays columns with headers', function (this: HasFinderAndGrid): void {
                 expect(
                     this.clrGridWidget
                         .getColumnHeaders()
+                        .unwrap()
                         .toArray()
                         .map((columnHeader: TestElement) => columnHeader.text())
                 ).toEqual(this.hostComponent.columns.map((col) => col.displayName));
@@ -104,14 +105,17 @@ describe('DatagridComponent', () => {
                 expect(
                     this.clrGridWidget
                         .getColumnHeaders()
+                        .unwrap()
                         .toArray()
                         .map((columnHeader: TestElement) => columnHeader.text())
                 ).toEqual(this.hostComponent.columns.map((col) => col.displayName));
-                expect(this.clrGridWidget.getColumnHeader(0).text()).toEqual(this.hostComponent.columns[0].displayName);
+                expect(this.clrGridWidget.getColumnHeader(0).unwrap().text()).toEqual(
+                    this.hostComponent.columns[0].displayName
+                );
             });
 
             it('displays rows based on the grid data received', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.getRows().length()).toBe(mockData.length);
+                expect(this.clrGridWidget.getRows().unwrap().length()).toBe(mockData.length);
             });
 
             it('gives proper css class for the grid', function (this: HasFinderAndGrid): void {
@@ -121,7 +125,7 @@ describe('DatagridComponent', () => {
             });
 
             it('sets no default CSS classnames for the rows', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.getRow(0).classes()).toEqual(['datagrid-row', 'ng-star-inserted']);
+                expect(this.clrGridWidget.getRow(0).unwrap().classes()).toEqual(['datagrid-row', 'ng-star-inserted']);
             });
 
             it('sets CSS classnames on rows', function (this: HasFinderAndGrid): void {
@@ -131,11 +135,11 @@ describe('DatagridComponent', () => {
                     return firstCall[index];
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getRow(0).classes()).toContain(
+                expect(this.clrGridWidget.getRow(0).unwrap().classes()).toContain(
                     'firstRowA',
                     'Expected the initial class to display for the first row.'
                 );
-                expect(this.clrGridWidget.getRow(1).classes()).toContain(
+                expect(this.clrGridWidget.getRow(1).unwrap().classes()).toContain(
                     'secondRowA',
                     'Expected some different initial class to display for the second row.'
                 );
@@ -143,11 +147,11 @@ describe('DatagridComponent', () => {
                     return secondCall[index];
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getRow(0).classes()).toContain(
+                expect(this.clrGridWidget.getRow(0).unwrap().classes()).toContain(
                     'firstRowB',
                     'Expected a new class to display for the first row.'
                 );
-                expect(this.clrGridWidget.getRow(1).classes()).toContain(
+                expect(this.clrGridWidget.getRow(1).unwrap().classes()).toContain(
                     'secondRowB',
                     'Expected a different new class to display for the second row.'
                 );
@@ -169,6 +173,7 @@ describe('DatagridComponent', () => {
                     expect(
                         this.vcdDatagrid.clrDatagrid
                             .getColumnHeaders()
+                            .unwrap()
                             .toArray()
                             .map((el) => el.text())
                     ).toEqual(['Name', 'City']);
@@ -187,7 +192,7 @@ describe('DatagridComponent', () => {
                 it('clips text when disableCliptext is unset', function (this: HasFinderAndGrid): void {
                     this.hostComponent.columns = [{ displayName: 'Name', renderer: 'name' }];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).unwrap().getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeFalsy();
                 });
 
@@ -196,7 +201,7 @@ describe('DatagridComponent', () => {
                         { displayName: 'Name', renderer: 'name', cliptextConfig: { size: TooltipSize.md } },
                     ];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).unwrap().getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeFalsy();
                 });
 
@@ -205,7 +210,7 @@ describe('DatagridComponent', () => {
                         { displayName: 'Name', renderer: 'name', cliptextConfig: { disabled: true } },
                     ];
                     this.finder.detectChanges();
-                    const res = this.clrGridWidget.getCell(0, 0).getInjector().get(ShowClippedTextDirective);
+                    const res = this.clrGridWidget.getCell(0, 0).unwrap().getInjector().get(ShowClippedTextDirective);
                     expect(res.disabled).toBeTruthy();
                 });
             });
@@ -225,8 +230,8 @@ describe('DatagridComponent', () => {
                         { displayName: 'Name', renderer: 'name' },
                     ];
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getColumn(0).classes()).toContain('some-class');
-                    expect(this.clrGridWidget.getColumn(1).classes()).not.toContain('some-class');
+                    expect(this.clrGridWidget.getColumn(0).unwrap().classes()).toContain('some-class');
+                    expect(this.clrGridWidget.getColumn(1).unwrap().classes()).not.toContain('some-class');
                 });
             });
 
@@ -234,20 +239,20 @@ describe('DatagridComponent', () => {
                 it('has multi selection capabilities when set to multi selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Multi;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getCheckboxWrapper().length()).toBeGreaterThan(0);
+                    expect(this.clrGridWidget.getCheckboxWrapper().unwrap().length()).toBeGreaterThan(0);
                 });
 
                 it('has single selection capabilities when set to single selection', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.Single;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getRadioWrapper().length()).toBeGreaterThan(0);
+                    expect(this.clrGridWidget.getRadioWrapper().unwrap().length()).toBeGreaterThan(0);
                 });
 
                 it('has none selection capabilities when set to none', function (this: HasFinderAndGrid): void {
                     this.hostComponent.selectionType = GridSelectionType.None;
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getCheckboxWrapper().length()).toEqual(0);
-                    expect(this.clrGridWidget.getRadioWrapper().length()).toEqual(0);
+                    expect(this.clrGridWidget.getCheckboxWrapper().unwrap().length()).toEqual(0);
+                    expect(this.clrGridWidget.getRadioWrapper().unwrap().length()).toEqual(0);
                 });
             });
 
@@ -580,7 +585,7 @@ describe('DatagridComponent', () => {
                 describe('pageSize', () => {
                     it('can set the page size before AfterViewInit', function (this: HasFinderAndGrid): void {
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().unwrap().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 5, totalItems: 150 },
                             ])
@@ -598,7 +603,7 @@ describe('DatagridComponent', () => {
                         };
                         this.finder.detectChanges();
                         tick();
-                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().unwrap().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 52, totalItems: 150 },
                             ])
@@ -613,7 +618,7 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().unwrap().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 15, totalItems: 150 },
                             ])
@@ -629,7 +634,7 @@ describe('DatagridComponent', () => {
                             rowHeight: 100,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().unwrap().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 19, totalItems: 150 },
                             ])
@@ -647,7 +652,7 @@ describe('DatagridComponent', () => {
                         };
                         this.finder.detectChanges();
                         tick();
-                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().unwrap().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 25, totalItems: 150 },
                             ])
@@ -660,7 +665,7 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().unwrap().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 100, totalItems: 150 },
                             ])
@@ -684,7 +689,7 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().unwrap().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 51, totalItems: 150 },
                             ])
@@ -700,7 +705,7 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: [10],
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationDescription().text()).toEqual(
+                        expect(this.clrGridWidget.getPaginationDescription().unwrap().text()).toEqual(
                             translationService.translate(DEFAULT_PAGINATION_TRANSLATION_KEY, [
                                 { firstItem: 1, lastItem: 51, totalItems: 150 },
                             ])
@@ -716,7 +721,7 @@ describe('DatagridComponent', () => {
                             pageSizeOptions: undefined,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationSizeSelector().text()).toEqual('Total Items5');
+                        expect(this.clrGridWidget.getPaginationSizeSelector().unwrap().text()).toEqual('Total Items5');
                     });
                 });
 
@@ -727,7 +732,7 @@ describe('DatagridComponent', () => {
                             shouldShowPageSizeSelector: false,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationSizeSelector().length()).toEqual(0);
+                        expect(this.clrGridWidget.getPaginationSizeSelector().unwrap().length()).toEqual(0);
                     });
 
                     it('shows the dropdown when set to true', function (this: HasFinderAndGrid): void {
@@ -736,7 +741,9 @@ describe('DatagridComponent', () => {
                             shouldShowPageSizeSelector: true,
                         };
                         this.finder.detectChanges();
-                        expect(this.clrGridWidget.getPaginationSizeSelector().text()).toEqual('Total Items52050100');
+                        expect(this.clrGridWidget.getPaginationSizeSelector().unwrap().text()).toEqual(
+                            'Total Items52050100'
+                        );
                     });
                 });
             });
@@ -748,7 +755,9 @@ describe('DatagridComponent', () => {
                         shouldShowPageSizeSelector: true,
                     };
                     this.finder.detectChanges();
-                    expect(this.clrGridWidget.getPaginationSizeSelector().text()).toEqual('Total Items52050100');
+                    expect(this.clrGridWidget.getPaginationSizeSelector().unwrap().text()).toEqual(
+                        'Total Items52050100'
+                    );
                 });
             });
 
@@ -781,32 +790,32 @@ describe('DatagridComponent', () => {
         describe('@Input() emptyGridPlaceholder', () => {
             it('does not show the placeholder while the grid is loading', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
-                expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('');
+                expect(this.clrGridWidget.getSpinner().unwrap().length()).toBeGreaterThan(0);
+                expect(this.clrGridWidget.getPlaceHolder().unwrap().text()).toEqual('');
             });
 
             it('shows the placeholder if the grid is empty', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
+                expect(this.clrGridWidget.getSpinner().unwrap().length()).toBeGreaterThan(0);
                 this.hostComponent.gridData = {
                     items: [],
                     totalItems: 0,
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getSpinner().length()).toEqual(0);
-                expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('Placeholder');
+                expect(this.clrGridWidget.getSpinner().unwrap().length()).toEqual(0);
+                expect(this.clrGridWidget.getPlaceHolder().unwrap().text()).toEqual('Placeholder');
             });
 
             it('does not show the placeholder if the grid has data', function (this: HasFinderAndGrid): void {
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getSpinner().length()).toBeGreaterThan(0);
+                expect(this.clrGridWidget.getSpinner().unwrap().length()).toBeGreaterThan(0);
                 this.hostComponent.gridData = {
                     items: mockData,
                     totalItems: 2,
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getSpinner().length()).toEqual(0);
-                expect(this.clrGridWidget.getPlaceHolder().text()).toEqual('');
+                expect(this.clrGridWidget.getSpinner().unwrap().length()).toEqual(0);
+                expect(this.clrGridWidget.getPlaceHolder().unwrap().text()).toEqual('');
             });
         });
 
@@ -865,25 +874,26 @@ describe('DatagridComponent', () => {
                 this.finder.detectChanges();
             });
             it('shows the columns with hidable value of  "Never"', function (this: HasFinderAndGrid): void {
-                expect(isColumnDisplayed(this.clrGridWidget.getColumn(0))).toBe(true);
+                expect(isColumnDisplayed(this.clrGridWidget.getColumn(0).unwrap())).toBe(true);
             });
 
             it('shows the columns with hidable value of  "Shown"', function (this: HasFinderAndGrid): void {
-                expect(isColumnDisplayed(this.clrGridWidget.getColumn(1))).toBe(true);
+                expect(isColumnDisplayed(this.clrGridWidget.getColumn(1).unwrap())).toBe(true);
             });
 
             it('hides the columns with hidable value of  "Hidden"', function (this: HasFinderAndGrid): void {
-                expect(isColumnDisplayed(this.clrGridWidget.getColumn(2))).toBe(false);
+                expect(isColumnDisplayed(this.clrGridWidget.getColumn(2).unwrap())).toBe(false);
                 expect(
                     this.clrGridWidget
                         .getHiddenColumnHeaders()
+                        .unwrap()
                         .toArray()
                         .map((header: TestElement) => header.text())
                 ).toEqual(['Default Renderer']);
             });
 
             it('shows the columns with hidable value of undefined', function (this: HasFinderAndGrid): void {
-                expect(isColumnDisplayed(this.clrGridWidget.getColumn(3))).toBe(true);
+                expect(isColumnDisplayed(this.clrGridWidget.getColumn(3).unwrap())).toBe(true);
             });
         });
 
@@ -900,8 +910,8 @@ describe('DatagridComponent', () => {
             });
 
             it('opens one detail pane when you click the button', function (this: HasFinderAndGrid): void {
-                this.clrGridWidget.getDetailRowButtons().toArray()[0].click();
-                expect(this.clrGridWidget.getDetailRows().length()).toEqual(1);
+                this.clrGridWidget.getDetailRowButtons().unwrap().toArray()[0].click();
+                expect(this.clrGridWidget.getDetailRows().unwrap().length()).toEqual(1);
             });
         });
 
@@ -918,13 +928,13 @@ describe('DatagridComponent', () => {
             });
 
             it('does NOT expand row when false', function (this: HasFinderAndGrid): void {
-                expect(this.clrGridWidget.getDetailRows().length()).toEqual(0);
+                expect(this.clrGridWidget.getDetailRows().unwrap().length()).toEqual(0);
             });
 
             it('expands row when true', function (this: HasFinderAndGrid): void {
                 this.hostComponent.isRowExpanded = true;
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getDetailRows().length()).toEqual(2);
+                expect(this.clrGridWidget.getDetailRows().unwrap().length()).toEqual(2);
             });
         });
 
@@ -940,14 +950,14 @@ describe('DatagridComponent', () => {
             });
 
             it('opens one detail pane when you click the button', function (this: HasFinderAndGrid): void {
-                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
+                this.clrGridWidget.getDetailPaneButtons().unwrap().toArray()[0].click();
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getDetailPanes().length()).toEqual(1);
-                expect(this.clrGridWidget.getDetailPaneHeader().text()).toEqual('Palo Alto');
+                expect(this.clrGridWidget.getDetailPanes().unwrap().length()).toEqual(1);
+                expect(this.clrGridWidget.getDetailPaneHeader().unwrap().text()).toEqual('Palo Alto');
             });
 
             it('gives the same config when called with the same arguments', function (this: HasFinderAndGrid): void {
-                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
+                this.clrGridWidget.getDetailPaneButtons().unwrap().toArray()[0].click();
                 this.finder.detectChanges();
                 expect(this.hostComponent.grid.getDetailPaneRenderSpec(mockData[0])).toEqual(
                     this.hostComponent.grid.getDetailPaneRenderSpec(mockData[0])
@@ -955,10 +965,10 @@ describe('DatagridComponent', () => {
             });
 
             it('updates the detail pane when the record changes', function (this: HasFinderAndGrid): void {
-                this.clrGridWidget.getDetailPaneButtons().toArray()[0].click();
+                this.clrGridWidget.getDetailPaneButtons().unwrap().toArray()[0].click();
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getDetailPanes().length()).toEqual(1);
-                expect(this.clrGridWidget.getDetailPaneHeader().text()).toEqual('Palo Alto');
+                expect(this.clrGridWidget.getDetailPanes().unwrap().length()).toEqual(1);
+                expect(this.clrGridWidget.getDetailPaneHeader().unwrap().text()).toEqual('Palo Alto');
                 this.hostComponent.gridData = {
                     items: [
                         {
@@ -969,8 +979,8 @@ describe('DatagridComponent', () => {
                     totalItems: 2,
                 };
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getDetailPanes().length()).toEqual(1);
-                expect(this.clrGridWidget.getDetailPaneHeader().text()).toEqual('NEW');
+                expect(this.clrGridWidget.getDetailPanes().unwrap().length()).toEqual(1);
+                expect(this.clrGridWidget.getDetailPaneHeader().unwrap().text()).toEqual('NEW');
             });
         });
 
@@ -1225,16 +1235,16 @@ describe('DatagridComponent', () => {
             it('shows the header if set and allows it to be changed', function (this: HasFinderAndGrid): void {
                 this.hostComponent.header = 'Some Header!';
                 this.finder.detectChanges();
-                expect(this.vcdDatagrid.getHeader().text()).toEqual('Some Header!');
+                expect(this.vcdDatagrid.getHeader().unwrap().text()).toEqual('Some Header!');
                 this.hostComponent.header = 'Some Other Header!';
                 this.finder.detectChanges();
-                expect(this.vcdDatagrid.getHeader().text()).toEqual('Some Other Header!');
+                expect(this.vcdDatagrid.getHeader().unwrap().text()).toEqual('Some Other Header!');
             });
 
             it('does not show a header when none is set', function (this: HasFinderAndGrid): void {
                 this.hostComponent.header = undefined;
                 this.finder.detectChanges();
-                expect(this.vcdDatagrid.getHeader().length()).toEqual(0);
+                expect(this.vcdDatagrid.getHeader().unwrap().length()).toEqual(0);
             });
         });
 
@@ -1403,10 +1413,11 @@ describe('DatagridComponent', () => {
             it('uses property path from  "renderer" property of column config ', function (this: HasFinderAndGrid): void {
                 this.hostComponent.columns = [{ displayName: '', renderer: 'details.gender' }];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getCell(0, 0).text()).toEqual(mockData[0].details.gender);
+                expect(this.clrGridWidget.getCell(0, 0).unwrap().text()).toEqual(mockData[0].details.gender);
                 expect(
                     this.clrGridWidget
                         .getRowCell(0)
+                        .unwrap()
                         .toArray()
                         .map((cell: TestElement) => cell.text())
                 ).toEqual([mockData[0].details.gender]);
@@ -1422,7 +1433,9 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getCell(0, 0).text()).toEqual(`${mockData[0].city}, ${mockData[0].state}`);
+                expect(this.clrGridWidget.getCell(0, 0).unwrap().text()).toEqual(
+                    `${mockData[0].city}, ${mockData[0].state}`
+                );
             });
         });
 
@@ -1440,7 +1453,7 @@ describe('DatagridComponent', () => {
                     },
                 ];
                 this.finder.detectChanges();
-                expect(this.clrGridWidget.getCell(0, 0).queryElements('strong').text()).toBe(mockData[0].name);
+                expect(this.clrGridWidget.getCell(0, 0).unwrap().queryElements('strong').text()).toBe(mockData[0].name);
             });
         });
     });

--- a/projects/components/src/quick-search/quick-search.component.spec.ts
+++ b/projects/components/src/quick-search/quick-search.component.spec.ts
@@ -6,20 +6,16 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ClarityModule } from '@clr/angular';
 import { MockTranslationService, TranslationService } from '@vcd/i18n';
-import { FormsModule } from '@angular/forms';
 import { AngularWidgetObjectFinder } from '../utils/test/widget-object/angular/angular-widget-finder';
 import { TestElement } from '../utils/test/widget-object/angular/angular-widget-object-element';
-import { WidgetObject } from '../utils/test/widget-object';
 import { QuickSearchResultItem, QuickSearchResultsType } from './quick-search-result';
 import { QuickSearchComponent, ResultActivatedEvent } from './quick-search.component';
-import { QuickSearchFilter } from './quick-search.service';
+import { QuickSearchService } from './quick-search.service';
 import { QuickSearchModule } from './quick-search.module';
 import { QuickSearchProviderDefaults } from './quick-search.provider';
-import { QuickSearchService } from './quick-search.service';
 import { QuickSearchWo } from './quick-search.wo';
 
 interface Test {
@@ -164,37 +160,37 @@ describe('QuickSearchComponent', () => {
 
     describe('visibility', () => {
         beforeEach(function (this: Test): void {
-            expect(this.quickSearch.getModalBody().length()).toBe(0, 'Quick Search should be closed');
+            expect(this.quickSearch.getModalBody().unwrap().length()).toBe(0, 'Quick Search should be closed');
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
-            expect(this.quickSearch.getModalBody().length()).not.toBe(0, 'Quick Search should be opened');
+            expect(this.quickSearch.getModalBody().unwrap().length()).not.toBe(0, 'Quick Search should be opened');
         });
 
         it('can be opened', function (this: Test): void {
-            expect(this.quickSearch.getModalBody().length()).not.toBe(0, 'Quick Search should be opened');
+            expect(this.quickSearch.getModalBody().unwrap().length()).not.toBe(0, 'Quick Search should be opened');
         });
 
         it('can be closed', function (this: Test): void {
             this.finder.hostComponent.spotlightOpen = false;
             this.finder.detectChanges();
-            expect(this.quickSearch.getModalBody().length()).toBe(0, 'Quick Search should be closed');
+            expect(this.quickSearch.getModalBody().unwrap().length()).toBe(0, 'Quick Search should be closed');
         });
 
         it('is closed when esc is pressed', function (this: Test): void {
             this.quickSearch.self().sendKeyboardEvent('keyup', { key: 'escape' });
-            expect(this.quickSearch.getModalBody().length()).toBe(0, 'Quick Search should be closed');
+            expect(this.quickSearch.getModalBody().unwrap().length()).toBe(0, 'Quick Search should be closed');
         });
 
         it('is closed when clicking outside', function (this: Test): void {
             this.quickSearch.getModalBackdrop().click();
-            expect(this.quickSearch.getModalBody().length()).toBe(0, 'Quick Search should be closed');
+            expect(this.quickSearch.getModalBody().unwrap().length()).toBe(0, 'Quick Search should be closed');
         });
 
         it('is closed when item is handled', function (this: Test): void {
             this.quickSearch.getInput().type('c');
-            this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'enter' });
+            this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'enter' });
             this.finder.detectChanges();
-            expect(this.quickSearch.getModalBody().length()).toBe(0, 'Quick Search should be closed');
+            expect(this.quickSearch.getModalBody().unwrap().length()).toBe(0, 'Quick Search should be closed');
         });
     });
 
@@ -212,7 +208,12 @@ describe('QuickSearchComponent', () => {
             this.finder.detectChanges();
             this.quickSearch.getInput().type('c');
             expect(searchHandlerSpy).toHaveBeenCalledWith('c');
-            expect(this.quickSearch.getSearchResultItems().map((item) => item.text())).toEqual(['copy', 'create']);
+            expect(
+                this.quickSearch
+                    .getSearchResultItems()
+                    .unwrap()
+                    .map((item) => item.text())
+            ).toEqual(['copy', 'create']);
         });
 
         it('displays a loading indicator when the result is a promise', function (this: Test): void {
@@ -220,7 +221,7 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             this.quickSearch.getInput().type('c');
-            expect(this.quickSearch.getSpinners().length()).toBe(
+            expect(this.quickSearch.getSpinners().unwrap().length()).toBe(
                 1,
                 'There should be a loading indicator in the second section'
             );
@@ -233,8 +234,13 @@ describe('QuickSearchComponent', () => {
             this.quickSearch.getInput().type('copy');
             tick(1000);
             this.finder.detectChanges();
-            expect(this.quickSearch.getSpinners().length()).toBe(0);
-            expect(this.quickSearch.getSearchResultItems().map((item) => item.text())).toEqual(['copy', 'copy']);
+            expect(this.quickSearch.getSpinners().unwrap().length()).toBe(0);
+            expect(
+                this.quickSearch
+                    .getSearchResultItems()
+                    .unwrap()
+                    .map((item) => item.text())
+            ).toEqual(['copy', 'copy']);
         }));
 
         it('displays result from the last search', fakeAsync(function (this: Test): void {
@@ -251,13 +257,18 @@ describe('QuickSearchComponent', () => {
             tick(500);
             this.finder.detectChanges();
             // There should be just one result form the first provider
-            expect(this.quickSearch.getSearchResultItems().text()).toEqual('create');
+            expect(this.quickSearch.getSearchResultItems().unwrap().text()).toEqual('create');
             // There should still be loading indicator from the second search
-            expect(this.quickSearch.getSpinners().length()).toBe(1);
+            expect(this.quickSearch.getSpinners().unwrap().length()).toBe(1);
             // Advance the clock so that the second search has finished also
             tick(500);
             this.finder.detectChanges();
-            expect(this.quickSearch.getSearchResultItems().map((item) => item.text())).toEqual(['create', 'create']);
+            expect(
+                this.quickSearch
+                    .getSearchResultItems()
+                    .unwrap()
+                    .map((item) => item.text())
+            ).toEqual(['create', 'create']);
         }));
 
         it('preserves the search criteria upon reopening', function (this: Test): void {
@@ -272,8 +283,8 @@ describe('QuickSearchComponent', () => {
             // Open again
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
-            expect(this.quickSearch.getInput().value()).toEqual('copy');
-            expect(this.quickSearch.getSearchResultItems().text()).toEqual('copy');
+            expect(this.quickSearch.getInput().unwrap().value()).toEqual('copy');
+            expect(this.quickSearch.getSearchResultItems().unwrap().text()).toEqual('copy');
         });
 
         it('uses a newly added search handler', function (this: Test): void {
@@ -313,8 +324,13 @@ describe('QuickSearchComponent', () => {
             tick();
             this.finder.detectChanges();
             const noResults = TestBed.inject(TranslationService).translate('vcd.cc.quickSearch.noResults', []);
-            expect(this.quickSearch.getSearchResultItems().toArray().length).toBe(0);
-            expect(this.quickSearch.getNoResults().map((item) => item.text())).toEqual([noResults]);
+            expect(this.quickSearch.getSearchResultItems().unwrap().toArray().length).toBe(0);
+            expect(
+                this.quickSearch
+                    .getNoResults()
+                    .unwrap()
+                    .map((item) => item.text())
+            ).toEqual([noResults]);
         }));
 
         describe('partial search result', () => {
@@ -323,12 +339,14 @@ describe('QuickSearchComponent', () => {
                 this.quickSearchData.spotlightSearchService.registerProvider(partialSearchProvider);
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
-                this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text())).toEqual([
-                    'section',
-                    partialSearchProvider.sectionName,
-                ]);
-                expect(this.quickSearch.getSearchResultAlerts().toArray()).toEqual([]);
+                this.quickSearch.getInput().unwrap().type('c');
+                expect(
+                    this.quickSearch
+                        .getSearchResultSectionTitles()
+                        .unwrap()
+                        .map((title) => title.text())
+                ).toEqual(['section', partialSearchProvider.sectionName]);
+                expect(this.quickSearch.getSearchResultAlerts().unwrap().toArray()).toEqual([]);
             });
 
             it('does not display partial information if total is equal to the number of items', function (this: Test): void {
@@ -336,12 +354,14 @@ describe('QuickSearchComponent', () => {
                 this.quickSearchData.spotlightSearchService.registerProvider(partialSearchProvider);
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
-                this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text())).toEqual([
-                    'section',
-                    partialSearchProvider.sectionName,
-                ]);
-                expect(this.quickSearch.getSearchResultAlerts().toArray()).toEqual([]);
+                this.quickSearch.getInput().unwrap().type('c');
+                expect(
+                    this.quickSearch
+                        .getSearchResultSectionTitles()
+                        .unwrap()
+                        .map((title) => title.text())
+                ).toEqual(['section', partialSearchProvider.sectionName]);
+                expect(this.quickSearch.getSearchResultAlerts().unwrap().toArray()).toEqual([]);
             });
 
             it('does not display partial information if total is undefined', function (this: Test): void {
@@ -349,12 +369,14 @@ describe('QuickSearchComponent', () => {
                 this.quickSearchData.spotlightSearchService.registerProvider(partialSearchProvider);
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
-                this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text())).toEqual([
-                    'section',
-                    partialSearchProvider.sectionName,
-                ]);
-                expect(this.quickSearch.getSearchResultAlerts().toArray()).toEqual([]);
+                this.quickSearch.getInput().unwrap().type('c');
+                expect(
+                    this.quickSearch
+                        .getSearchResultSectionTitles()
+                        .unwrap()
+                        .map((title) => title.text())
+                ).toEqual(['section', partialSearchProvider.sectionName]);
+                expect(this.quickSearch.getSearchResultAlerts().unwrap().toArray()).toEqual([]);
             });
 
             describe('when total count is bigger than the number of items', () => {
@@ -369,7 +391,9 @@ describe('QuickSearchComponent', () => {
                     ).translate('vcd.cc.quickSearch.partialResultTitle', [
                         { title: partialSearchProvider.sectionName, lastItem: 2, totalItems: 3 },
                     ]);
-                    expect(this.quickSearch.getSearchResultSectionTitles().toArray()[1].text()).toEqual(partial);
+                    expect(this.quickSearch.getSearchResultSectionTitles().unwrap().toArray()[1].text()).toEqual(
+                        partial
+                    );
                 });
 
                 it('displays warning message to refine the search', function (this: Test): void {
@@ -377,12 +401,12 @@ describe('QuickSearchComponent', () => {
                     this.quickSearchData.spotlightSearchService.registerProvider(partialSearchProvider);
                     this.finder.hostComponent.spotlightOpen = true;
                     this.finder.detectChanges();
-                    this.quickSearch.getInput().type('c');
+                    this.quickSearch.getInput().unwrap().type('c');
                     const warning = TestBed.inject(TranslationService).translate('vcd.cc.quickSearch.refineQuery', [
                         { max: 2 },
                     ]);
                     this.finder.detectChanges();
-                    expect(this.quickSearch.getSearchResultAlerts().text()).toEqual(warning);
+                    expect(this.quickSearch.getSearchResultAlerts().unwrap().text()).toEqual(warning);
                 });
             });
         });
@@ -393,26 +417,31 @@ describe('QuickSearchComponent', () => {
                 this.quickSearchData.spotlightSearchService.registerProvider(debounceSearchProvider);
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
-                this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text())).toEqual([
-                    'section',
-                ]);
+                this.quickSearch.getInput().unwrap().type('c');
+                expect(
+                    this.quickSearch
+                        .getSearchResultSectionTitles()
+                        .unwrap()
+                        .map((title) => title.text())
+                ).toEqual(['section']);
                 tick(100);
                 this.finder.detectChanges();
-                expect(this.quickSearch.getSpinners().length()).toBe(1);
-                expect(this.quickSearch.getSearchResultItems().map((title) => title.text())).toEqual([
-                    'copy',
-                    'create',
-                ]);
+                expect(this.quickSearch.getSpinners().unwrap().length()).toBe(1);
+                expect(
+                    this.quickSearch
+                        .getSearchResultItems()
+                        .unwrap()
+                        .map((title) => title.text())
+                ).toEqual(['copy', 'create']);
                 tick(200);
                 this.finder.detectChanges();
-                expect(this.quickSearch.getSpinners().length()).toBe(0);
-                expect(this.quickSearch.getSearchResultItems().map((title) => title.text())).toEqual([
-                    'copy',
-                    'create',
-                    'copy',
-                    'create',
-                ]);
+                expect(this.quickSearch.getSpinners().unwrap().length()).toBe(0);
+                expect(
+                    this.quickSearch
+                        .getSearchResultItems()
+                        .unwrap()
+                        .map((title) => title.text())
+                ).toEqual(['copy', 'create', 'copy', 'create']);
             }));
         });
     });
@@ -425,8 +454,8 @@ describe('QuickSearchComponent', () => {
             // Set search
             this.quickSearch.getInput().type('copy');
             //
-            expect(this.quickSearch.getSearchResultItems().length()).toBe(1);
-            expect(this.quickSearch.getSearchResultSectionTitles().text()).toEqual('section');
+            expect(this.quickSearch.getSearchResultItems().unwrap().length()).toBe(1);
+            expect(this.quickSearch.getSearchResultSectionTitles().unwrap().text()).toEqual('section');
         });
 
         it('displays icon next to a section title', function (this: Test): void {
@@ -438,9 +467,12 @@ describe('QuickSearchComponent', () => {
             this.finder.detectChanges();
             // Set search
             this.quickSearch.getInput().type('copy');
-            expect(this.quickSearch.getTitleIcons().map((el) => el.attributes().getNamedItem('shape').value)).toEqual([
-                'user',
-            ]);
+            expect(
+                this.quickSearch
+                    .getTitleIcons()
+                    .unwrap()
+                    .map((el) => el.attributes().getNamedItem('shape').value)
+            ).toEqual(['user']);
         });
 
         it('displays all section titles when there are results', function (this: Test): void {
@@ -452,11 +484,13 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             // Set search
-            this.quickSearch.getInput().type('copy');
-            expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text())).toEqual([
-                'section',
-                'new section',
-            ]);
+            this.quickSearch.getInput().unwrap().type('copy');
+            expect(
+                this.quickSearch
+                    .getSearchResultSectionTitles()
+                    .unwrap()
+                    .map((title) => title.text())
+            ).toEqual(['section', 'new section']);
         });
 
         it('does not display section title if it is not provided', function (this: Test): void {
@@ -472,7 +506,7 @@ describe('QuickSearchComponent', () => {
             // Set search
             this.quickSearch.getInput().type('copy');
             //
-            expect(this.quickSearch.getSearchResultSectionTitles().text()).toEqual('section');
+            expect(this.quickSearch.getSearchResultSectionTitles().unwrap().text()).toEqual('section');
         });
 
         it('does not display section title if there are no results', function (this: Test): void {
@@ -483,8 +517,8 @@ describe('QuickSearchComponent', () => {
             // Set search
             this.quickSearch.getInput().type('no match');
             // Check expectations
-            expect(this.quickSearch.getSearchResultItems().length()).toBe(0);
-            expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(0);
+            expect(this.quickSearch.getSearchResultItems().unwrap().length()).toBe(0);
+            expect(this.quickSearch.getSearchResultSectionTitles().unwrap().length()).toEqual(0);
         });
 
         it('displays nested providers title correctly with nested, filtered providers', function (this: Test): void {
@@ -499,21 +533,22 @@ describe('QuickSearchComponent', () => {
             this.finder.detectChanges();
             // Set search
             this.quickSearch.getInput().type('o');
-            expect(this.quickSearch.getSearchResultItems().length()).toBe(4);
-            expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text())).toEqual([
-                'section',
-                'Some Nested Provider',
-                'section',
-                'another section',
-            ]);
+            expect(this.quickSearch.getSearchResultItems().unwrap().length()).toBe(4);
+            expect(
+                this.quickSearch
+                    .getSearchResultSectionTitles()
+                    .unwrap()
+                    .map((title) => title.text())
+            ).toEqual(['section', 'Some Nested Provider', 'section', 'another section']);
 
-            this.quickSearch.getInput().type('copy');
-            expect(this.quickSearch.getSearchResultItems().length()).toBe(2);
-            expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text().toString())).toEqual([
-                'section',
-                'Some Nested Provider',
-                'section',
-            ]);
+            this.quickSearch.getInput().unwrap().type('copy');
+            expect(this.quickSearch.getSearchResultItems().unwrap().length()).toBe(2);
+            expect(
+                this.quickSearch
+                    .getSearchResultSectionTitles()
+                    .unwrap()
+                    .map((title) => title.text().toString())
+            ).toEqual(['section', 'Some Nested Provider', 'section']);
         });
 
         it('orders nested providers by their given order', function (this: Test): void {
@@ -533,15 +568,14 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             // Set search
-            this.quickSearch.getInput().type('o');
+            this.quickSearch.getInput().unwrap().type('o');
             //
-            expect(this.quickSearch.getSearchResultSectionTitles().map((title) => title.text())).toEqual([
-                'section',
-                'Another Nested Provider',
-                'section',
-                'Some Nested Provider',
-                'section',
-            ]);
+            expect(
+                this.quickSearch
+                    .getSearchResultSectionTitles()
+                    .unwrap()
+                    .map((title) => title.text())
+            ).toEqual(['section', 'Another Nested Provider', 'section', 'Some Nested Provider', 'section']);
         });
     });
 
@@ -553,7 +587,7 @@ describe('QuickSearchComponent', () => {
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
             });
 
             it('can update the selected item with a new one from the same section', function (this: Test): void {
@@ -562,9 +596,9 @@ describe('QuickSearchComponent', () => {
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
                 this.quickSearch.getInput().type('cr');
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('create');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('create');
             });
 
             it('can update the selected item with a new one from a different section', function (this: Test): void {
@@ -576,7 +610,7 @@ describe('QuickSearchComponent', () => {
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
                 this.quickSearch.getInput().type('another');
-                expect(this.quickSearch.getSelectedSearchResultItem().toArray()[0].text().toString()).toEqual(
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().toArray()[0].text().toString()).toEqual(
                     'another'
                 );
             });
@@ -588,7 +622,7 @@ describe('QuickSearchComponent', () => {
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSelectedSearchResultItem().toArray().toString()).toEqual('');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().toArray().toString()).toEqual('');
             });
 
             it('selects the first item after the promise is resolved', fakeAsync(function (this: Test): void {
@@ -599,7 +633,7 @@ describe('QuickSearchComponent', () => {
                 this.quickSearch.getInput().type('c');
                 tick(1000);
                 this.finder.detectChanges();
-                expect(this.quickSearch.getSelectedSearchResultItem().toArray()[0].text()).toEqual('copy');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().toArray()[0].text()).toEqual('copy');
             }));
 
             it('does not change manual selection', fakeAsync(function (this: Test): void {
@@ -609,10 +643,10 @@ describe('QuickSearchComponent', () => {
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('copy');
                 // Pressing arrow up selects the first available result, in this case it is the from from the simple provider
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowUp' });
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowUp' });
                 tick(1000);
                 this.finder.detectChanges();
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
             }));
         });
 
@@ -624,8 +658,8 @@ describe('QuickSearchComponent', () => {
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowUp' });
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowUp' });
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
             });
 
             it('selects first item when arrow down is pressed before search is completed', function (this: Test): void {
@@ -635,17 +669,17 @@ describe('QuickSearchComponent', () => {
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
             });
 
             it('selects next item when arrow down is pressed', function (this: Test): void {
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('create');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('create');
             });
 
             it(
@@ -655,12 +689,12 @@ describe('QuickSearchComponent', () => {
                     this.finder.hostComponent.spotlightOpen = true;
                     this.finder.detectChanges();
                     this.quickSearch.getInput().type('c');
-                    this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                    this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
                     // Test the selection is from the first section
-                    expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('create');
-                    this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                    expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('create');
+                    this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
                     // Test the selection now is from the second section
-                    expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                    expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
                 }
             );
 
@@ -669,28 +703,28 @@ describe('QuickSearchComponent', () => {
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSearchResultItems().length()).toBe(4);
+                expect(this.quickSearch.getSearchResultItems().unwrap().length()).toBe(4);
                 // Go to the bottom of the list
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
                 // Test the selection is the bottom of the second section
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('create');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('create');
                 // Go beyond the length of the list
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
                 // Test the selection is the first item of the first selection
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
             });
 
             it('selects previous item when arrow up is pressed', function (this: Test): void {
                 this.finder.hostComponent.spotlightOpen = true;
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('create');
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowUp' });
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowDown' });
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('create');
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowUp' });
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
             });
 
             it('selects the last item when being at the top of the list and up is pressed', function (this: Test): void {
@@ -700,11 +734,11 @@ describe('QuickSearchComponent', () => {
                 this.finder.detectChanges();
                 this.quickSearch.getInput().type('c');
                 // Test
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('copy');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('copy');
                 // Press arrow up key
-                this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'ArrowUp' });
+                this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'ArrowUp' });
                 // Test
-                expect(this.quickSearch.getSelectedSearchResultItem().text()).toEqual('create');
+                expect(this.quickSearch.getSelectedSearchResultItem().unwrap().text()).toEqual('create');
             });
         });
     });
@@ -714,7 +748,7 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             this.quickSearch.getInput().type('c');
-            this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'enter' });
+            this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'enter' });
             expect(itemHandlerSpy).toHaveBeenCalledWith('copy');
         });
 
@@ -728,7 +762,7 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             this.quickSearch.getInput().type('c');
-            this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'enter' });
+            this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'enter' });
             expect(itemHandlerSpy).not.toHaveBeenCalled();
         });
 
@@ -742,7 +776,7 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             this.quickSearch.getInput().type('c');
-            this.quickSearch.getSearchResultItems().toArray()[1].click();
+            this.quickSearch.getSearchResultItems().unwrap().toArray()[1].click();
             this.finder.detectChanges();
             expect(itemHandlerSpy).toHaveBeenCalledWith('create');
         });
@@ -753,7 +787,7 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             this.quickSearch.getInput().type('c');
-            this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'enter' });
+            this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'enter' });
             const event: ResultActivatedEvent = {
                 itemDisplayText: 'copy',
                 sectionTitle: 'section',
@@ -769,7 +803,7 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             this.quickSearch.getInput().type('c');
-            this.quickSearch.getInput().sendKeyboardEvent('keydown', { key: 'enter' });
+            this.quickSearch.getInput().unwrap().sendKeyboardEvent('keydown', { key: 'enter' });
             expect(this.quickSearchData.resultActivated).not.toHaveBeenCalled();
         });
 
@@ -780,7 +814,7 @@ describe('QuickSearchComponent', () => {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
             this.quickSearch.getInput().type('c');
-            this.quickSearch.getSearchResultItems().toArray()[1].click();
+            this.quickSearch.getSearchResultItems().unwrap().toArray()[1].click();
             const event: ResultActivatedEvent = {
                 itemDisplayText: 'create',
                 sectionTitle: 'section',
@@ -794,7 +828,7 @@ describe('QuickSearchComponent', () => {
         it('default to empty', function (this: Test): void {
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
-            expect(this.quickSearch.getInput().value()).toBe('');
+            expect(this.quickSearch.getInput().unwrap().value()).toBe('');
         });
 
         it('can be set', function (this: Test): void {
@@ -802,7 +836,7 @@ describe('QuickSearchComponent', () => {
             this.finder.detectChanges();
             this.finder.hostComponent.spotlightOpen = true;
             this.finder.detectChanges();
-            expect(this.quickSearch.getInput().placeholder()).toBe('Search...');
+            expect(this.quickSearch.getInput().unwrap().placeholder()).toBe('Search...');
         });
     });
 
@@ -813,17 +847,17 @@ describe('QuickSearchComponent', () => {
         });
 
         it('can project content at the top of the results', function (this: Test): void {
-            expect(this.quickSearch.getSearchResultItems().elements.toString()).toEqual('');
+            expect(this.quickSearch.getSearchResultItems().unwrap().elements.toString()).toEqual('');
             this.finder.hostComponent.isTopOfResultsShown = true;
             this.finder.detectChanges();
-            expect(this.quickSearch.getTopOfResults().text()).toEqual('Top of results');
+            expect(this.quickSearch.getTopOfResults().unwrap().text()).toEqual('Top of results');
         });
 
         it('can project content at the bottom of the results', function (this: Test): void {
-            expect(this.quickSearch.getBottomOfResults().elements.toString()).toEqual('');
+            expect(this.quickSearch.getBottomOfResults().unwrap().elements.toString()).toEqual('');
             this.finder.hostComponent.isBottomOfResultsShown = true;
             this.finder.detectChanges();
-            expect(this.quickSearch.getBottomOfResults().text()).toEqual('Bottom of results');
+            expect(this.quickSearch.getBottomOfResults().unwrap().text()).toEqual('Bottom of results');
         });
     });
 
@@ -846,14 +880,14 @@ describe('QuickSearchComponent', () => {
             this.quickSearchData.anotherSimpleProvider.sectionName = 'another section';
             this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.anotherSimpleProvider);
             this.quickSearch.getInput().type('copy');
-            expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(1);
+            expect(this.quickSearch.getSearchResultSectionTitles().unwrap().length()).toEqual(1);
 
             // When the type filter is present,, the list of providers is filtered based on it.
             // In this case, the type:simple filter is set and anotherSimpleProvider is removed.
             this.quickSearch.getFilterButton('type').click();
             this.quickSearch.getFilterDropdownOptions(0).click();
-            expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(1);
-            expect(this.quickSearch.getSearchResultItems().text()).toEqual('copy');
+            expect(this.quickSearch.getSearchResultSectionTitles().unwrap().length()).toEqual(1);
+            expect(this.quickSearch.getSearchResultItems().unwrap().text()).toEqual('copy');
         });
 
         it('can set filter values through the QuickSearchService', function (this: Test): void {
@@ -869,13 +903,13 @@ describe('QuickSearchComponent', () => {
             this.quickSearchData.anotherSimpleProvider.sectionName = 'another section';
             this.quickSearchData.spotlightSearchService.registerProvider(this.quickSearchData.anotherSimpleProvider);
             this.quickSearch.getInput().type('copy');
-            expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(1);
+            expect(this.quickSearch.getSearchResultSectionTitles().unwrap().length()).toEqual(1);
 
             // When the type filter is present, the list of providers is filtered based on it.
             // In this case, the type:simple filter is set and anotherSimpleProvider is removed.
             this.quickSearchData.spotlightSearchService.selectFilter('type', ['simple']);
-            expect(this.quickSearch.getSearchResultSectionTitles().length()).toEqual(1);
-            expect(this.quickSearch.getSearchResultItems().text()).toEqual('copy');
+            expect(this.quickSearch.getSearchResultSectionTitles().unwrap().length()).toEqual(1);
+            expect(this.quickSearch.getSearchResultItems().unwrap().text()).toEqual('copy');
         });
     });
 });

--- a/projects/components/src/quick-search/quick-search.wo.ts
+++ b/projects/components/src/quick-search/quick-search.wo.ts
@@ -24,12 +24,10 @@ export class QuickSearchWo<T> extends BaseWidgetObject<T> {
      */
     getInput = this.factory.dataUi(DataUi.searchInput);
 
-    _getSearchResultSectionTitles = this.internalFactory.dataUi(DataUi.searchResultSectionTitles);
-
     /**
      * Returns the titles of all sections appearing in the search results
      */
-    getSearchResultSectionTitles = this.factory.unwrap(this._getSearchResultSectionTitles);
+    getSearchResultSectionTitles = this.factory.dataUi(DataUi.searchResultSectionTitles);
 
     /**
      * Returns each search result item in each section
@@ -72,16 +70,15 @@ export class QuickSearchWo<T> extends BaseWidgetObject<T> {
     getBottomOfResults = this.factory.css('.bottom-of-results');
 
     getFilterButton(id: string) {
-        return this.el.get({ dataUiSelector: DataUi.filterButton(id) }).unwrap();
+        return this.el.get({ dataUiSelector: DataUi.filterButton(id) });
     }
 
     getFilterDropdownOptions(index: number) {
-        return this.el.get({ dataUiSelector: DataUi.filterDropdownItem, index }).unwrap();
+        return this.el.get({ dataUiSelector: DataUi.filterDropdownItem, index });
     }
 
     /**
      * Gives the icon next to each section title.
      */
-    getTitleIcons = (options?: FindElementOptions) =>
-        this._getSearchResultSectionTitles(options).get('clr-icon').unwrap();
+    getTitleIcons = (options?: FindElementOptions) => this.getSearchResultSectionTitles(options).get('clr-icon');
 }

--- a/projects/components/src/sharing-modal/sharing-modal.component.spec.ts
+++ b/projects/components/src/sharing-modal/sharing-modal.component.spec.ts
@@ -45,14 +45,13 @@ class VcdDropdownWidgetObject<T> extends BaseWidgetObject<T> {
     getSearchWarning = this.factory.css('.search-warning');
 
     getSelectToogleByText = (text: string) =>
-        this.el.get({ cssSelector: 'label', text }).parents('div').get('clr-checkbox-wrapper input').unwrap();
+        this.el.get({ cssSelector: 'label', text }).parents('div').get('clr-checkbox-wrapper input');
 
-    getRightsOptionsByText = (text: string) =>
-        this.el.get({ cssSelector: 'label', text }).parents('div').get('option').unwrap();
+    getRightsOptionsByText = (text: string) => this.el.get({ cssSelector: 'label', text }).parents('div').get('option');
 
-    getComboboxDropdownRows = () => this.el.parents('body').get('clr-option').unwrap();
+    getComboboxDropdownRows = () => this.el.parents('body').get('clr-option');
 
-    getTabByHeader = (title: string) => this.el.get({ cssSelector: '.nav-item button', text: title }).unwrap();
+    getTabByHeader = (title: string) => this.el.get({ cssSelector: '.nav-item button', text: title });
 
     getCurrentShareDatagrid = () => this.el.findWidget<ClrDatagridWidgetObject<T>>(ClrDatagridWidgetObject);
 
@@ -86,10 +85,10 @@ describe('SharingModalComponent', () => {
 
     describe('@Input() isOpened', () => {
         it('closes the sharing modal when set to close', function (this: HasVcdSharingModal): void {
-            expect(this.widget.getModalBody().length()).toEqual(1);
+            expect(this.widget.getModalBody().unwrap().length()).toEqual(1);
             this.finder.hostComponent.opened = false;
             this.finder.detectChanges();
-            expect(this.widget.getModalBody().length()).toEqual(0);
+            expect(this.widget.getModalBody().unwrap().length()).toEqual(0);
         });
     });
 
@@ -97,7 +96,7 @@ describe('SharingModalComponent', () => {
         it('sets the title of the modal', function (this: HasVcdSharingModal): void {
             this.finder.hostComponent.title = 'This is a title';
             this.finder.detectChanges();
-            expect(this.widget.getModalHeader().text()).toEqual('This is a title');
+            expect(this.widget.getModalHeader().unwrap().text()).toEqual('This is a title');
         });
     });
 
@@ -141,6 +140,7 @@ describe('SharingModalComponent', () => {
             expect(
                 this.widget
                     .getTabHeaders()
+                    .unwrap()
                     .toArray()
                     .map((el) => el.text())
             ).toEqual(['Users', 'Groups']);
@@ -183,8 +183,8 @@ describe('SharingModalComponent', () => {
             this.widget.getTabByHeader('Users').click();
             await timeout(0);
             this.finder.detectChanges();
-            expect(this.widget.getCurrentShareDatagrid().getRows().length()).toEqual(1);
-            expect(this.widget.getCurrentShareDatagrid().getCell(0, 1).text()).toEqual('ryan');
+            expect(this.widget.getCurrentShareDatagrid().getRows().unwrap().length()).toEqual(1);
+            expect(this.widget.getCurrentShareDatagrid().getCell(0, 1).unwrap().text()).toEqual('ryan');
         });
 
         it('allows the user to search for entities', async function (this: HasVcdSharingModal): Promise<void> {
@@ -220,6 +220,7 @@ describe('SharingModalComponent', () => {
             expect(
                 this.widget
                     .getComboboxDropdownRows()
+                    .unwrap()
                     .toArray()
                     .map((el) => el.text())
             ).toEqual(['ryan']);
@@ -247,7 +248,7 @@ describe('SharingModalComponent', () => {
             this.widget.openComboboxButton().click();
             await timeout(401);
             this.finder.detectChanges();
-            expect(this.widget.getErrorLabel().text()).toEqual('BAD');
+            expect(this.widget.getErrorLabel().unwrap().text()).toEqual('BAD');
             this.widget.openComboboxButton().click();
         });
 
@@ -283,7 +284,7 @@ describe('SharingModalComponent', () => {
             this.widget.openComboboxButton().click();
             await timeout(401);
             this.finder.detectChanges();
-            expect(this.widget.getSearchWarning().text()).toEqual(
+            expect(this.widget.getSearchWarning().unwrap().text()).toEqual(
                 new MockTranslationService().translate('vcd.cc.sharing-results-warning', [1, 15])
             );
             this.widget.openComboboxButton().click();
@@ -387,6 +388,7 @@ describe('SharingModalComponent', () => {
             expect(
                 this.widget
                     .getRightsOptionsByText('Select all users')
+                    .unwrap()
                     .toArray()
                     .map((el) => el.text())
             ).toEqual(['read']);
@@ -490,7 +492,7 @@ describe('SharingModalComponent', () => {
             this.widget.openComboboxButton().click();
             await timeout(401);
             this.finder.detectChanges();
-            this.widget.getComboboxDropdownRows().toArray()[0].click();
+            this.widget.getComboboxDropdownRows().unwrap().toArray()[0].click();
             await timeout(0);
             this.finder.detectChanges();
             this.widget.getAddButton().click();
@@ -614,7 +616,9 @@ describe('SharingModalComponent', () => {
             this.widget.getTabByHeader('Users').click();
             await timeout(0);
             this.finder.detectChanges();
-            (this.widget.getActiveTab().getComponentInstance() as SharingModalTabComponent<any>).updateEntityRights(
+            (this.widget.getActiveTab().unwrap().getComponentInstance() as SharingModalTabComponent<
+                any
+            >).updateEntityRights(
                 {
                     name: 'ryan',
                     id: 'ryan',

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -121,10 +121,10 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
     getSpinner = this.factory.css(Css.SPINNER);
 
     /**
-     * Helper function to retrieve a row
+     * Return a row by index
      * @param row 0-based index of row
      */
-    private _getRow(row: number): WidgetObjectElement<T> {
+    getRow(row: number): WidgetObjectElement<T> {
         return this.el.get(`${Css.ROW}:nth-of-type(${row + 1})`);
     }
 
@@ -133,25 +133,15 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * @param row 0-based index of row
      * @param col 0-based index of column
      */
-    getCell(row: number, col: number): T {
-        return this._getRow(row)
-            .get(`${Css.CELL}:nth-of-type(${col + 1})`)
-            .unwrap();
-    }
-
-    /**
-     * Return a row by index
-     * @param row 0-based index of row
-     */
-    getRow(row: number): T {
-        return this._getRow(row).unwrap();
+    getCell(row: number, col: number) {
+        return this.getRow(row).get(`${Css.CELL}:nth-of-type(${col + 1})`);
     }
 
     /**
      * Return a column by index
      * @param col 0-based index of column
      */
-    getColumn(col: number): T {
+    getColumn(col: number) {
         return this.factory.css(`${Css.COLUMN}:nth-of-type(${col + 1})`)();
     }
 
@@ -159,30 +149,30 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * Returns all the cell elements in the given row
      * @param row 0-based index of row
      */
-    getRowCell(row: number): T {
-        return this._getRow(row).get(Css.CELL).unwrap();
+    getRowCell(row: number) {
+        return this.getRow(row).get(Css.CELL);
     }
 
     /**
      * Returns the button on the top of the grid with the given buttonClass
      */
-    getTopButton(btnClass: string): T {
+    getTopButton(btnClass: string) {
         return this.factory.css(`button.${btnClass}`)();
     }
 
     /**
      * Returns the button at a row with the given buttonClass
      */
-    getRowButton(btnClass: string, row: number): T {
-        return this._getRow(row).get(`button.${btnClass}`).unwrap();
+    getRowButton(btnClass: string, row: number) {
+        return this.getRow(row).get(`button.${btnClass}`);
     }
 
     /**
      * Returns a header
      * @param col 0-based index of header
      */
-    getColumnHeader(col: number): T {
-        return this.el.get(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`).unwrap();
+    getColumnHeader(col: number) {
+        return this.el.get(`${Css.COLUMN_TITLE}:nth-of-type(${col + 1})`);
     }
 
     /**
@@ -190,14 +180,14 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      * perform both single and multiple selection
      * @param row 0-based index of row
      */
-    getSelectionLabelForRow(row: number): T {
-        return this._getRow(row).get(Css.ROW_ACTION_CONTAINER).unwrap();
+    getSelectionLabelForRow(row: number) {
+        return this.getRow(row).get(Css.ROW_ACTION_CONTAINER);
     }
 
     /**
      * Returns filter toggle
      */
-    get filterToggle(): T {
-        return this.el.get(Css.COLUMN).get(Css.FILTER).get(Css.FILTER_TOGGLE).unwrap();
+    get filterToggle() {
+        return this.el.get(Css.COLUMN).get(Css.FILTER).get(Css.FILTER_TOGGLE);
     }
 }

--- a/projects/components/src/utils/test/widget-object/angular/angular-widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object/angular/angular-widget-object.spec.ts
@@ -64,8 +64,8 @@ class HeaderWidgetObject<T> extends BaseWidgetObject<T> {
     /**
      * This is a bad example for a method for an h1 because an h1 widget can't know that it contains a b tag
      */
-    getBoldText(): T {
-        return this.el.get('b').unwrap();
+    getBoldText() {
+        return this.el.get('b');
     }
 }
 
@@ -78,23 +78,20 @@ class HeaderWidgetObject<T> extends BaseWidgetObject<T> {
 class ClickTrackerWidgetObject<T> extends BaseWidgetObject<T> {
     static tagName = 'vcd-click-tracker';
 
-    private _getClickCount = this.internalFactory.dataUi(DataUi.clickCount);
-
-    getClickCount = this.factory.unwrap(this._getClickCount);
+    getClickCount = this.factory.dataUi(DataUi.clickCount);
 
     getHeaderText = this.factory.dataUi(DataUi.header);
 
     getTrackerElement = this.factory.dataUi(DataUi.clickReceiver);
 
-    _getNameInput = this.internalFactory.dataUi(DataUi.nameInput);
     getNameInput = this.factory.dataUi(DataUi.nameInput);
 
     getButtons = this.factory.dataUi(DataUi.button);
 
     getButtonByLabel = this.factory.dataUi('button');
 
-    getTrackerElementUsingParent(): T {
-        return this._getClickCount().parents(`[data-ui=${DataUi.clickReceiver}]`).unwrap();
+    getTrackerElementUsingParent() {
+        return this.getClickCount().parents(`[data-ui=${DataUi.clickReceiver}]`);
     }
 
     findHeaderWidget(): HeaderWidgetObject<T> {
@@ -102,8 +99,8 @@ class ClickTrackerWidgetObject<T> extends BaseWidgetObject<T> {
     }
 
     typeNameInput(value: string) {
-        this._getNameInput().clear();
-        this._getNameInput().type(value);
+        this.getNameInput().clear();
+        this.getNameInput().type(value);
     }
 }
 
@@ -145,7 +142,7 @@ describe('AngularWidgetFinder', () => {
         describe('find', () => {
             it('returns the first one within the fixture if no classname is specified', function (this: HasAngularFinder): void {
                 const widget = this.finder.find<ClickTrackerWidgetObject<TestElement>>(ClickTrackerWidgetObject);
-                expect(widget.getHeaderText().text()).toEqual('hello');
+                expect(widget.getHeaderText().unwrap().text()).toEqual('hello');
             });
         });
     });
@@ -167,26 +164,26 @@ describe('AngularWidgetObjectElement', () => {
 
     describe('get', () => {
         it('can find elements by CSS selector', function (this: HasClickTracker): void {
-            expect(this.clickTracker.getClickCount().text()).toEqual('0');
+            expect(this.clickTracker.getClickCount().unwrap().text()).toEqual('0');
         });
         it('can find an element by text', function (this: HasClickTracker): void {
-            expect(this.clickTracker.getButtonByLabel({ text: 'BUTTON2' }).text()).toEqual('BUTTON2');
+            expect(this.clickTracker.getButtonByLabel({ text: 'BUTTON2' }).unwrap().text()).toEqual('BUTTON2');
         });
         it('can find an element by index', function (this: HasClickTracker): void {
-            expect(this.clickTracker.getButtonByLabel({ index: 0 }).text()).toEqual('BUTTON');
+            expect(this.clickTracker.getButtonByLabel({ index: 0 }).unwrap().text()).toEqual('BUTTON');
         });
     });
 
     describe('findWidget', () => {
         it('can find widgets within widgets', function (this: HasClickTracker): void {
-            expect(this.clickTracker.findHeaderWidget().getBoldText().text()).toEqual('hello');
+            expect(this.clickTracker.findHeaderWidget().getBoldText().unwrap().text()).toEqual('hello');
         });
     });
 
     describe('parents', () => {
         it('can find a parent by css selector', function (this: HasClickTracker): void {
             this.clickTracker.getTrackerElementUsingParent().click();
-            expect(this.clickTracker.getClickCount().text()).toEqual('1');
+            expect(this.clickTracker.getClickCount().unwrap().text()).toEqual('1');
         });
     });
 });
@@ -211,14 +208,14 @@ describe('TestElement', () => {
 
     describe('text', () => {
         it('can find elements within itself passing a css query', function (this: HasClickTracker): void {
-            expect(this.clickTracker.getClickCount().text()).toEqual('0');
+            expect(this.clickTracker.getClickCount().unwrap().text()).toEqual('0');
         });
     });
 
     describe('click', () => {
         it('calls detectChanges after clicking', function (this: HasClickTracker): void {
             this.clickTracker.getTrackerElement().click();
-            expect(this.clickTracker.getClickCount().text()).toEqual('1');
+            expect(this.clickTracker.getClickCount().unwrap().text()).toEqual('1');
         });
     });
 
@@ -227,7 +224,7 @@ describe('TestElement', () => {
             this.clickTracker.self().getComponentInstance().name = 'Ryan';
             this.clickTracker.self().detectChanges();
             tick();
-            expect(this.clickTracker.getNameInput().value()).toEqual('Ryan');
+            expect(this.clickTracker.getNameInput().unwrap().value()).toEqual('Ryan');
         }));
     });
 
@@ -236,15 +233,15 @@ describe('TestElement', () => {
             this.clickTracker.self().getComponentInstance().name = 'Ryan';
             this.clickTracker.self().detectChanges();
             tick();
-            expect(this.clickTracker.getNameInput().value()).toEqual('Ryan');
+            expect(this.clickTracker.getNameInput().unwrap().value()).toEqual('Ryan');
             this.clickTracker.getNameInput().clear();
-            expect(this.clickTracker.getNameInput().value()).toEqual('');
+            expect(this.clickTracker.getNameInput().unwrap().value()).toEqual('');
         }));
     });
 
     describe('length', () => {
         it('says how many elements are in this TestElement', function (this: HasClickTracker): void {
-            expect(this.clickTracker.getButtons().length()).toEqual(2);
+            expect(this.clickTracker.getButtons().unwrap().length()).toEqual(2);
         });
     });
 
@@ -253,6 +250,7 @@ describe('TestElement', () => {
             expect(
                 this.clickTracker
                     .getButtons()
+                    .unwrap()
                     .toArray()
                     .map((el) => el.text())
             ).toEqual(['BUTTON', 'BUTTON2']);
@@ -261,16 +259,16 @@ describe('TestElement', () => {
 
     describe('classes', () => {
         it('gives the classes of an input', function (this: HasClickTracker): void {
-            expect(this.clickTracker.getNameInput().classes()).toContain('name');
+            expect(this.clickTracker.getNameInput().unwrap().classes()).toContain('name');
         });
     });
 
     describe('clear', () => {
         it('clears a given input', function (this: HasClickTracker): void {
             this.clickTracker.typeNameInput('ryan');
-            expect(this.clickTracker.getNameInput().value()).toEqual('ryan');
+            expect(this.clickTracker.getNameInput().unwrap().value()).toEqual('ryan');
             this.clickTracker.typeNameInput('hannah');
-            expect(this.clickTracker.getNameInput().value()).toEqual('hannah');
+            expect(this.clickTracker.getNameInput().unwrap().value()).toEqual('hannah');
         });
     });
 });

--- a/projects/components/src/utils/test/widget-object/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/widget-object.ts
@@ -128,7 +128,8 @@ export interface WidgetObjectElement<T> extends Locator<T>, ElementActions {
  * It provides two main functions:
  *   - Access to key HTML elements within it so that tests can assert something about their content
  *   - Abstracting interactions. For example, a login method that takes a username and password and
- *     enters it into both fields and then clicks the submit button.
+ *     enters it into both fields and then clicks the submit button. Note that these interactions
+ *     cannot contain assertions as those are specific to a testing environment.
  *
  * These widgets can be used in multiple environments by implementing two pieces:
  * - A subclass of WidgetObjectElement<T> where T is the environment's HTMLElement wrapper, such as DebugElement,
@@ -139,44 +140,31 @@ export interface WidgetObjectElement<T> extends Locator<T>, ElementActions {
  * @example
  *
  * class LoginWidgetObject<T> extends BaseWidgetObject<T> {
- *      // Private accessors return WidgetObjectElement using the factory
- *      private _getUserNameInput = this.internalFactory.css('.username');
+ *      private getUserNameInput = this.factory.css('.username');
  *
- *      // Public accessors return T and can be composed from their private counterparts
- *      // Differentiate them by the underscore to make it clear one is returning the internal format
  *      public getUsernameInput = this.factory.unwrap(this._getUsernameInput);
  *
- *      // Don't need to expose this publicly, user underscore so it's clear it returns the WidgetObjectElement
- *      private _getOkButton = this.internalFactory.text('button', OK);
+ *      private getOkButton = this.factory.text('button', OK);
  *
  *      // Don't need an internal version, use the factory methods to create public methods
  *      public errorMessage = this.factory.dataUi('error-message');
  *
  *       // Sometimes there's no factory for more complex finding logic, write a custom query.
- *       // Be sure to call unwrap on the result if exposing it publicly
- *      getOkButtonContainer(): T {
- *          return this.el.getByText('button', 'Ok').parent('.button-container').unwrap();
+ *      getOkButtonContainer() {
+ *          return this.el.getByText('button', 'Ok').parents('.button-container');
  *      }
  *      ...
  *
  *      login(user, password) {
- *          this._getUsernameInput().type(user);
- *          this._getPasswordInput().type(password);
- *          this._getOkButton().click();
+ *          this.getUsernameInput().type(user);
+ *          this.getPasswordInput().type(password);
+ *          this.getOkButton().click();
  *      }
  * }
  */
 export class BaseWidgetObject<T> {
     /**
-     * This is like {@link #factory} but it returns WidgetObjectElements, which can be used internally
-     */
-    protected internalFactory = {
-        css: (cssSelector: string) => (options?: FindElementOptions) => this.el.get({ cssSelector, ...options }),
-        dataUi: (name: string) => this.internalFactory.css(`[data-ui="${name}"]`),
-    };
-
-    /**
-     * Helpers for creating methods to find HTML elements within the widget object. They can find two types of elements:
+     * Helpers for creating methods to find HTML elements within the widget object. They return a
      *
      * - WidgetObjectElements<T> which wrap the T which is unknown to this base class into a common interface that
      *   can be be used within to WidgetObject subclasses to provide methods that can abstract interactions with
@@ -184,42 +172,17 @@ export class BaseWidgetObject<T> {
      *   and then hits the submit button; These elements don't provide means to assert anything or even to read
      *   information from the widget objects elements such as their text, CSS class names, etc.
      *
-     * - The generic specified by <T> which depends on the implementation such as a DebugElement in Angular, a
-     *   Chainable in Cypress, or a WebElement in Selenium.
+     *   If a test wants to use the native functionality (T), they can call unwrap on the returned WidgetObjectElement.
+     *   For example, a Cypress test will call widgetObject.getSomeEl().unwrap().should("be.visible")
      *
-     * Note that unlike Google Material's Harnesses, we do not impose a `TestElement` interface to be used from
-     * different implementations where all the methods return promises. The main reason is that it allows
-     * calls from different implementations to feel more natural, according to their testing environment. For example:
-     *
-     * - Avoids adding `await`s all over unit tests where they aren't necessarily needed. When trying this approach,
-     *   it was tricky to try to convert Cypress values into Promises in a reliable way. It initially looked promising
-     *   (pun intended) but turned out not to work with nested promises.
-     *
-     * - Allows the calls to WidgetObject methods to be more like their native objects instead of forcing them
-     *   to comply with a TestElement interface we have defined. That is, Cypress has a natural way to read text at
-     *   polling intervals automatically so you can still benefit from that when writing a Cypress Tests while
-     *   you would need a different mechanism in your Angular unit tests where you have a DebugElement.
-     *
-     *   This also prevents widget object methods from querying information about the elements forcing any assertions
+     *   This prevents widget object methods from querying information about the elements forcing any assertions
      *   to be run from the outside, which we believe is the correct way to structure codes since assertions are
      *   framework specific.
      *
-     *   Each factory method returns an ElementLocator<WidgetObjectElement<T>> which should never be public
-     *   but also has a corresponding method prefixed with _ to indicate the it returns `T` which is what should be
-     *   consumed by users of the class.
      */
     protected factory = {
-        /**
-         * Utility to create versions of factories that return the unwrapped T
-         */
-        unwrap: (fun: ElementLocator<WidgetObjectElement<T>>) => {
-            return (options?: FindElementOptions) => fun(options).unwrap();
-        },
-
-        css: (cssSelector: string) => this.factory.unwrap(this.internalFactory.css(cssSelector)),
-
-        /** Utility to find by data-ui attribute which is the suggested way to tag elements in the DOM for testing  */
-        dataUi: (name: string) => this.factory.unwrap(this.internalFactory.dataUi(name)),
+        css: (cssSelector: string) => (options?: FindElementOptions) => this.el.get({ cssSelector, ...options }),
+        dataUi: (name: string) => this.factory.css(`[data-ui="${name}"]`),
     };
 
     constructor(protected el: WidgetObjectElement<T>) {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type
-   [x] Feature

## What does this change do?

WidgetObject#internalFactory has caused confusion for developers. It caused a different way to interact with components depending on whether you're inside a `WidgetObject` or you're within a test (stepdef or unit test). 

To avoid this confusion, we now always expose `WidgetObjectElement`s and callers call `unwrap()` on their own if they want to use the `T` functionality that is specific to the testing framework being used.

Also removed the explicit return types for WidgetObject methods since they will all (mostly) return WidgetObjectElement or void for methods that abstract interactions.

## What manual testing did you do?

Loaded the examples application, clicked through each example, verifying one piece of functionality for each


## Does this PR introduce a breaking change?
-   [x] Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Wherever one was using `internalFactory` to create methods to find elements, one can just use `factory` and if one needs to access native functionality, they can call `unwrap()` from its call sites.

