### PR TITLE
Add the ability to disable datagrid's row selection

### DIFF
--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -47,6 +47,7 @@
         [ngForTrackBy]="trackBy"
         [ngClass]="this.clrDatarowCssClassGetter(restItem, i)"
         [clrDgItem]="restItem"
+        [clrDgSelectable]="isRowSelectable(restItem)"
     >
         <clr-dg-cell
             *ngIf="shouldDisplayContextualActionsInRow"

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -281,6 +281,13 @@ interface ColumnConfigInternal<R, T> extends GridColumn<R> {
 })
 export class DatagridComponent<R extends B, B = any> implements OnInit, AfterViewInit {
     /**
+     * The parent component could provide a callback function to calculate if the row is selectable.
+     * When null (default) all rows are selectable.
+     */
+    @Input()
+    isRowSelectableCallback: (item: R) => boolean = null;
+
+    /**
      * Sets the configuration of columns on the grid and updates the {@link columnsConfig} array. Also pushes
      * notifications for listeners to make changes to the _columns array
      */
@@ -1009,6 +1016,19 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
 
             return columnConfig;
         });
+    }
+
+    /**
+     * Apply the parent's component callback when available.
+     * The default is to make all rows selectable.
+     * @param row to make selectable or not.
+     */
+    public isRowSelectable(row: R): boolean {
+        if (!this.isRowSelectableCallback) {
+            return true;
+        }
+
+        return this.isRowSelectableCallback(row);
     }
 
     ngOnInit(): void {

--- a/projects/components/src/utils/test/datagrid/datagrid.wo.ts
+++ b/projects/components/src/utils/test/datagrid/datagrid.wo.ts
@@ -22,6 +22,7 @@ const Css = {
     PAGINATION_NEXT: '.pagination-next',
     TOP_POSITIONED_BUTTON: 'clr-dg-action-bar button',
     ROW_ACTION_CONTAINER: '.datagrid-select label',
+    ROW_ACTION_INPUT: '.datagrid-select input',
     CHECKBOX_WRAPPER: 'clr-checkbox-wrapper',
     RADIO_WRAPPER: 'clr-radio-wrapper',
     FILTER: 'clr-dg-filter',
@@ -182,6 +183,15 @@ export class ClrDatagridWidgetObject<T> extends BaseWidgetObject<T> {
      */
     getSelectionLabelForRow(row: number) {
         return this.getRow(row).get(Css.ROW_ACTION_CONTAINER);
+    }
+
+    /**
+     * Returns the input of .datagrid-select element in the given row. This function can be used to
+     * perform both single and multiple selection
+     * @param row 0-based index of row
+     */
+    getSelectionInputForRow(row: number) {
+        return this.getRow(row).get(Css.ROW_ACTION_INPUT);
     }
 
     /**

--- a/projects/examples/src/components/datagrid/datagrid-is-row-selectable-example.component.html
+++ b/projects/examples/src/components/datagrid/datagrid-is-row-selectable-example.component.html
@@ -1,0 +1,9 @@
+<button class="btn btn-primary" (click)="selectionType = GridSelectionType.Single">Single Select</button>
+<button class="btn btn-primary" (click)="selectionType = GridSelectionType.Multi">Multi Select Select</button>
+<vcd-datagrid
+    [gridData]="gridData"
+    (gridRefresh)="refresh($event)"
+    [columns]="columns"
+    [selectionType]="selectionType"
+    [isRowSelectableCallback]="isRowSelectableCallback"
+></vcd-datagrid>

--- a/projects/examples/src/components/datagrid/datagrid-is-row-selectable-example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-is-row-selectable-example.component.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright 2022 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import { GridColumn, GridDataFetchResult, GridSelectionType, GridState } from '@vcd/ui-components';
+
+interface VM {
+    href: string;
+    name: string;
+    isSelectable: boolean;
+}
+
+/**
+ * Making data rows be unselectable.
+ */
+@Component({
+    selector: 'vcd-datagrid-is-row-selectable-example',
+    templateUrl: './datagrid-is-row-selectable-example.component.html',
+})
+export class DatagridIsRowSelectableExampleComponent {
+    selectionType = GridSelectionType.Multi;
+    GridSelectionType = GridSelectionType;
+
+    gridData: GridDataFetchResult<VM> = {
+        items: [],
+    };
+
+    columns: GridColumn<VM>[] = [
+        {
+            displayName: 'Name',
+            renderer: 'name',
+        },
+        {
+            displayName: 'Is Selectable',
+            renderer: 'isSelectable',
+        },
+    ];
+
+    isRowSelectableCallback = (vm: VM) => {
+        return vm.isSelectable;
+    };
+
+    refresh(eventData: GridState<VM>): void {
+        this.gridData = {
+            items: [
+                { href: 'https://abc.de/vm-1', name: 'vm-1', isSelectable: false },
+                { href: 'https://abc.de/vm-2', name: 'vm-2', isSelectable: true },
+                { href: 'https://abc.de/vm-3', name: 'vm-3', isSelectable: false },
+                { href: 'https://abc.de/vm-4', name: 'vm-4', isSelectable: true },
+            ],
+            totalItems: 4,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid-is-row-selectable-example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-is-row-selectable-example.module.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2022 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { VcdComponentsModule } from '@vcd/ui-components';
+import { DatagridIsRowSelectableExampleComponent } from './datagrid-is-row-selectable-example.component';
+
+@NgModule({
+    declarations: [DatagridIsRowSelectableExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
+    exports: [DatagridIsRowSelectableExampleComponent],
+    entryComponents: [DatagridIsRowSelectableExampleComponent],
+})
+export class DatagridIsRowSelectableExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -44,6 +44,8 @@ import { DatagridSortExampleComponent } from './datagrid-sort.example.component'
 import { DatagridSortExampleModule } from './datagrid-sort.example.module';
 import { DatagridThreeRenderersExampleComponent } from './datagrid-three-renderers.example.component';
 import { DatagridThreeRenderersExampleModule } from './datagrid-three-renderers.example.module';
+import { DatagridIsRowSelectableExampleComponent } from './datagrid-is-row-selectable-example.component';
+import { DatagridIsRowSelectableExampleModule } from './datagrid-is-row-selectable-example.module';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -79,6 +81,11 @@ Documentation.registerDocumentationEntry({
             component: DatagridRowSelectExampleComponent,
             title: 'Selectable datagrid rows',
             urlSegment: 'datagrid-row-select',
+        },
+        {
+            component: DatagridIsRowSelectableExampleComponent,
+            title: 'Disabling selection of datagrid rows',
+            urlSegment: 'datagrid-is-row-selectable',
         },
         {
             component: DatagridPaginationExampleComponent,
@@ -171,6 +178,7 @@ Documentation.registerDocumentationEntry({
         DatagridDetailPaneExampleModule,
         DatagridColumnWidthExampleModule,
         DatagridActionDisplayConfigExampleModule,
+        DatagridIsRowSelectableExampleModule,
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
Clarity's datagrid supports clrDgSelectable, which disable/enable row selectability. This change will allow VCD datagrid to use clrDgSelectable. It will take a callback function to calculate row's selectability.

Signed-off-by: Xuanvinh Vu <xvu@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Add the ability to disable datagrid's row selection

## What manual testing did you do?
Tested in development of VCD migrate VM workflow. The datagrid row is selectable when the VM is migratable.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/67131449/156197837-f370da9b-64d2-4a31-abcc-60d97de2a62f.png)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
