### PR TITLE
Fix vcd-action-menu matching the wrong content-area

### DIFF
--- a/projects/components/src/dropdown/dynamic-dropdown-position.directive.ts
+++ b/projects/components/src/dropdown/dynamic-dropdown-position.directive.ts
@@ -5,7 +5,6 @@
 
 import { DOCUMENT } from '@angular/common';
 import {
-    AfterContentInit,
     ContentChild,
     Directive,
     ElementRef,
@@ -18,7 +17,7 @@ import {
 import { ClrDropdown, ClrDropdownMenu } from '@clr/angular';
 
 const CONTENT_AREA_SELECTOR = '.content-area';
-const NO_SCROLLING_CLASSNAME = 'no-scrolling'; // Set by Clarity when a modal is opened
+export const NO_SCROLLING_CLASSNAME = 'no-scrolling'; // Set by Clarity when a modal is opened
 // Extra space on the right and left of drop down menus to shift them left or right and prevent any clipping
 const MENU_BUFFER_SPACE = 150;
 
@@ -53,8 +52,8 @@ const MENU_BUFFER_SPACE = 150;
 @Directive({
     selector: 'clr-dropdown[vcdDynamicDropdown]',
 })
-export class DynamicDropdownPositionDirective implements AfterContentInit {
-    private contentAreaElement: HTMLElement;
+export class DynamicDropdownPositionDirective {
+    private contentAreaElement: HTMLElement | null;
     private dropdownTriggerElement: HTMLElement;
     private dropdownMenuElement: HTMLElement;
     private dropdownTriggerRect: DOMRect;
@@ -71,6 +70,10 @@ export class DynamicDropdownPositionDirective implements AfterContentInit {
                 // Recalculate the dropdown position on open
                 this.dropdownTriggerRect = this.dropdownTriggerElement.getBoundingClientRect();
                 this.dropdownMenuRect = this.dropdownMenuElement.getBoundingClientRect();
+                this.isInsideModal = this.document.body.classList.contains(NO_SCROLLING_CLASSNAME);
+                this.contentAreaElement = this.isInsideModal
+                    ? null
+                    : (this.document.body.querySelector(CONTENT_AREA_SELECTOR) as HTMLElement);
                 this.resetPosition(this.dropdownMenuElement, this.positionTop, this.positionLeft);
             }
             try {
@@ -90,13 +93,6 @@ export class DynamicDropdownPositionDirective implements AfterContentInit {
         private dropDownBtn: ClrDropdown,
         @Optional() @SkipSelf() private parentDropdown: DynamicDropdownPositionDirective
     ) {}
-
-    ngAfterContentInit(): void {
-        this.isInsideModal = this.document.body.classList.contains(NO_SCROLLING_CLASSNAME);
-        if (!this.isInsideModal) {
-            this.contentAreaElement = this.document.body.querySelector(CONTENT_AREA_SELECTOR) as HTMLElement;
-        }
-    }
 
     private get positionTop(): number {
         const dropdownTriggerRect = this.dropdownTriggerRect;


### PR DESCRIPTION
## Description

BrowserAnimationsModule causes the angular routing to delay removing old DOM elements that were present in previous routes. This leads to cases where we have two `.content-area` elements, and the `DynamicDropdownPositionDirective` matches the one which belonged to the old route and thus later gets destroyed.

This commit makes the `DynamicDropdownPositionDirective` compute the contentAreaElement just before positioning the dropdown menu, ensuring it picks the relevant `.content-area` at the time of its opening.

Signed-off-by: Davi Barreto <dbarreto@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Makes `DynamicDropdownPositionDirective` compute the content area element just before positioning the dropdown menu
## What manual testing did you do?
* Manually verified COR-10789:
  1. Logged in to  VCD tenant portal
  2. Navigated to applications, selected list(grid) view
  3. Navigated to Libraries
  4. Navigated back to applications
  5. Clicked on any `action-menu`
  6. Verified it opens
* Ran github unit tests
* Ran all VCD unit tests 

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
* [Stackblitz demo](https://stackblitz.com/edit/angular-13-template-bzz4kj?file=src%2Fapp%2Fapp.module.ts) showing Angular being slow to remove old DOM elements
* [Angular issue](https://github.com/angular/angular/issues/19742) about the slow DOM removal