### PR TITLE
Fix route-analyzer not handling equal module basenames

### DIFF
--- a/projects/route-analyzer/CHANGELOG.MD
+++ b/projects/route-analyzer/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### [Fixed]
+- Fixed bug that broke the route-analyzer when two routing modules had the same base name
 
 ## [0.0.6]
 ### [Added]


### PR DESCRIPTION
Before this commit, the route-analyzer would search for modules by their basenames (eg. my-module.ts). This could match the wrong module in cases where we had two module files with same file name but in different folders.

This change fixes the issue by matching absolute paths instead of only basenames.

Signed-off-by: Davi Barreto <dbarreto@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix

## What does this change do?
This change makes the route-analyzer correctly handle duplicate file names by using the absolute path.

## What manual testing did you do?
### Test new output is unchanged when there are no duplicate module names
    a. Run the old route-analyzer locally against VCD master
    b. Store the contents of `gen-routes/tenant/app-route.ts` into a separate file
    c. Run the newly changed route-analyzer locally against VCD
    d. Verify the generated `app-route.ts` file from step a. is strictly equal to step c.
### Test the old script breaks when duplicate modules are found
    a. checkout vcd_ui master
    b. cd content/core
    c. Run the following commands to setup a duplicate module with loadChildren:
    d.  ng g m z-module --routing
    e.  ng g m z-module/catalogs --routing --route catalogs --module=z-module
    f. change app.route.tenant.ts line 32, make it point to ZModuleModule
    g.  npm run gen-app-routes
    h. verify an error is thrown
### Test the new script works when duplicate modules are found
    a. Perform steps a. through f. from the previous test case
    b. Place the fixed route-analyzer under the node_modules folder
    c. npm run gen-app-routes
    d. verify no error is thrown

    
## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
