### PR TITLE
The Tooltip  is visible when the component is destroyed

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -118,7 +118,6 @@ jobs:
                   key: ${{github.sha}}-examples
 
             - run: |
-                  npm ci
                   npm run build-components-doc
                   npm run build-examples-doc
                   npm run generate-translations
@@ -200,7 +199,6 @@ jobs:
                   key: ${{github.sha}}-examples
 
             - run: |
-                  npm ci
                   npx ng deploy --no-build
               if: github.event_name == 'push' && github.ref == 'refs/heads/master'
               env:

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [3.0.0-dev.2]
 ### Added
 - Customizable text for the unlimited checkbox of the `NumberWithUnitFormInputComponent`.
+### Fixed
+- Tooltip doesn't close when going to new tab or page
 
 ## [3.0.0-dev.1]
 ### Added

--- a/projects/components/src/lib/directives/show-clipped-text.directive.spec.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.spec.ts
@@ -7,7 +7,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { fireTipTransitionEndForTests, ShowClippedTextDirective, TooltipPosition } from './show-clipped-text.directive';
 import {
     ShowClippedTextDirectiveTestHelper,
-    ShowClippedTextDirectiveTestHostComponent
+    ShowClippedTextDirectiveTestHostComponent,
 } from './show-clipped-text.directive.test-helper';
 
 /** The this parameter passed to the each test */
@@ -107,6 +107,28 @@ describe('ShowClippedTextDirective', () => {
             // Transition end is not called when the window is not focused, so need to add this.
             fireTipTransitionEndForTests(new Event('transitionend'));
             expect(helper.tooltipVisibility).toBe('hidden', 'CSS visibility should have been set to hidden');
+        }));
+
+        it('hide the tooltip after the component is destroyed', fakeAsync(function (this: Test): void {
+            const helper = this.clippedTextHelper;
+            helper.width = '10px';
+            helper.moveMouseOverSecondHost();
+            expect(helper.isTooltipVisible).toBe(true, 'tooltip should be visible');
+            helper.componentInstance.showSecondHost = false;
+            this.fixture.detectChanges();
+            tick(1);
+            expect(helper.isTooltipVisible).toBe(false, 'tooltip should not be visible');
+        }));
+
+        it('does not hide the tooltip if the active component is destroyed', fakeAsync(function (this: Test): void {
+            const helper = this.clippedTextHelper;
+            helper.width = '10px';
+            helper.moveMouseOverHost();
+            expect(helper.isTooltipVisible).toBe(true, 'tooltip should be visible');
+            helper.componentInstance.showSecondHost = false;
+            this.fixture.detectChanges();
+            tick(1);
+            expect(helper.isTooltipVisible).toBe(true, 'tooltip should be visible');
         }));
     });
 

--- a/projects/components/src/lib/directives/show-clipped-text.directive.test-helper.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.test-helper.ts
@@ -119,7 +119,9 @@ export class ShowClippedTextDirectiveTestHelper {
 @Component({
     template: `
         <div [vcdShowClippedText]="{ disabled: disabled }" style="width: 20px" #div>{{ text }}</div>
-        <div [vcdShowClippedText]="{ disabled: disabled }" style="width: 20px" #div2>{{ text2 }}</div>
+        <div [vcdShowClippedText]="{ disabled: disabled }" style="width: 20px" #div2 *ngIf="showSecondHost">
+            {{ text2 }}
+        </div>
     `,
 })
 export class ShowClippedTextDirectiveTestHostComponent {
@@ -130,4 +132,5 @@ export class ShowClippedTextDirectiveTestHostComponent {
     public text = 'texting';
     public text2 = 'texting too';
     public disabled = false;
+    public showSecondHost = true;
 }

--- a/projects/components/src/lib/directives/show-clipped-text.directive.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.ts
@@ -151,7 +151,7 @@ const tip = {
             width: rect.width + 'px',
             height: rect.height + 'px',
             opacity: '1',
-            wordBreak: 'break-all',
+            wordBreak: 'break-word',
         });
         setStyle(tip.content, {
             visibility: 'visible',
@@ -282,6 +282,9 @@ export class ShowClippedTextDirective implements OnDestroy, OnInit {
     deactivate(): void {
         ShowClippedTextDirective.instanceCount--;
         unwatchEvents(this.hostElement, this.onMouseIn, this.onMouseOut);
+        if (tip.currentDirective === this) {
+            tip.hideTooltip(0);
+        }
         if (ShowClippedTextDirective.instanceCount === 0) {
             tip.destroy();
         }

--- a/projects/examples/src/app/components/show-clipped-text/hide/hide-clipped-text-example.component.html
+++ b/projects/examples/src/app/components/show-clipped-text/hide/hide-clipped-text-example.component.html
@@ -1,0 +1,10 @@
+<div class="scroll-container">
+    <button class="btn btn-outline" (click)="toggleContainer()" [disabled]="isClippedContainerVisible">
+        Show container
+    </button>
+    <div class="clipped-container" *ngIf="isClippedContainerVisible" vcdShowClippedText (click)="toggleContainer()">
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's
+        standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make
+        a type specimen book.
+    </div>
+</div>

--- a/projects/examples/src/app/components/show-clipped-text/hide/hide-clipped-text-example.component.scss
+++ b/projects/examples/src/app/components/show-clipped-text/hide/hide-clipped-text-example.component.scss
@@ -1,0 +1,12 @@
+.scroll-container {
+    position: relative;
+    width: 100%;
+    height: 500px;
+    overflow: auto;
+}
+.clipped-container {
+    width: 300px;
+    padding: 10px;
+    margin-top: 30px;
+    cursor: pointer;
+}

--- a/projects/examples/src/app/components/show-clipped-text/hide/hide-clipped-text-example.component.ts
+++ b/projects/examples/src/app/components/show-clipped-text/hide/hide-clipped-text-example.component.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'vcd-hide-clipped-text-example',
+    templateUrl: './hide-clipped-text-example.component.html',
+    styleUrls: ['./hide-clipped-text-example.component.scss'],
+})
+export class HideClippedTextPositioningExampleComponent implements OnInit {
+    public isClippedContainerVisible: boolean = true;
+
+    constructor() {}
+
+    ngOnInit(): void {}
+
+    toggleContainer(): void {
+        this.isClippedContainerVisible = !this.isClippedContainerVisible;
+    }
+}

--- a/projects/examples/src/app/components/show-clipped-text/hide/hide-clipped-text-example.module.ts
+++ b/projects/examples/src/app/components/show-clipped-text/hide/hide-clipped-text-example.module.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2019 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ClarityModule } from '@clr/angular';
+import { VcdComponentsModule } from '@vcd/ui-components';
+import { HideClippedTextPositioningExampleComponent } from './hide-clipped-text-example.component';
+
+@NgModule({
+    declarations: [HideClippedTextPositioningExampleComponent],
+    imports: [CommonModule, VcdComponentsModule, ClarityModule],
+    exports: [HideClippedTextPositioningExampleComponent],
+    entryComponents: [HideClippedTextPositioningExampleComponent],
+})
+export class HideClippedTextPositioningExampleModule {}

--- a/projects/examples/src/app/components/show-clipped-text/show-clipped-text-examples.module.ts
+++ b/projects/examples/src/app/components/show-clipped-text/show-clipped-text-examples.module.ts
@@ -7,6 +7,8 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ShowClippedTextDirective } from '@vcd/ui-components';
 import { Documentation } from '@vmw/ng-live-docs';
+import { HideClippedTextPositioningExampleComponent } from './hide/hide-clipped-text-example.component';
+import { HideClippedTextPositioningExampleModule } from './hide/hide-clipped-text-example.module';
 import { ShowClippedTextPositioningExampleComponent } from './positioning/show-clipped-text-positioning-example.component';
 import { ShowClippedTextPositioningExampleModule } from './positioning/show-clipped-text-positioning-example.module';
 import { ShowClippedTextSizingExampleComponent } from './sizing/show-clipped-text-sizing-example.component';
@@ -27,9 +29,19 @@ Documentation.registerDocumentationEntry({
             title: 'Dynamic Positioning of tooltip',
             urlSegment: 'show-clipped-text-positioning',
         },
+        {
+            component: HideClippedTextPositioningExampleComponent,
+            title: 'Hide the tooltip when the component is destroyed',
+            urlSegment: 'hide-clipped-text',
+        },
     ],
 });
 @NgModule({
-    imports: [CommonModule, ShowClippedTextPositioningExampleModule, ShowClippedTextSizingExampleModule],
+    imports: [
+        CommonModule,
+        ShowClippedTextPositioningExampleModule,
+        ShowClippedTextSizingExampleModule,
+        HideClippedTextPositioningExampleModule,
+    ],
 })
 export class ShowClippedTextExamplesModule {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Bugzilla bug: https://bugzilla.eng.vmware.com/show_bug.cgi?id=2881645
When the component is destroyed the tooltip still remains visible.  
The solution is to hide Tooltip on ngOnDestroy of the Tooltip host component.

## What manual testing did you do?
- Go to vApp/VM list and hover on the name
- Click on the name
- See the Tooltip

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information
