### PR TITLE
[publish @vcd/ui-components] Start tracking Angular major version

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [12.0.1-dev.1]
+Same as 4.0.1-dev.1 . Created because we'll use major versions that match Angular and Clarity's versions
+
 ## [4.0.1-dev.1]
 ### Fixed
 - Fix visibility updates getting lost when `actionItem.availability` is an observable

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,14 +1,14 @@
 {
     "name": "@vcd/ui-components",
-    "version": "4.0.1-dev.1",
+    "version": "12.0.1-dev.1",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },
     "peerDependencies": {
-        "@clr/angular": ">=4.0.10",
-        "@angular/common": ">=10.0.0",
-        "@angular/core": ">=10.0.0",
-        "@vcd/i18n": "1.0.0-dev.1",
+        "@clr/angular": ">=12",
+        "@angular/common": ">=12",
+        "@angular/core": ">=12",
+        "@vcd/i18n": ">=1.0.0-dev.1",
         "@vcd/angular-client": "0.0.2-alpha.1",
         "@vcd/bindings": "9.1.1"
     }


### PR DESCRIPTION
Start using v12 to match v12 of Clarity and Angular so that we won't need a compatibility table.

Signed-off-by: Juan Mendes <mendesjuan@gmail.com>

## PR Checklist

-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [x] Version bump

## What does this change do?

## What manual testing did you do?
Running the application and verifying each grid example

## Does this PR introduce a breaking change?

-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
