### PR TITLE
Publish by commit message

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -207,6 +207,9 @@ jobs:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     publish-components:
+        if: contains(github.event.head_commit.message, '[publish @vcd/ui-components')
+            && github.event_name == 'push'
+            && github.ref == 'refs/heads/master'
         needs: [build-components, unit-testing]
         runs-on: ubuntu-latest
         steps:
@@ -239,10 +242,7 @@ jobs:
                   file-name: ./projects/components/package.json
 
             - name: Publish components@next
-              if: steps.check-version.outputs.changed == 'true'
-                  && endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vcd/ui-components]')
               run: |
                   cd ./dist/components
                   npm publish --tag next --access public
@@ -250,10 +250,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
             - name: Publish components@latest
-              if: steps.check-version.outputs.changed == 'true'
-                  && !endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vcd/ui-components@latest]')
               run: |
                   cd ./dist/components
                   npm publish
@@ -261,6 +258,9 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
     publish-i18n:
+        if: contains(github.event.head_commit.message, '[publish @vcd/i18n')
+                && github.event_name == 'push'
+                && github.ref == 'refs/heads/master'
         needs: [build-i18n, unit-testing]
         runs-on: ubuntu-latest
         steps:
@@ -293,10 +293,7 @@ jobs:
                   file-name: ./projects/i18n/package.json
 
             - name: Publish i18n@next
-              if: steps.check-version.outputs.changed == 'true'
-                  && endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vcd/i18n]')
               run: |
                   cd ./dist/i18n
                   npm publish --tag next --access public
@@ -304,10 +301,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
             - name: Publish i18n@latest
-              if: steps.check-version.outputs.changed == 'true'
-                  && !endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vcd/i18n@latest]')
               run: |
                   cd ./dist/i18n
                   npm publish
@@ -315,6 +309,9 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
     publish-route-analyzer:
+        if: contains(github.event.head_commit.message, '[publish @vcd/route-analyzer')
+                    && github.event_name == 'push'
+                    && github.ref == 'refs/heads/master'
         needs: [build-route-analyzer, unit-testing]
         runs-on: ubuntu-latest
         steps:
@@ -347,10 +344,7 @@ jobs:
                   file-name: ./projects/route-analyzer/package.json
 
             - name: Publish route-analyzer@next
-              if: steps.check-version.outputs.changed == 'true'
-                  && endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vcd/route-analyzer]')
               run: |
                   cd ./dist/route-analyzer
                   npm publish --tag next --access public
@@ -358,10 +352,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
             - name: Publish route-analyzer@latest
-              if: steps.check-version.outputs.changed == 'true'
-                  && !endsWith(steps.check-version.outputs.version, 'next')
-                  && github.event_name == 'push'
-                  && github.ref == 'refs/heads/master'
+              if: contains(github.event.head_commit.message, '[publish @vcd/route-analyzer@latest]')
               run: |
                   cd ./dist/route-analyzer
                   npm publish

--- a/README.md
+++ b/README.md
@@ -71,15 +71,28 @@ For all development, nightly builds, the version should be created using `npm ve
 
 See [ci-cd.yml](.github/workflows/ci-cd.yml)
 
--   Make a change to one or more of the following files
-    -   [projects/i18n/package.json](./projects/i18n/package.json)
-    -   [projects/components/package.json](./projects/components/package.json)
-    -   [projects/route-analyzer/package.json](./projects/route-analyzer/package.json)
--   Create a PR
--   When the PR is merged, an action will run and publish the packages to npm.
-    -   By creating a version that ends with `next`, for example `"version" : "1.2.3-next""`, the npm version will be tagged
-        with `@next`
-    -   Versions that don't end with `next` will be published without a tag, which means it will be considered `@latest`.
+We recommend that a separate PR be created when publishing a new version of the library. To publish a new version
+of `@vcd/ui-components` or `@vcd/route-analyzer` or `@vcd/i18n`, you must add the following anywhere in your commit message:
+
+-   `[publish lib-name]` to publish an `@next` release
+-   `[publish lib-name@latest]` to publish an `@latest` release
+
+Where lib-name is one of the following:
+
+- `@vcd/ui-components`
+- `@vcd/route-analyzer`
+- `@vcd/i18n`
+
+And modify the corresponding package.json files:
+
+-   [projects/components/package.json](./projects/components/package.json)
+-   [projects/i18n/package.json](./projects/i18n/package.json).
+-   [projects/route-analyzer/package.json](./projects/route-analyzer/package.json).
+
+Note that `@latest` releases are only to be created when we release a version of VCD. Most releases, except for the
+final release that is used by a release of VCD, should be `@next`.
+
+Merging the PR will publish the mentioned packages when it's pushed to master
 
 ## Angular CLI
 


### PR DESCRIPTION
This is copying the work from [live-docs](https://github.com/vmware/live-docs/pull/42)

## Problem Description

Checking the actual package.json version was causing problems
when using versions such as `3.0.0-dev.1` because the action we used wasn't able to tell that `3.0.0-dev.2` was higher
    
## New Behavior
We don't check versions anymore. Users are responsible for updating
package.json to a valid version and an error will occur if, for
 example, they add the magic string but forget to bump package.json.
    
The magic strings are described in the [Publishing section of our  README.md file](https://github.com/vmware/vmware-cloud-director-ui-components/pull/406/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R80)

## Testing Done

Created multiple commits, each with the following modifications, which were removed for the PR:
* npm publish command was changed to an echo
* checks for master branch were removed

### Created different commits

* One commit did not have any of the magic strings
  * Made sure that the job to publish was completely ignored 

## Steps

* [Publishing the action including all three libraries, using default `@next`](https://github.com/juanmendes/vmware-cloud-director-ui-components/actions/runs/1841679722)
* [Publishing the action including all three libraries, using `@latest`](https://github.com/juanmendes/vmware-cloud-director-ui-components/actions/runs/1842792650)
* [Not publishing](https://github.com/juanmendes/vmware-cloud-director-ui-components/actions/runs/1842809699)

