### PR TITLE
Fix incorrect aria-label on remove quick search filter buttons

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed `QuickSearchComponent` filter button aria-label.
+
 ## [13.0.1-dev.6]
 
 ### Added

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -25,6 +25,7 @@ vcd.cc.exporter.downloading=Downloading...
 vcd.cc.exporter.writing=Writing File...
 vcd.cc.quickSearch.partialResultTitle={title} ({lastItem} of {totalItems})
 vcd.cc.quickSearch.refineQuery=The search shows a maximum of {max} results. Refine your query to improve the accuracy.
+vcd.cc.quickSearch.removeFilter=Stop filtering by {selectedFilter}
 vcd.cc.quickSearch.noResults=No results found.
 
 vcd.cc.units.bytes.B=B

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -72,7 +72,11 @@
                 <button
                     type="button"
                     class="btn btn-icon btn-link remove-col-button"
-                    aria-label="home"
+                    [attr.aria-label]="
+                        'vcd.cc.quickSearch.removeFilter'
+                            | translate
+                                : { selectedFilter: filter.bubbleI18nKey | translate: { option: option.display } }
+                    "
                     (click)="searchService.selectFilter(filter.id, [option.key], false)"
                 >
                     <clr-icon shape="close" class="badge badge-info"> </clr-icon>


### PR DESCRIPTION
The aria-label property was wrongly hard coded as "home". Replaced it with a dynamic string which reflects the filter's label.

## PR Checklist

Please check if your PR fulfills the following requirements:
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix

## What does this change do?
Adds the correct aria-label to the quick search filter remove buttons

## What manual testing did you do?
1. `npx nx serve examples`
2. Navigate to http://localhost:4200/quickSearch/example/filters
3. Click "Here" to open the quick search
4. Add a filter
5. Turn screen reader on and navigate to the delete filter button "x"
6. Verify the screen reader states `Stop filtering by "<name of filter>"`

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/28786474/220677301-3c76ef96-b805-4424-8dfc-cdf26601e45c.png)


## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No
