### PR TITLE
Tab signposts

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Fixed `@vcd/ui-components` compiler path not pointing to `public-api.ts`.
+* Fixed `DataExporterComponent` info icons not being tabbable.
 
 ## [13.0.1-dev.4]
 ### Fixed

--- a/projects/components/src/data-exporter/data-exporter.component.html
+++ b/projects/components/src/data-exporter/data-exporter.component.html
@@ -18,7 +18,6 @@
                         </clr-checkbox-wrapper>
                         <div class="fill-space"></div>
                         <clr-signpost>
-                            <clr-icon clrSignpostTrigger shape="info-circle" size="24"></clr-icon>
                             <clr-signpost-content *clrIfOpen>
                                 <span>{{ friendlyNamesInfoMessage | lazyString }}</span>
                             </clr-signpost-content>
@@ -32,7 +31,6 @@
                         </clr-checkbox-wrapper>
                         <div class="fill-space"></div>
                         <clr-signpost>
-                            <clr-icon clrSignpostTrigger shape="info-circle" size="24"></clr-icon>
                             <clr-signpost-content *clrIfOpen>
                                 <span>{{ sanitizeInfoMessage | lazyString }}</span>
                             </clr-signpost-content>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Users were unable to tab to the info signposts to activate them and view their content. Removing the clr-icon to make the signposts consistent with Clarity examples fixes the tabbing.

## What manual testing did you do?
In VCD from the Virtual Machines page select "EXPORT VMS".
In the data exporter modal hit the tab and cycle
through the components in the modal.
Observe the info icons can be focused using tab and
opened using space.

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
