### PR TITLE
Updating number-with-unit input read-only label.

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed number-with-unit input read-only label to be hidden when empty.
+
+## [Unreleased]
 - Add translation for `Filter By` label in Quick search component
 
 ## [2.0.0-dev.26]

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.html
@@ -1,5 +1,5 @@
 <div class="clr-form-control" [vcdResponsiveInput]="{ disabled: !isResponsive }" *ngIf="isReadOnly">
-    <label class="clr-control-label">{{ label }}</label>
+    <label *ngIf="label" class="clr-control-label">{{ label }}</label>
     <span class="clr-control-container readonly-text">{{ displayValue || '-' }}</span>
 </div>
 


### PR DESCRIPTION
Making number-with-unit-form-input read-only label
visibility consistent with the non-read-only code.

Testing Done:
Built and manually tested within VCD.
Confirmed label is no longer taking space when empty.

Signed-off-by: Bryan Bozzi <bryanv@vmware.com>