### PR TITLE
Allow WidgetObjects to  find elements by exact text - allow selecting options from select elements.

### DIFF
--- a/projects/components/src/lib/directives/show-clipped-text.directive.ts
+++ b/projects/components/src/lib/directives/show-clipped-text.directive.ts
@@ -99,6 +99,7 @@ const tip = {
     destroy(): void {
         document.body.removeChild(tip.container);
         unwatchEvents(tip.container, tip.onMouseEnter, tip.onMouseLeave);
+        tip.clearHideTimeout();
         tip.content.removeEventListener('transitionend', this.onTransitionEnd);
         tip.container = null;
         tip.content = null;

--- a/projects/components/src/utils/test/widget-object/angular/angular-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/angular/angular-widget-object-element.ts
@@ -30,6 +30,8 @@ export class AngularWidgetObjectElement implements WidgetObjectElement<TestEleme
                 matches = [matches[selector.index]];
             } else if (selector.text) {
                 matches = matches.filter((el) => el.nativeElement.textContent.includes(selector.text));
+            } else if (selector.exactText) {
+                matches = matches.filter((el) => el.nativeElement.textContent.trim() === selector.exactText);
             }
         }
         return new AngularWidgetObjectElement(new TestElement(matches, this.testElement.fixture));
@@ -83,7 +85,9 @@ export class AngularWidgetObjectElement implements WidgetObjectElement<TestEleme
     /**
      * @inheritdoc
      */
-    select(value: string, options?: unknown): void {}
+    select(value: string, options?: unknown): void {
+        this.testElement.select(value, options);
+    }
 
     type(value: string): void {
         this.testElement.type(value);
@@ -198,6 +202,23 @@ export class TestElement implements Iterable<TestElement> {
      */
     blur(): void {
         this.forEach((el) => el.nativeElement.dispatchEvent(new Event('blur')));
+        this.fixture.detectChanges();
+    }
+
+    /**
+     * Select an option by text in all the contained elements..
+     */
+    select(value: string, options: unknown): void {
+        this.forEach((el) => {
+            const optionIndex = el
+                .queryAll(By.css('option'))
+                .findIndex((optionEl) => (optionEl.nativeElement as HTMLOptionElement).text === value);
+            if (optionIndex > -1) {
+                const selectElement = el.nativeElement as HTMLSelectElement;
+                selectElement.selectedIndex = optionIndex;
+                selectElement.dispatchEvent(new Event('change'));
+            }
+        });
         this.fixture.detectChanges();
     }
 

--- a/projects/components/src/utils/test/widget-object/angular/angular-widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object/angular/angular-widget-object.spec.ts
@@ -48,6 +48,11 @@ const DataUi = {
                 [attr.data-ui]="DataUi.nameInput"
                 [(ngModel)]="name"
             />
+            <select>
+                <option>Lorem</option>
+                <option>Ipsum</option>
+                <option>Dolor</option>
+            </select>
         </div>
     `,
 })
@@ -91,6 +96,9 @@ class ClickTrackerWidgetObject<T> extends BaseWidgetObject<T> {
     getButtons = this.factory.dataUi(DataUi.button);
 
     getButtonByLabel = this.factory.dataUi('button');
+
+    getSelect = this.factory.css('select');
+    getOptions = this.factory.css('option');
 
     getTrackerElementUsingParent() {
         return this.getClickCount().parents(`[data-ui=${DataUi.clickReceiver}]`);
@@ -277,6 +285,20 @@ describe('TestElement', () => {
             expect(this.clickTracker.getNameInput().unwrap().value()).toEqual('ryan');
             this.clickTracker.typeNameInput('hannah');
             expect(this.clickTracker.getNameInput().unwrap().value()).toEqual('hannah');
+        });
+    });
+
+    describe('select', () => {
+        it('selects an option based on the option text', function (this: HasClickTracker): void {
+            const selectText = 'Ipsum';
+
+            this.clickTracker.getSelect().select(selectText);
+
+            const options = this.clickTracker.getOptions().unwrap().elements;
+            expect(options[0].properties.selected).toBeFalsy();
+            expect(options[1].properties.selected).toBeTruthy();
+            expect(options[1].nativeElement.text).toBe(selectText);
+            expect(options[2].properties.selected).toBeFalsy();
         });
     });
 });

--- a/projects/components/src/utils/test/widget-object/angular/angular-widget-object.spec.ts
+++ b/projects/components/src/utils/test/widget-object/angular/angular-widget-object.spec.ts
@@ -38,6 +38,8 @@ const DataUi = {
             </p>
             <button disabled [attr.data-ui]="DataUi.button">BUTTON</button>
             <button [attr.data-ui]="DataUi.button">BUTTON2</button>
+            <button [attr.data-ui]="DataUi.button">BUTTON3</button>
+            <button [attr.data-ui]="DataUi.button">BUTTON33</button>
             <input
                 type="text"
                 id="fname"
@@ -169,6 +171,12 @@ describe('AngularWidgetObjectElement', () => {
         it('can find an element by text', function (this: HasClickTracker): void {
             expect(this.clickTracker.getButtonByLabel({ text: 'BUTTON2' }).unwrap().text()).toEqual('BUTTON2');
         });
+        it('finds multiple elements using text', function (this: HasClickTracker): void {
+            expect(this.clickTracker.getButtonByLabel({ text: 'BUTTON3' }).unwrap().elements.length).toBe(2);
+        });
+        it('finds single element using exactText', function (this: HasClickTracker): void {
+            expect(this.clickTracker.getButtonByLabel({ exactText: 'BUTTON3' }).unwrap().elements.length).toBe(1);
+        });
         it('can find an element by index', function (this: HasClickTracker): void {
             expect(this.clickTracker.getButtonByLabel({ index: 0 }).unwrap().text()).toEqual('BUTTON');
         });
@@ -241,7 +249,7 @@ describe('TestElement', () => {
 
     describe('length', () => {
         it('says how many elements are in this TestElement', function (this: HasClickTracker): void {
-            expect(this.clickTracker.getButtons().unwrap().length()).toEqual(2);
+            expect(this.clickTracker.getButtons().unwrap().length()).toEqual(4);
         });
     });
 
@@ -253,7 +261,7 @@ describe('TestElement', () => {
                     .unwrap()
                     .toArray()
                     .map((el) => el.text())
-            ).toEqual(['BUTTON', 'BUTTON2']);
+            ).toEqual(['BUTTON', 'BUTTON2', 'BUTTON3', 'BUTTON33']);
         });
     });
 

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-finder.ts
@@ -50,6 +50,7 @@ export class CypressWidgetObjectFinder<T> {
             cssSelector: query,
             dataUiSelector: findOptions?.dataUiSelector,
             text: findOptions?.text,
+            exactText: findOptions?.exactText,
             index: findOptions?.index,
             options: findOptions?.options,
         };

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.spec.ts
@@ -78,6 +78,17 @@ describe('CypressWidgetObjectFinder', () => {
             expect(containsSpy).toHaveBeenCalledWith(FakeWidget.tagName, 'text', { matchCase: false });
         });
 
+        it('finds a widget using exactText', () => {
+            const getSpy = spyOn(cy, 'get').and.callThrough();
+            const containsSpy = spyOn(cy, 'contains').and.callThrough();
+            new CypressWidgetObjectFinder().find(FakeWidget, { exactText: 'exactText[]{}' });
+            expect(getSpy).toHaveBeenCalledWith('body', { timeout: undefined });
+            // contains should be called with a regular expression that has RegEx characters escaped
+            expect(containsSpy).toHaveBeenCalledWith(FakeWidget.tagName, /^\s*exactText\[\]\{\}\s*$/g, {
+                matchCase: false,
+            });
+        });
+
         it('finds a widget using index', () => {
             const index = 0;
             const getSpy = spyOn(cy, 'get').and.callThrough();

--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
@@ -41,6 +41,10 @@ export class CypressWidgetObjectElement<T extends ElementActions> implements Wid
         } else if (selector.text) {
             const queryOptions = { matchCase: false, ...(selector.options || {}) };
             chainable = root.contains(cssSelector, selector.text, queryOptions);
+        } else if (selector.exactText) {
+            const queryOptions = { matchCase: false, ...(selector.options || {}) };
+            const exactTextEscaped = selector.exactText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            chainable = root.contains(cssSelector, new RegExp(`^\\s*${exactTextEscaped}\\s*$`, 'g'), queryOptions);
         } else {
             chainable = root.find(cssSelector, selector.options);
         }

--- a/projects/components/src/utils/test/widget-object/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/widget-object.ts
@@ -30,6 +30,9 @@ export type FindElementOptions = {
     /** To search for the element containing the given text. Ignored if {@link #index} is passed */
     text?: string;
 
+    /** To search for the element matching the given text exactly. Ignored if {@link #index} or  {@link #text} is passed */
+    exactText?: string;
+
     /** An implementation specific parent can be used to start the search */
     ancestor?: unknown;
 

--- a/projects/components/src/utils/test/widget-object/widget-object.ts
+++ b/projects/components/src/utils/test/widget-object/widget-object.ts
@@ -96,7 +96,7 @@ export interface ElementActions {
      * @param value The text of the dropdown to select
      * @param options Options to be passed down to implementations
      */
-    select(value: string, options: UnknownOptions): void;
+    select(value: string, options?: UnknownOptions): void;
 
     /**
      * For inputs or text areas, clears the current value.


### PR DESCRIPTION
Signed-off-by: Bryan Bozzi <bryanv@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [x] Other... Please describe:
Testing framework changes

## What does this change do?
Implemented the select function to select options.
Added exactText to FindElementOptions so that
we can find elements by text content more precisely.

## What manual testing did you do?
Added a unit test for exactText.
Ran unit tests which utilize this functionality.
Manually tested the Cypress implementation of exactText by:
Temporarily adding two buttons to the header, the first with text "Button15" and the second with "Button1".
Temporarily creating a test that first finds an element by text "Button1" which will find the first button in the header (with text "Button15"). It then finds an element by exactText "Button1" which finds the second button (with text "Button1").

## Screenshots (if applicable)
<img width="1792" alt="Screen Shot 2022-02-28 at 4 18 42 PM" src="https://user-images.githubusercontent.com/2762780/156204669-b2922c08-9271-49bf-bc66-ae2aed0dd236.png">
<img width="1792" alt="Screen Shot 2022-02-28 at 4 18 27 PM" src="https://user-images.githubusercontent.com/2762780/156204675-2b143226-bddb-438d-b278-a30bc68a8847.png">


## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
