### PR TITLE
Fix route-analyzer not finding modules on windows machines

### DIFF
--- a/projects/route-analyzer/CHANGELOG.MD
+++ b/projects/route-analyzer/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed a regression where the route-analyzer was unnable to find routes on windows machines
 
 ## [0.0.9]
 ### [Fixed]

--- a/projects/route-analyzer/src/lib/route-analyzer.ts
+++ b/projects/route-analyzer/src/lib/route-analyzer.ts
@@ -315,7 +315,13 @@ function fixupLoadChildren(
             ? path.join(moduleFolderPath, loadChildrenImportPath)
             : path.join(programDirectory, moduleFolderPath, loadChildrenImportPath);
 
+        /**
+         * This conversion to posix is necessary since this script is using posix paths everywhere else.
+         * Not converting here would break for windows users, because the above `path.join` will have generated windows paths.
+         */
+        const absolutePathAsPosix = absolutePath.split(path.sep).join(path.posix.sep);
+
         // Must append the file extension, as the TS imports never include it
-        return `${absolutePath}.ts`;
+        return `${absolutePathAsPosix}.ts`;
     }
 }


### PR DESCRIPTION
A previous commit introduced a regression where the route analyzer was unable to find modules on windows machines. The issue was that the new strings generated by nodejs were windows like, but the remaining script logic uses posix.

Fixed by ensuring we always convert to posix after joining the absolute paths.

## PR Checklist

Please check if your PR fulfills the following requirements:
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix

## What does this change do?
Fixes the route analyzer for windows users

## What manual testing did you do?
1. On a windows machine
2. Place the fixed route-analyzer on VCD UI
3. Run the route-analyzer
4. Verify no errors are thrown

## Does this PR introduce a breaking change?

-   [x] No
