### PR TITLE
Fix alignment in nested dropdowns

### DIFF
--- a/projects/components/src/dropdown/dropdown.component.scss
+++ b/projects/components/src/dropdown/dropdown.component.scss
@@ -1,5 +1,8 @@
-.nested-dropdown-menu ::ng-deep .nested-dropdown {
-    display: block;
-    white-space: nowrap;
+.nested-dropdown-menu {
     max-width: 15rem;
+
+    ::ng-deep .nested-dropdown {
+        display: block;
+        white-space: nowrap;
+    }
 }


### PR DESCRIPTION
Clarity buttons have max-width 18rem, while nested dropdowns have a hardcoded 15rem. This breaks the alignment when both elements are in the same container and the button contains a longer text (expanding over the 15rem).
This commit moves the max-width constraint from the nested dropdown into its parent element, ensuring the items remain always aligned.

Signed-off-by: Davi Barreto <dbarreto@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Fixes alignment in nested dropdowns which contains sibling buttons with long texts.

## What manual testing did you do?
Added long text via dev tools and verified the fix (see screenshots)

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/28786474/159455923-905b2e26-3224-4038-8b1e-2dfd64d917ac.png)
![image](https://user-images.githubusercontent.com/28786474/159456455-03817bae-767b-465f-9ce3-ee2d29a98299.png)




## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
