### PR TITLE
Add regex to route objects created by route-analyzer

### DIFF
--- a/projects/route-analyzer/CHANGELOG.MD
+++ b/projects/route-analyzer/CHANGELOG.MD
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.6]
+### [Added]
+- route objects now contain regex property to allow you to test existing URLs
+
 ## [0.0.5]
 - Fixed version 0.0.4 which was using the wrong version of yargs causing errors when you
   run the script.

--- a/projects/route-analyzer/package.json
+++ b/projects/route-analyzer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/route-analyzer",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "bin": "cli.js",
     "dependencies": {
         "@wessberg/ts-evaluator": "0.0.25",

--- a/projects/route-analyzer/src/lib/gen-route-builder.spec.ts
+++ b/projects/route-analyzer/src/lib/gen-route-builder.spec.ts
@@ -8,6 +8,7 @@ import { AppRoute } from './app-route';
 
 interface RouteHelper {
     route(...args: string[]): string;
+    regex: RegExp;
     tagName?: string;
 }
 
@@ -96,6 +97,39 @@ describe('generateRouteBuilder', () => {
         it('is not added to route objects that do have component declared for it', function () {
             const { hi } = getRoutesObj([{ path: 'hi', component: { name: 'TagComponent', tagName: 'my-tag' } }]);
             expect(hi.tagName).toBe('my-tag');
+        });
+    });
+
+    describe('regex', () => {
+        it('matches URLs without trailing slashes', function () {
+            const { test_id } = getRoutesObj([{ path: 'test/:id' }]);
+            expect(test_id.regex.test('/test/123')).toBe(true);
+        });
+
+        it('matches URLs with trailing slashes', function () {
+            const { test_id } = getRoutesObj([{ path: 'test/:id' }]);
+            expect(test_id.regex.test('/test/123/')).toBe(true);
+        });
+
+        it('does not match URLs not starting with slash', function () {
+            const { test_id } = getRoutesObj([{ path: 'test/:id' }]);
+            expect(test_id.regex.test('test/123')).toBe(false);
+        });
+
+        it('ignores content before the beginning of the route (to allow for full URLs)', function () {
+            const { test_id } = getRoutesObj([{ path: 'test/:id' }]);
+            expect(test_id.regex.test('https://google.com/test/123/')).toBe(true);
+        });
+
+        it('does not match route missing an id', () => {
+            const { test_id } = getRoutesObj([{ path: 'test/:id' }]);
+            expect(test_id.regex.test('/test/')).toBe(false);
+            expect(test_id.regex.test('/test')).toBe(false);
+        });
+
+        it('matches routes with multiple replacements', () => {
+            const { a_id_b_idd } = getRoutesObj([{ path: 'a/:id/b/:idd' }]);
+            expect(a_id_b_idd.regex.test('/a/123/b/123')).toBe(true);
         });
     });
 });

--- a/projects/route-analyzer/src/lib/gen-route-builder.ts
+++ b/projects/route-analyzer/src/lib/gen-route-builder.ts
@@ -5,7 +5,7 @@
 import { normalize, join, strings, Path } from '@angular-devkit/core';
 import { AppRoute } from './app-route';
 
-export function generateRouteBuilder(routes: AppRoute[], baseFilename: string = 'RouteBuilder'): string {
+export function generateRouteBuilder(routes: AppRoute[]): string {
     const out: string[] = [];
 
     // Map to avoid duplicate property names for similar paths
@@ -51,12 +51,15 @@ export function generateRouteBuilder(routes: AppRoute[], baseFilename: string = 
         out.push(`export const ${pathPropName} =  {
     route(${argsList}) {
         return \`${fullPath.replace(replacementSegmentRegex, (_, p: string) => `$\{${strings.camelize(p)}}`)}\`;
-    },${
-        route.component?.tagName
-            ? `
+    },
+
+    regex: /${fullPath.replace(replacementSegmentRegex, () => '[^/]+').replace(/\//g, '\\/')}\\/?$/,
+${
+    route.component?.tagName
+        ? `
     tagName: ${JSON.stringify(route.component.tagName)},`
-            : ''
-    }
+        : ''
+}
 }`);
     });
 

--- a/projects/route-analyzer/src/lib/route-analyzer.ts
+++ b/projects/route-analyzer/src/lib/route-analyzer.ts
@@ -181,6 +181,8 @@ function routeCallToRoutes(moduleRouteCall: ModuleRouteCall, typeChecker: ts.Typ
                 const tagName = getTagName(prop.initializer, typeChecker);
                 if (tagName) {
                     route.component.tagName = tagName;
+                } else {
+                    console.warn(`Warning: Component ${route.component.name} does not have a tag name`);
                 }
             } else if (propName === ROUTE_PROP.DATA) {
                 // Don't lose an existing tagName that may have been added

--- a/projects/route-analyzer/src/lib/route-info.ts
+++ b/projects/route-analyzer/src/lib/route-info.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+export interface RouteInfo {
+    /**
+     * Calls this to create a route
+     * @param args replacement IDs for each replaceable part of the URL
+     */
+    route(...args: string[]): string;
+
+    /**
+     * Regex that can be used to see if this route matches an existing URL
+     */
+    regex: RegExp;
+
+    /**
+     * The tag name that will be rendered by Angular's router for this route.
+     */
+    tagName?: string;
+}

--- a/projects/route-analyzer/src/public-api.ts
+++ b/projects/route-analyzer/src/public-api.ts
@@ -8,3 +8,4 @@
  */
 
 export * from './lib/app-route';
+export * from './lib/route-info';


### PR DESCRIPTION
## What does this change do?
Adds a `regex` property to objects created by route-analyzer
    
This regex can be tested against existing URLs to see if a URL matches a route.

This is going to be used in VCD UI automated smoke tests to find the HTML tag name for any given URL

## What manual testing did you do?
None, unit testing only

## PR Type
-  [x] Feature
-  [x] Version bump

## Does this PR introduce a breaking change?
-   [x] No

## PR Checklist
-   [x]  Tests for the changes have been added (for bug fixes / features)
-   [x] Changelog has been updated

