### PR TITLE
Add action textKey as `data-ui` attribute on action button elements

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.0.0-dev.25]
+## Changed
+- Add action textKey as `data-ui` attribute on action button HTML elements
 
 ## [2.0.0-dev.24]
 ## Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.24",
+    "version": "2.0.0-dev.25",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/action-menu/action-menu.component.html
+++ b/projects/components/src/action-menu/action-menu.component.html
@@ -90,6 +90,7 @@
         [ngClass]="action.class"
         (click)="runActionHandler(action)"
         [disabled]="isActionDisabled(action)"
+        [attr.data-ui]="action.textKey"
     >
         <ng-container *ngIf="shouldShowText">{{
             action.isTranslatable === false ? action.textKey : (action.textKey | translate)

--- a/projects/components/src/common/interfaces/action-item.interface.ts
+++ b/projects/components/src/common/interfaces/action-item.interface.ts
@@ -40,7 +40,8 @@ export type ActionHandlerType<R, T> = (selectedEntities?: R[], handlerData?: T) 
  */
 export interface BaseActionItem<R, T> {
     /**
-     * The i18n key or a translated string for contents of a action button
+     * The i18n key or a translated string for contents of a action button. This is also added as the data-ui attribute on a action button
+     * HTML element so that it can be used as a CSS selector
      */
     textKey?: string;
     /**

--- a/projects/components/src/dropdown/dropdown.component.html
+++ b/projects/components/src/dropdown/dropdown.component.html
@@ -75,6 +75,7 @@
                         (keydown.space)="onDropdownItemActivated($event)"
                         (keydown.escape)="onDropdownEscPressed($event)"
                         [clrDisabled]="isItemDisabled(item)"
+                        [attr.data-ui]="item.textKey"
                     >
                         <ng-container *ngIf="shouldShowText">{{
                             item.isTranslatable === false ? item.textKey : (item.textKey | translate)

--- a/projects/examples/src/app/components/action-menu/action-menu.examples.module.ts
+++ b/projects/examples/src/app/components/action-menu/action-menu.examples.module.ts
@@ -9,6 +9,8 @@ import { ActionMenuComponent } from '@vcd/ui-components';
 import { Documentation } from '@vmw/ng-live-docs';
 import { ActionMenuContextualActionsExampleComponent } from './contextual-actions/action-menu-contextual-actions-example.component';
 import { ActionMenuContextualActionsExampleModule } from './contextual-actions/action-menu-contextual-actions-example.module';
+import { ActionMenuDataUiExampleComponent } from './data-ui-attribute/action-menu-data-ui-example.component';
+import { ActionMenuDataUiExampleModule } from './data-ui-attribute/action-menu-data-ui-example.module';
 import { ActionMenuHideDisableExampleComponent } from './hide-disable/action-menu-hide-disable-example.component';
 import { ActionMenuHideDisableExampleModule } from './hide-disable/action-menu-hide-disable.example.module';
 import { ActionMenuSearchDebounceExampleComponent } from './search-debounce/action-menu-search-debounce.example.component';
@@ -80,6 +82,12 @@ Documentation.registerDocumentationEntry({
             title: 'Debounced Action Search',
             urlSegment: 'action-menu-search-debounce',
         },
+        {
+            component: ActionMenuDataUiExampleComponent,
+            forComponent: null,
+            title: 'Data-ui attributes on actions',
+            urlSegment: 'action-menu-data-ui-attr',
+        },
     ],
 });
 
@@ -93,6 +101,7 @@ Documentation.registerDocumentationEntry({
         ActionMenuHideDisableExampleModule,
         ActionMenuSearchExampleModule,
         ActionMenuSearchDebounceExampleModule,
+        ActionMenuDataUiExampleModule,
     ],
 })
 export class ActionMenuExamplesModule {}

--- a/projects/examples/src/app/components/action-menu/data-ui-attribute/action-menu-data-ui-example.component.html
+++ b/projects/examples/src/app/components/action-menu/data-ui-attribute/action-menu-data-ui-example.component.html
@@ -1,0 +1,8 @@
+<div>
+    <p>
+        The textKeys of following actions are added as data-ui attributes on their HTML button elements. Inspect the
+        action button HTML elements to notice the data-ui attributes on them
+    </p>
+    <vcd-action-menu [actions]="actions" [actionDisplayConfig]="inlineActionDisplayConfig" [selectedEntities]="[{}]">
+    </vcd-action-menu>
+</div>

--- a/projects/examples/src/app/components/action-menu/data-ui-attribute/action-menu-data-ui-example.component.scss
+++ b/projects/examples/src/app/components/action-menu/data-ui-attribute/action-menu-data-ui-example.component.scss
@@ -1,0 +1,5 @@
+vcd-action-menu ::ng-deep .inline-actions-container {
+    & .inline-action-dropdown ::ng-deep .nested-dropdown > .first-dropdown-toggle {
+        margin-top: 0 !important;
+    }
+}

--- a/projects/examples/src/app/components/action-menu/data-ui-attribute/action-menu-data-ui-example.component.ts
+++ b/projects/examples/src/app/components/action-menu/data-ui-attribute/action-menu-data-ui-example.component.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { ActionDisplayConfig, ActionItem, ActionStyling, ActionType, TextIcon } from '@vcd/ui-components';
+
+@Component({
+    selector: 'vcd-action-menu-data-ui-example',
+    templateUrl: './action-menu-data-ui-example.component.html',
+    styleUrls: ['./action-menu-data-ui-example.component.scss'],
+})
+export class ActionMenuDataUiExampleComponent {
+    actions: ActionItem<any, any>[] = [
+        {
+            textKey: 'actionMenu.dataUi.example.static.featured',
+            actionType: ActionType.STATIC_FEATURED,
+        },
+        {
+            textKey: 'actionMenu.dataUi.example.static',
+            actionType: ActionType.STATIC,
+        },
+        {
+            textKey: 'Grouped Actions',
+            children: [
+                {
+                    textKey: 'actionMenu.dataUi.example.contextual',
+                },
+                {
+                    textKey: 'actionMenu.dataUi.example.contextual.featured',
+                    actionType: ActionType.CONTEXTUAL_FEATURED,
+                },
+            ],
+            isTranslatable: false,
+        },
+    ];
+    inlineActionDisplayConfig: ActionDisplayConfig = {
+        contextual: {
+            styling: ActionStyling.INLINE,
+            buttonContents: TextIcon.TEXT,
+        },
+    };
+}

--- a/projects/examples/src/app/components/action-menu/data-ui-attribute/action-menu-data-ui-example.module.ts
+++ b/projects/examples/src/app/components/action-menu/data-ui-attribute/action-menu-data-ui-example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { VcdActionMenuModule } from '@vcd/ui-components';
+import { ActionMenuDataUiExampleComponent } from './action-menu-data-ui-example.component';
+
+@NgModule({
+    declarations: [ActionMenuDataUiExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdActionMenuModule],
+    exports: [ActionMenuDataUiExampleComponent],
+    entryComponents: [ActionMenuDataUiExampleComponent],
+})
+export class ActionMenuDataUiExampleModule {}

--- a/projects/examples/src/assets/our-translations.json
+++ b/projects/examples/src/assets/our-translations.json
@@ -13,7 +13,11 @@
         "grouped.actions.with.single.child": "Grouped actions with single child",
         "contextual.actions": "Contextual actions",
         "result.filter.identifier": "Result: {option}",
-        "provider.filter.identifier": "Provider: {option}"
+        "provider.filter.identifier": "Provider: {option}",
+        "actionMenu.dataUi.example.static.featured": "Static Featured",
+        "actionMenu.dataUi.example.static": "Static",
+        "actionMenu.dataUi.example.contextual": "Contextual",
+        "actionMenu.dataUi.example.contextual.featured": "Contextual Featured"
     },
     "de": {
         "select.all": "Wählen Sie Alle",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [X] Other... Please describe: Add action textKey as `data-ui` attribute on action button elements

## What does this change do?
Add action textKey as `data-ui` attribute on action button elements to use data-ui attributes as css selectors for selecting the elements in tests

## What manual testing did you do?
- Started the examples application and verified in the Chrome elements tab
that the action object's textKey is added as a data-ui attribute on the action
 button element

https://user-images.githubusercontent.com/10735165/121927886-94398a80-cd0d-11eb-9571-f3e9d881441b.mov

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No