### PR TITLE
Use nx instead of ng to deploy to GH Pages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,6 +38,6 @@ jobs:
             - uses: bahmutov/npm-install@v1
             - run: |
                 npx nx build examples --configuration=production --base-href=/vmware-cloud-director-ui-components/
-                npx ng deploy --no-build
+                npx nx deploy --no-build
               env:
                 GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION




## PR Type
-   [ ] Build related changes
-   [ ] CI related changes

## What does this change do?
Fix a problem deploying to https://github.com/vmware/vmware-cloud-director-ui-components/actions/runs/3500816579/jobs/5863877369


Testing Done
============

The error at https://github.com/vmware/vmware-cloud-director-ui-components/actions/runs/3500816579/jobs/5863877369 was reproducible locally.

Running `nx deploy` instead of `ng deploy` fixes the problem.

## Does this PR introduce a breaking change?
-   [x] No


