### PR TITLE
Publishing ui-components with rxjs version 6.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "codecov.io": "0.1.6",
         "copyfiles": "^2.4.1",
         "cross-spawn": "^7.0.3",
-        "karma-coverage": "^2.2.0",
+        "karma-coverage": "2.2.0",
         "lint-staged": "^12.3.7",
         "messageformat": "1.0.2",
         "mkdirp": "^1.0.4",
@@ -43,7 +43,7 @@
         "prismjs": "^1.23.0",
         "properties": "1.2.1",
         "rbradford-compodoc": "^1.1.11",
-        "rxjs": "7.4.0",
+        "rxjs": "^6.5.5",
         "schematics-utilities": "^2.0.2",
         "systemjs": "0.20.19",
         "tsickle": "^0.39.1",
@@ -83,7 +83,7 @@
         "jasmine-spec-reporter": "~5.0.0",
         "karma": "6.3.16",
         "karma-chrome-launcher": "~3.1.0",
-        "karma-coverage-istanbul-reporter": "^3.0.3",
+        "karma-coverage-istanbul-reporter": "3.0.3",
         "karma-jasmine": "~4.0.0",
         "karma-jasmine-html-reporter": "^1.5.0",
         "mkdirp": "^1.0.4",
@@ -21908,11 +21908,14 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "dependencies": {
-        "tslib": "~2.1.0"
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
       }
     },
     "node_modules/rxjs-compat": {
@@ -21922,9 +21925,9 @@
       "peer": true
     },
     "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -42410,17 +42413,17 @@
       }
     },
     "rxjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "requires": {
-        "tslib": "~2.1.0"
+        "tslib": "^1.9.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "prismjs": "^1.23.0",
     "properties": "1.2.1",
     "rbradford-compodoc": "^1.1.11",
-    "rxjs": "7.4.0",
+    "rxjs": "6.5.5",
     "schematics-utilities": "^2.0.2",
     "systemjs": "0.20.19",
     "tsickle": "^0.39.1",

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "13.0.1-dev.1",
+    "version": "13.0.1-dev.2",
     "dependencies": {
         "@ngx-formly/core": "5.6.1"
     },

--- a/projects/components/src/common/subscription/subscription-tracker.ts
+++ b/projects/components/src/common/subscription/subscription-tracker.ts
@@ -4,8 +4,8 @@
  */
 
 import { Injectable, OnDestroy } from '@angular/core';
-import { Subscriber } from 'rxjs';
 import { Observable, PartialObserver, Subscription } from 'rxjs';
+import { toSubscriber } from 'rxjs/internal-compatibility';
 
 /**
  * An interface that knows how to subscribe and unsubscribe from observables.
@@ -31,18 +31,6 @@ export interface ISubscriptionTracker {
      * Unsubscribes from all subscriptions on this {@link Subscribable}.
      */
     unsubscribeAll(): void;
-}
-
-export function toSubscriber<T>(
-    next?: PartialObserver<T> | ((value: T) => void),
-    error?: (error: any) => void,
-    complete?: () => void
-): Subscriber<T> {
-    if (next instanceof Subscriber) {
-        return next as Subscriber<T>;
-    }
-
-    return { next, error, complete } as Subscriber<T>;
 }
 
 /**

--- a/projects/components/src/datagrid/filters/datagrid-filter.ts
+++ b/projects/components/src/datagrid/filters/datagrid-filter.ts
@@ -92,7 +92,7 @@ export abstract class DatagridFilter<V, C extends FilterConfig<V>>
         const obs = this.getDebounceTimeMs()
             ? this.formGroup.valueChanges.pipe(debounceTime(this.getDebounceTimeMs()))
             : this.formGroup.valueChanges;
-        this.subscriptionTracker.subscribe(obs, () => this.changes.next(null));
+        this.subscriptionTracker.subscribe(obs, () => this.changes.next());
     }
 
     /**


### PR DESCRIPTION
We updated ui-components rxjs version to 7.4.0 but in vcd-ui that version causes a lot
of breaking changes which will need to be handled in a separate future time slot.

- vcd-ui currently uses rxjs@6.6.3 and wherever the SubscriptionTracker is used there errors:
"TypeError: _a.bind is not a function"
"TypeError: fn.call is not a function"
- 731 unit tests are also failing

- The simplest solution is to revert to the previous rxjs version that ui-components used - 6.5.5
- This fixes all the above mentioned issues

[publish @vcd/ui-components]

Signed-off-by: Georgi Atanasov <georgi.atanasov147@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [x] Version bump
-   [ ] Other... Please describe:

## What does this change do?
- Reverts to the previous rxjs version that ui-components used - 6.5.5

## What manual testing did you do?
- Executed 'start' & tested the subscription tracker example
- Executed unit tests
- Executed unit tests in vcd-ui with this version
- Started vcd-ui with this version

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
