### PR TITLE
Fix bug when passing index=0 to CypressWidgetObjectElement.get

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- Fixed number-with-unit input read-only label to be hidden when empty.
 
-## [Unreleased]
+
+## [2.0.0-dev.27]
+### Fixed
+- Fixed `number-with-unit-input`s read-only label to be hidden when empty.
 - Add translation for `Filter By` label in Quick search component
+- `CypressWidgetObjectElement.get` which was ignoring `FindElementOptions#index` if it was set to 0
 
 ## [2.0.0-dev.26]
 ## Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "2.0.0-dev.26",
+    "version": "2.0.0-dev.27",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
@@ -79,13 +79,14 @@ describe('CypressWidgetObjectFinder', () => {
         });
 
         it('finds a widget using index', () => {
+            const index = 0;
             const getSpy = spyOn(cy, 'get').and.callThrough();
             const findSpy = spyOn(cy, 'find').and.callThrough();
             const eqSpy = spyOn(cy, 'eq').and.callThrough();
-            new CypressWidgetObjectFinder().find(FakeWidget, { index: 1 });
+            new CypressWidgetObjectFinder().find(FakeWidget, { index });
             expect(getSpy).toHaveBeenCalledWith('body', { timeout: undefined });
             expect(findSpy).toHaveBeenCalledWith(FakeWidget.tagName, undefined);
-            expect(eqSpy).toHaveBeenCalledWith(1);
+            expect(eqSpy).toHaveBeenCalledWith(index);
         });
     });
 });

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
@@ -36,7 +36,7 @@ export class CypressWidgetObjectElement<T extends ElementActions> implements Wid
         let chainable: any;
         if (typeof selector === 'string') {
             chainable = root.find(selector);
-        } else if (selector.index) {
+        } else if (typeof selector.index === 'number') {
             chainable = root.find(cssSelector, selector.options).eq(selector.index);
         } else if (selector.text) {
             const queryOptions = { matchCase: false, ...(selector.options || {}) };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [x] Version bump

## What does this change do?
Fixes a bug where if you tried to pass `{index:0}` when calling a `CypressWidgetObjectElement#get(...)`, the index would be ignored and you'd still get all the matching elements from your query (instead of just the first one)

## What manual testing did you do?
No manual testing but unit test was adjusted to use `index: 0.
## Screenshots (if applicable)

## Does this PR introduce a breaking change?
-   [x] No


## Other information
