### PR TITLE
FormSelectComponent not taking in translation params

### DIFF
--- a/projects/components/src/form/base-form-control.ts
+++ b/projects/components/src/form/base-form-control.ts
@@ -5,6 +5,7 @@
 
 import { Directive, Input } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, FormControl, NgControl, ValidatorFn } from '@angular/forms';
+import { TranslationService } from '@vcd/i18n';
 import { IdGenerator } from '../utils/id-generator/id-generator';
 import { CanBeReadOnly } from './interfaces/can-be-read-only.interface';
 
@@ -110,7 +111,7 @@ export class BaseFormControl implements ControlValueAccessor, CanBeReadOnly {
      */
     protected initialValue: number | string | boolean;
 
-    constructor(ngControl: NgControl) {
+    constructor(ngControl: NgControl, protected translationService: TranslationService) {
         if (ngControl) {
             ngControl.valueAccessor = this;
             this.formControlNameDirective = ngControl;
@@ -140,6 +141,18 @@ export class BaseFormControl implements ControlValueAccessor, CanBeReadOnly {
         return Object.keys(this.formControl.errors || {});
     }
 
+    /**
+     * Return the translated error strings.
+     */
+    get translatedErrors(): string[] {
+        return this.errorKeys.map((errorKey) => {
+            return this.translationService.translate(
+                errorKey,
+                this.getTranslationParams(this.formControl.errors[errorKey])
+            );
+        });
+    }
+
     registerOnChange(onChange: (...args: unknown[]) => unknown): void {
         this.onChange = onChange;
     }
@@ -153,4 +166,15 @@ export class BaseFormControl implements ControlValueAccessor, CanBeReadOnly {
     }
 
     writeValue(val: any): void {}
+
+    /**
+     * When errorObjectValue param is not an array we pass back the control's value to stay backward compatible.
+     */
+    private getTranslationParams(errorObjectValue: any): any {
+        if (Array.isArray(errorObjectValue)) {
+            return errorObjectValue;
+        }
+
+        return [this.formControl.value];
+    }
 }

--- a/projects/components/src/form/form-checkbox/form-checkbox.component.ts
+++ b/projects/components/src/form/form-checkbox/form-checkbox.component.ts
@@ -5,6 +5,7 @@
 
 import { Component, Input, OnInit, Optional, Self } from '@angular/core';
 import { NgControl } from '@angular/forms';
+import { TranslationService } from '@vcd/i18n';
 import { BaseFormControl } from '../base-form-control';
 
 export enum CheckBoxStyling {
@@ -63,7 +64,7 @@ export class FormCheckboxComponent extends BaseFormControl {
         return this.styling === CheckBoxStyling.CHECKBOX;
     }
 
-    constructor(@Self() @Optional() controlDirective: NgControl) {
-        super(controlDirective);
+    constructor(@Self() @Optional() controlDirective: NgControl, protected translationService: TranslationService) {
+        super(controlDirective, translationService);
     }
 }

--- a/projects/components/src/form/form-input/form-input.component.ts
+++ b/projects/components/src/form/form-input/form-input.component.ts
@@ -15,6 +15,7 @@ import {
     ViewChild,
 } from '@angular/core';
 import { AbstractControl, FormControl, NgControl, ValidationErrors } from '@angular/forms';
+import { TranslationService } from '@vcd/i18n';
 import { BaseFormControl, defaultValidatorForControl } from '../base-form-control';
 
 /**
@@ -92,8 +93,8 @@ export class FormInputComponent extends BaseFormControl implements AfterViewInit
      */
     @Output() escapeClicked = new EventEmitter<boolean>(false);
 
-    constructor(@Self() @Optional() controlDirective: NgControl) {
-        super(controlDirective);
+    constructor(@Self() @Optional() controlDirective: NgControl, protected translationService: TranslationService) {
+        super(controlDirective, translationService);
     }
 
     /**

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -30,8 +30,8 @@
             </clr-signpost>
 
             <span class="clr-subtext" *ngIf="showErrors" [id]="errorsId">
-                <div *ngFor="let key of errorKeys">
-                    <div>{{ key | translate: [formControl.value] }}</div>
+                <div *ngFor="let error of translatedErrors">
+                    <div>{{ error }}</div>
                 </div>
             </span>
 

--- a/projects/components/src/form/form-select/form-select.component.ts
+++ b/projects/components/src/form/form-select/form-select.component.ts
@@ -5,6 +5,7 @@
 
 import { Component, Input, Optional, Self } from '@angular/core';
 import { NgControl } from '@angular/forms';
+import { TranslationService } from '@vcd/i18n';
 import { SelectOption } from '../../common/interfaces/select-option';
 import { BaseFormControl } from '../base-form-control';
 
@@ -32,8 +33,8 @@ export class FormSelectComponent extends BaseFormControl {
      */
     @Input() hint: string;
 
-    constructor(@Self() @Optional() ngControl: NgControl) {
-        super(ngControl);
+    constructor(@Self() @Optional() ngControl: NgControl, protected translationService: TranslationService) {
+        super(ngControl, translationService);
     }
 
     get selectedOption(): SelectOption {

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -215,11 +215,11 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
     constructor(
         @Self() @Optional() controlDirective: NgControl,
         private fb: FormBuilder,
-        private translationService: TranslationService,
+        protected translationService: TranslationService,
         private unitFormatter: UnitFormatter,
         private changeDetector: ChangeDetectorRef
     ) {
-        super(controlDirective);
+        super(controlDirective, translationService);
     }
 
     ngOnInit(): void {

--- a/projects/examples/src/components/form-input/form-input-components.examples.module.ts
+++ b/projects/examples/src/components/form-input/form-input-components.examples.module.ts
@@ -22,6 +22,7 @@ import { NumberWithUnitFormInputUnitlessExampleComponent } from './number-with-u
 import { NumberWithUnitFormInputUnitlessExampleModule } from './number-with-unit-form-input-unitless.example.module';
 import { NumberWithUnitFormInputExampleComponent } from './number-with-unit-form-input.example.component';
 import { NumberWithUnitFormInputExampleModule } from './number-with-unit-form-input.example.module';
+import { FormSelectValidationExampleComponent } from './form-select-validation.example.component';
 
 Documentation.registerDocumentationEntry({
     component: FormInputComponent,
@@ -50,6 +51,11 @@ Documentation.registerDocumentationEntry({
             component: FormSelectDisabledExampleComponent,
             title: 'Select form input with disabled options',
             urlSegment: 'form-select-disabled',
+        },
+        {
+            component: FormSelectValidationExampleComponent,
+            title: 'Select form input validation',
+            urlSegment: 'form-select-validation',
         },
     ],
 });

--- a/projects/examples/src/components/form-input/form-select-validation.example.component.html
+++ b/projects/examples/src/components/form-input/form-select-validation.example.component.html
@@ -1,0 +1,9 @@
+<form [formGroup]="formGroup" class="clr-form-horizontal">
+    <vcd-form-select
+        [showAsterisk]="true"
+        [label]="'Select Input'"
+        [options]="options"
+        [formControlName]="'selectInput'"
+    >
+    </vcd-form-select>
+</form>

--- a/projects/examples/src/components/form-input/form-select-validation.example.component.ts
+++ b/projects/examples/src/components/form-input/form-select-validation.example.component.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright 2022 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { AbstractControl, FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { FormSelectComponent, SelectOption } from '@vcd/ui-components';
+
+/**
+ * This example shows the select form input validates the selection to be between 1 and 3.
+ * The select form input takes a validator that returns an i18n key and replacement values. For example, { 'vcd.cc.warning.numRange': ['one', 'three'] }.
+ */
+@Component({
+    selector: 'vcd-form-select-validation-example-component',
+    templateUrl: './form-select-validation.example.component.html',
+})
+export class FormSelectValidationExampleComponent {
+    formGroup: FormGroup;
+
+    @ViewChild('selectInputComponent', { static: true }) selectInputComponent: FormSelectComponent;
+
+    options: SelectOption[] = [
+        {
+            display: '',
+            value: '',
+        },
+        {
+            display: 'zero',
+            value: 0,
+        },
+        {
+            display: 'one',
+            value: 1,
+        },
+        {
+            display: 'two',
+            value: 2,
+        },
+        {
+            display: 'three',
+            value: 3,
+        },
+        {
+            display: 'four',
+            value: 4,
+        },
+    ];
+
+    constructor(private fb: FormBuilder) {
+        this.formGroup = this.fb.group({
+            selectInput: ['one', [Validators.required, this.oneAndThreeRangeValidator]],
+        });
+    }
+
+    /**
+     * This hardcoded to show that validator can return anything to be passed to its translation key.
+     * In a real application you would never hardcode English in the value.
+     * The first value being passed as 'placeholder' is being ignored by the existing translation.
+     */
+    private oneAndThreeRangeValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
+        // vcd.cc.warning.numRange=Only numbers in the range of {1} to {2} are allowed
+        if (control.value < 1 || control.value > 3) {
+            return { 'vcd.cc.warning.numRange': ['placeholder', 'one', 'three'] };
+        }
+        return null;
+    };
+}

--- a/projects/examples/src/components/form-input/form-select.example.module.ts
+++ b/projects/examples/src/components/form-input/form-select.example.module.ts
@@ -8,9 +8,14 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { VcdFormModule } from '@vcd/ui-components';
 import { FormSelectDisabledExampleComponent } from './form-select-disabled.example.component';
 import { FormSelectExampleComponent } from './form-select.example.component';
+import { FormSelectValidationExampleComponent } from './form-select-validation.example.component';
 
 @NgModule({
-    declarations: [FormSelectExampleComponent, FormSelectDisabledExampleComponent],
+    declarations: [
+        FormSelectExampleComponent,
+        FormSelectDisabledExampleComponent,
+        FormSelectValidationExampleComponent,
+    ],
     imports: [VcdFormModule, ReactiveFormsModule],
     exports: [FormSelectExampleComponent],
 })


### PR DESCRIPTION
## Description
The `FormSelectComponent` was hardcoded to use its control's `.value` to be passed to the translation service (along with its key) to display the error messages.

Now, instead of passing its `.value`, it will use the values provided by the `ValidationErrors`'s values. The translation parameters could be `any` or an array of `any`. This get pass to the TranslationService to be used for translation.

## Example

```typescript
// My custom validator
function isAllGoodValidator(control: FormControl) {
   if (control.value != "SaulGoodman") {
      return {'some.error.key': [ 'all', 'is', 'man', 'good', 'It']}
   }
   return null;
}

// In en.properties
// some.error.key={4} {1} {0} {3}, {2}!
```

The select above would show the following error message: `It is all good, man!`
   



Signed-off-by: Xuanvinh Vu xvu@vmware.com

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Before this change, the FormSelectComponent translates its validation keys with the selected option's value. Sometime this is not the behavior we want so with this change the user can pass in the translation parameters to be use with the translation key(s). To do this a new method called `translatedErrors()` is introduced in the `BaseFormControl`. When a form input component wants to get the translated error messages all it needs is to call `translatedErrors()`.

We should refactor other form input components to use this new method instead of translating the error messages themselves. https://github.com/vmware/vmware-cloud-director-ui-components/issues/450

## What manual testing did you do?
 Manually tested the "Select form input validation" example.
- Select the empty option from the select input and verify that validation messages are shown. The messages are "Required" and "Only numbers in the range of one to three are allowed".
- Select value from "one" to "three" and verify that there are no validation message shown.
- Select "four" from the select input and verify that validation message "Only numbers in the range of one to three are allowed" is shown.

## Screenshots (if applicable)
Validator that return key/value where the value is an array to be passed to translation service
![image](https://user-images.githubusercontent.com/67131449/197611882-5c9b8038-9007-474e-bbb6-b80250660cf6.png)

Multiple validators
![image](https://user-images.githubusercontent.com/67131449/197611748-091ecc13-5234-40d3-97e5-b0e03c581bfb.png)


## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
