### PR TITLE
Fix CypressWidgetObject parents() function returning many parents.

### DIFF
--- a/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
+++ b/projects/components/src/utils/test/widget-object/cypress/cypress-widget-object-element.ts
@@ -57,10 +57,10 @@ export class CypressWidgetObjectElement<T extends ElementActions> implements Wid
     parents(selector: string | FindElementOptions): CypressWidgetObjectElement<T> {
         const root = this.getBase();
         if (typeof selector === 'string') {
-            return new CypressWidgetObjectElement(root.parents(selector), false, this.alias);
+            return new CypressWidgetObjectElement(root.parents(selector).eq(0), false, this.alias);
         }
         return new CypressWidgetObjectElement(
-            root.parents(SelectorUtil.extractSelector(selector), selector.options),
+            root.parents(SelectorUtil.extractSelector(selector), selector.options).eq(0),
             false,
             this.alias
         );


### PR DESCRIPTION
The CypressWidgetObject implementation of parents() was returning
all parents that matched the query instead of the closest parent.

Testing Done:
Manually confirmed the fix with Cypress tests in VCD.

Signed-off-by: Bryan Bozzi <bryanv@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

## What manual testing did you do?

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
