### PR TITLE
Fix NumberWithUnitFormInputComponent not restoring its value after un-toggling "unlimited"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,8 +19,8 @@ jobs:
                   node-version: 16.10.0
             - uses: bahmutov/npm-install@v1
 #            Cannot run in parallel because it tries to run ngcc for each test target.
-            - run: npx nx affected --target=test --base=origin/master --parallel
-            - run: npx nx affected --target=lint --base=origin/master --parallel
+            - run: npx nx affected --target=test --base=origin/master --parallel=1
+            - run: npx nx affected --target=lint --base=origin/master --parallel=1
             - name: Upload coverage to Codecov
               if: success()
               uses: codecov/codecov-action@v1

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* Fixed `number-with-unit-input` not restoring its value on repeated "unlimited" toggling.
 
 ## [13.0.1-dev.3]
 ### Fixed

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.spec.ts
@@ -208,6 +208,28 @@ describe('VcdNumberWithUnitFormInputComponent', () => {
             expect(noUnlimited.isInputFieldDisabled).toBe(false);
             expect(noUnlimited.displayValue).toEqual(ts.translate(Hertz.Mhz.getValueWithUnitTranslationKey(), [-1]));
         }));
+
+        it('restores the previous input when toggling and un-toggling the unlimited checkbox', fakeAsync(() => {
+            const testValue = 123;
+            // input testValue mhz into numberWithUnitInput
+            numberWithUnitInput.typeInput(testValue.toString());
+            expect(numberWithUnitInput.displayValue).toEqual(
+                ts.translate(Hertz.Mhz.getValueWithUnitTranslationKey(), [testValue])
+            );
+            expect(numberWithUnitInput.formControl.value).toEqual(testValue);
+
+            // toggle ON unlimited, assert component value is changed
+            numberWithUnitInput.clickUnlimitedCheckbox();
+            expect(numberWithUnitInput.displayValue).toEqual(ts.translate('vcd.cc.unlimited'));
+            expect(numberWithUnitInput.formControl.value).toEqual(-1);
+
+            // toggle OFF unlimited, assert component value is restored
+            numberWithUnitInput.clickUnlimitedCheckbox();
+            expect(numberWithUnitInput.displayValue).toEqual(
+                ts.translate(Hertz.Mhz.getValueWithUnitTranslationKey(), [testValue])
+            );
+            expect(numberWithUnitInput.formControl.value).toEqual(testValue);
+        }));
     });
 
     describe('unitOptions', () => {

--- a/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
+++ b/projects/components/src/form/number-with-unit-input/number-with-unit-form-input.component.ts
@@ -193,11 +193,11 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
     unitMax: number;
 
     /**
-     * This is the last real value for the input. Used in case when user toggles the unlimited checkbox twice in a row.
+     * This is the last text value for the input. Used in case when user toggles the unlimited checkbox twice in a row.
      * When unlimited is checked the value of the input is cleared, then when toggled again, the input value should be
      * set to the last value.
      */
-    lastRealValue: number = null;
+    private lastTextValue: string = '';
 
     /**
      * Should this functionality be provided at the base class?
@@ -245,7 +245,6 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
 
     onUnlimitedCheckboxChange(unlimitedChecked: boolean): void {
         this.unlimitedControlValue = unlimitedChecked;
-        this.textInputValue = unlimitedChecked ? '' : this.lastRealValue?.toString() || '';
 
         // If there is no unit currently selected, we need to writeValue to recalculate everything.
         if (!this.unitsControlValue && !unlimitedChecked) {
@@ -258,8 +257,10 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
             this.changeDetector.detectChanges();
             this.textInputEl.focus();
             this.textInputEl.select();
+            this.textInputValue = this.lastTextValue;
         } else {
-            this.lastRealValue = this.bestValue;
+            this.lastTextValue = this.textInputValue;
+            this.textInputValue = '';
         }
         this.fireUiChange();
     }
@@ -322,8 +323,8 @@ export class NumberWithUnitFormInputComponent extends BaseFormControl implements
 
         if (!this.isUnlimitedValue(value)) {
             if (this.bestValue) {
-                this.lastRealValue = this.bestValue;
                 this.textInputValue = this.bestValue.toString();
+                this.lastTextValue = this.textInputValue;
             }
             if (this.bestUnit) {
                 this.unitsControlValue = this.bestUnit.getMultiplier().toString();


### PR DESCRIPTION
Fix NumberWithUnitFormInputComponent not restoring its value after un-toggling "unlimited"

NumberWithUnitFormInputComponent has a feature which restores the input value once the "unlimited" checkbox is turned off. However, that feature seems to have regressed in some of the past refactorings. This commit fixes the restore feature and adds a test to prevent future regressions.

A note on replacing `lastRealValue` with `lastTextValue`: older implementations (before a couple refactorings) were calling `.setValue` on a nested `vcd-form-input` and that is why we needed the computed real value. Currently that is no longer the case, and instead, the `getValue` method computes the real value from the text input. Hence replacing `lastRealValue` with `lastTextValue` and restoring it instead.

Signed-off-by: Davi Barreto <dbarreto@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] **Not applicable** - Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Fixes NumberWithUnitFormInputComponent not restoring its value on repeated toggling of "unlimited" checkbox.

## What manual testing did you do?
### Manual testing steps:

1. Start with an empty `number-with-unit-form-input` and "unlimited" toggled off
2. Type a numeric value into the text field
3. Toggle ON the "Unlimited" option
4. Observe the text input is disabled and empty as expected
5. Toggle OFF the "Unlimited" option

Broken behavior (before): the text input is enabled, but remains empty
Fixed behavior (after): the text input is enabled, and has restored its value from step 2

### Additional testing:
* Tested against VCD unit tests.

## Screenshots (if applicable)
Before:

![throwaway](https://user-images.githubusercontent.com/28786474/205952105-b53c6b01-dce9-4485-bd59-af6a18c99a0e.gif)

After:

![throwaway](https://user-images.githubusercontent.com/28786474/205951799-e972ccbf-d376-4a39-a797-b05af3aa9bc2.gif)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
