### PR TITLE
Sharing Modal Format and Search

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Add translation for `Filter By` label in Quick search component
 
+## [2.0.0-dev.26]
+## Changed
+- Change record format in UsersGroupsOrgsSharingModalDirective to be RECORDS
+- Export FilterBuilder
+
 ## [2.0.0-dev.25]
 ## Changed
 - Add action textKey as `data-ui` attribute on action button HTML elements

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.25",
+    "version": "2.0.0-dev.26",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/sharing-modal/users-groups-orgs-sharing-modal.directive.ts
+++ b/projects/components/src/sharing-modal/users-groups-orgs-sharing-modal.directive.ts
@@ -182,6 +182,7 @@ export class UsersGroupsOrgsSharingModalDirective implements OnInit {
                     {
                         links: false,
                         multisite: true,
+                        format: Query.Format,
                     }
                 )
                 .toPromise();

--- a/projects/components/src/utils/index.ts
+++ b/projects/components/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './test/index';
 export * from './unit/unit';
 export * from './unit/unit-formatter';
 export * from './common-util';
+export * from './filter-builder';

--- a/projects/components/src/utils/rest/rest-query-search.client.ts
+++ b/projects/components/src/utils/rest/rest-query-search.client.ts
@@ -43,6 +43,7 @@ export interface RestQuery {
 export interface RestQueryOptions {
     links?: boolean;
     multisite?: boolean;
+    format?: Query.Format;
 }
 
 /**
@@ -87,6 +88,10 @@ export class RestQueryService extends VcdApiClient {
         let multisite: boolean;
         if (options?.multisite) {
             multisite = options.multisite;
+        }
+
+        if (options?.format) {
+            toSend.format(options.format);
         }
 
         return this.query(toSend, multisite);


### PR DESCRIPTION

Signed-off-by: Ria Mahoney <mpatrice@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [x] Version bump
-   [ ] Other... Please describe:

## What does this change do?
* Sends data in RECORDS format instead of IDRECORDS
* Exports FilterBuilder

## Why was the change made?
* New Sharing Modal requires filter on search/dropdown
* Former records format prevented some entities from appearing

## What manual testing did you do?
### Verify available users/groups/orgs appear in Sharing Modal search combobox
* Navigate to Catalogs and open Sharing Modal
* Verify that users appear in the search combobox
* Repeat for User Groups and for Organizations
### Verify changes are saved
* Navigate to Catalogs and open Sharing Modal
* Select Users tab
* Search for a user in the search combobox, select rights in the dropdown, and click ADD
* Click Submit to save changes and exit the modal
* Reopen the modal to see that the user with new rights added appears in the datagrid below the search combobox
* Repeat for Groups tab and for Organizations tab
### Verify toggle for sharing with ALL
* Navigate to Catalogs and open Sharing Modal
* Use the toggle to share with All Users and Groups
* Click Submit to save changes and exit the modal
* Reopen the modal and see that toggle still points to share with All Users and Groups
* De-select toggle and click Submit
* Reopen the modal and see that the toggle is still deselected
* Repeat with the toggle to share with All Organizations
### Verify FilterBuilder removes current org
* Log into org1
* Navigate to Catalogs and open Sharing Modal
* Select the Organizations tab
* Verify that org1 is NOT an option in the search combobox
* Verify that all other orgs ARE available in the search combobox

## Screenshots (if applicable)

## Does this PR introduce a breaking change?
-   [x] Yes

This will remove the `id` property from the records in favor of an `href` property
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
