### PR TITLE
Fix publishing of @vcd/ui-components and @vcd/i18n

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "12.0",
+    "version": "12.0.0",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/i18n/package.json
+++ b/projects/i18n/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/i18n",
-    "version": "12.0",
+    "version": "12.0.0",
     "peerDependencies": {
         "@angular/common": ">12",
         "@angular/core": ">12"


### PR DESCRIPTION
See https://github.com/vmware/vmware-cloud-director-ui-components/runs/5672638746?check_suite_focus=true

[publish @vcd/ui-components@latest]
[publish @vcd/i18n@latest]

> npm ERR! Invalid version: "12.0"

Signed-off-by: Juan Mendes <mendesjuan@gmail.com>

