### PR TITLE
Fix schema validation error when deploying

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,8 +36,10 @@ jobs:
               with:
                   node-version: 16.10.0
             - uses: bahmutov/npm-install@v1
+            # --cname does not need to be passed but we get a schema validation error if we don't pass anything
+            # > Property 'cname' does not match the schema. 'false' should be a 'string'.
             - run: |
                 npx nx build examples --configuration=production --base-href=/vmware-cloud-director-ui-components/
-                npx nx deploy --no-build
+                npx nx deploy examples --no-build --cname=
               env:
                 GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
See error run https://github.com/vmware/vmware-cloud-director-ui-components/actions/runs/3524378013/jobs/5909738240

> nx run examples:deploy --no-build
 >  NX   Property 'cname' does not match the schema. 'false' should be a 'string'.
 >  NX   Running target "examples:deploy" failed

## Testing Done

Ran ` npx nx deploy examples --no-build  --cname=` locally without errors

Signed-off-by: Juan Mendes <mendesjuan@gmail.com>

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [x] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

## What manual testing did you do?

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
