### PR TITLE
Exposing CsvExporterService

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Exposed CsvExporterService from `@vcd/ui-components`
 
 ## [13.0.1-dev.5]
 ### Fixed

--- a/projects/components/src/data-exporter/index.ts
+++ b/projects/components/src/data-exporter/index.ts
@@ -6,3 +6,4 @@
 export * from './data-exporter.component';
 export * from './data-exporter.module';
 export * from './data-exporter.wo';
+export * from './csv-exporter.service';


### PR DESCRIPTION
This is going to be used to generate reports from vcd_ui

Tested by using `npm pack` and then istalling the tar file locally on vcd_ui and making sure it can be used. See video attached to PR.

Signed-off-by: Juan Mendes <mendesjuan@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Feature

## What does this change do?
Expose CsvExporterService

## What manual testing did you do?
* Built `@vcd/ui-components`
* created an npm package using `npm pack` from the `dist` folder
* Installed the tar file using npm install from vcd_ui's `content/core`
* Used the exporter to generate a CSV.

## Screenshots (if applicable)

https://user-images.githubusercontent.com/549331/211342405-ce9e5011-4b6b-4239-a247-54f6d7868412.mov




## Does this PR introduce a breaking change?
-   [x] No

