### PR TITLE
Fix accessibility issues related to quick-search component

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed accessibility of filters inside the quick-search component
 * Fixed inaccessibility of quick-search results by a screen reader  
+* Added a name property for quick-search dialog so that a screen reader can announce a proper dialog name
 
 ## [13.0.1-dev.6]
 

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* Fixed accessibility of filters inside the quick-search component
 
 ## [13.0.1-dev.6]
 

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Fixed accessibility of filters inside the quick-search component
+* Fixed inaccessibility of quick-search results by a screen reader  
 
 ## [13.0.1-dev.6]
 

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed accessibility of filters inside the quick-search component
 * Fixed inaccessibility of quick-search results by a screen reader  
 * Added a name property for quick-search dialog so that a screen reader can announce a proper dialog name
+* Fixed accessibility of the pin button inside the quick-search component
 
 ## [13.0.1-dev.6]
 

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed inaccessibility of quick-search results by a screen reader  
 * Added a name property for quick-search dialog so that a screen reader can announce a proper dialog name
 * Fixed accessibility of the pin button inside the quick-search component
+* Removed empty space above search input inside the quick-search component
 
 ## [13.0.1-dev.6]
 

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -116,3 +116,4 @@ vcd.cc.rights=Rights
 
 # Quick search
 vcd.cc.search.filterBy=Filter By
+vcd.cc.search.filterBy.btn.label=Filter By {0}

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -117,3 +117,4 @@ vcd.cc.rights=Rights
 # Quick search
 vcd.cc.search.filterBy=Filter By
 vcd.cc.search.filterBy.btn.label=Filter By {0}
+vcd.cc.search.pin.btn.label=Pin {0}

--- a/projects/components/src/components.module.ts
+++ b/projects/components/src/components.module.ts
@@ -17,6 +17,7 @@ import { ResponsiveInputDirectiveModule } from './lib/directives/responsive-inpu
 import { ShowClippedTextDirectiveModule } from './lib/directives/show-clipped-text.directive.module';
 import { QuickSearchModule } from './quick-search/quick-search.module';
 import { VcdSharingModalModule } from './sharing-modal/sharing-modal.module';
+import { AriaActivedescendantModule } from './lib/directives';
 
 @NgModule({
     exports: [
@@ -33,6 +34,7 @@ import { VcdSharingModalModule } from './sharing-modal/sharing-modal.module';
         ResponsiveInputDirectiveModule,
         AlternativeTextModule,
         VcdSharingModalModule,
+        AriaActivedescendantModule,
     ],
 })
 export class VcdComponentsModule {}

--- a/projects/components/src/lib/directives/aria-activedescendant/aria-active-descendant.directive.ts
+++ b/projects/components/src/lib/directives/aria-activedescendant/aria-active-descendant.directive.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { Directive, ElementRef, Input, OnInit, Renderer2 } from '@angular/core';
+import { IdGenerator } from '../../../utils';
+import { AriaActiveDescendantService } from './aria-active-descendant.service';
+
+/**
+ * Sets a unique id attribute and marks the element as active descendant with {@link AriaActiveDescendantService}
+ */
+@Directive({
+    selector: '[vcdAriaActiveDescendant]',
+})
+export class AriaActiveDescendantDirective implements OnInit {
+    private readonly uniqueId: string = this.idGenerator.generate();
+
+    @Input('vcdAriaActiveDescendant')
+    public set isActive(value: boolean) {
+        if (value) {
+            this.activedescendantService.selectDescendant(this.uniqueId);
+        }
+    }
+
+    constructor(
+        private elementRef: ElementRef,
+        private renderer: Renderer2,
+        private activedescendantService: AriaActiveDescendantService,
+        private idGenerator: IdGenerator
+    ) {}
+
+    ngOnInit() {
+        this.renderer.setAttribute(this.elementRef.nativeElement, 'id', this.uniqueId);
+    }
+}

--- a/projects/components/src/lib/directives/aria-activedescendant/aria-active-descendant.service.ts
+++ b/projects/components/src/lib/directives/aria-activedescendant/aria-active-descendant.service.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+
+/**
+ * Communication service between {@link AriaActiveDescendantDirective} and observer of activeDescendantObservable
+ */
+@Injectable()
+export class AriaActiveDescendantService {
+    private activeDescendantSubject: Subject<string> = new BehaviorSubject<string>('');
+
+    /**
+     * Observed by element which owns the section with possible active descendants
+     */
+    public activeDescendantObservable: Observable<string> = this.activeDescendantSubject.asObservable();
+
+    /**
+     * Marks element as active descendant
+     * @param id attribute of active descendant element
+     */
+    public selectDescendant(id: string): void {
+        this.activeDescendantSubject.next(id);
+    }
+}

--- a/projects/components/src/lib/directives/aria-activedescendant/aria-activedescendant.module.ts
+++ b/projects/components/src/lib/directives/aria-activedescendant/aria-activedescendant.module.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { NgModule } from '@angular/core';
+import { AriaActiveDescendantDirective } from './aria-active-descendant.directive';
+
+@NgModule({
+    declarations: [AriaActiveDescendantDirective],
+    exports: [AriaActiveDescendantDirective],
+})
+export class AriaActivedescendantModule {}

--- a/projects/components/src/lib/directives/aria-activedescendant/index.ts
+++ b/projects/components/src/lib/directives/aria-activedescendant/index.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+export * from './aria-active-descendant.directive';
+export * from './aria-active-descendant.service';
+export * from './aria-activedescendant.module';

--- a/projects/components/src/lib/directives/index.ts
+++ b/projects/components/src/lib/directives/index.ts
@@ -9,3 +9,4 @@ export * from './responsive-input/responsive-input.directive';
 export * from './responsive-input/responsive-input.module';
 export * from './show-clipped-text.directive';
 export * from './show-clipped-text.directive.module';
+export * from './aria-activedescendant';

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -84,16 +84,20 @@
 </ng-template>
 
 <ng-template let-searchSection #searchSectionTemplate>
-    <ul class="list-unstyled compact">
+    <ul class="list-unstyled compact" role="none">
         <li
             class="search-result-item"
-            role="button"
-            *ngFor="let item of searchSection.result?.items"
+            role="row"
+            *ngFor="let item of searchSection.result?.items; let i = index"
             (click)="itemClicked(item)"
             [ngClass]="item === selectedItem ? 'selected' : ''"
             [attr.data-ui]="DataUi.searchResultItems"
         >
-            {{ item.displayText }}
+            <span role="gridcell">
+                <button [vcdAriaActiveDescendant]="item === selectedItem">
+                    {{ item.displayText }}
+                </button>
+            </span>
         </li>
         <li>
             <clr-alert
@@ -123,11 +127,15 @@
         </div>
         <input
             #searchInput
-            type="text"
+            type="search"
+            role="searchbox"
             class="clr-input"
             [placeholder]="placeholder || ''"
             [(ngModel)]="searchCriteria"
             [attr.data-ui]="DataUi.searchInput"
+            [attr.aria-owns]="resultsGridId"
+            [attr.aria-controls]="resultsGridId"
+            [attr.aria-activedescendant]="activeDescendantId"
         />
         <button class="btn btn-link pin-button" (click)="togglePinned()">
             <clr-icon shape="pin" size="20" [ngClass]="this.searchService.isPinned ? 'is-solid' : ''"> </clr-icon>
@@ -136,24 +144,29 @@
     <clr-control-helper class="input-helper">{{ helper }}</clr-control-helper>
     <ng-container *ngTemplateOutlet="filtersSection"> </ng-container>
     <ng-content select=".top-of-results"></ng-content>
-    <div class="search-result-container">
-        <section
+    <div class="search-result-container" role="grid" [attr.id]="resultsGridId" *ngIf="searchInput.value !== ''">
+        <div
             class="no-results"
+            role="row"
             [attr.data-ui]="DataUi.noResults"
             *ngIf="searchService.hasNoResults && !searchService.isLoading"
         >
-            {{ 'vcd.cc.quickSearch.noResults' | translate }}
-        </section>
-        <section
+            <span role="gridcell" [vcdAriaActiveDescendant]="searchService.hasNoResults && !searchService.isLoading">
+                {{ 'vcd.cc.quickSearch.noResults' | translate }}
+            </span>
+        </div>
+        <div
             *ngFor="let searchSection of _ungroupedSearchSections; let i = index; trackBy: sectionTrackBy"
             class="search-result-section section-index-0-{{ i + 1 }}"
             data-ui="search-result-section"
         >
-            <div *ngIf="!searchSection.isLoading">
+            <div *ngIf="!searchSection.isLoading" role="rowgroup" [attr.aria-labelledby]="'ungrouped-search-' + i">
                 <h5
                     *ngIf="searchSection.shouldShowText"
                     class="search-result-section-title"
+                    role="presentation"
                     [attr.data-ui]="DataUi.searchResultSectionTitles"
+                    [attr.id]="'ungrouped-search-' + i"
                 >
                     <ng-container *ngTemplateOutlet="sectionTitle; context: { $implicit: searchSection }">
                     </ng-container>
@@ -161,24 +174,30 @@
                 <ng-container *ngTemplateOutlet="searchSectionTemplate; context: { $implicit: searchSection }">
                 </ng-container>
             </div>
-        </section>
+        </div>
         <div *ngFor="let parentSearchSection of _groupedSearchSections; let n = index; trackBy: groupSectionTrackBy">
             <h5
                 *ngIf="showParentSectionTitle(parentSearchSection)"
                 class="search-result-section-title"
                 [attr.data-ui]="DataUi.searchResultSectionTitles"
+                [attr.id]="'grouped-search-result-' + n"
+                role="presentation"
             >
                 {{ parentSearchSection.headerTitle }}
             </h5>
-            <section
+            <div
                 *ngFor="let searchSection of parentSearchSection.subSections; let i = index; trackBy: sectionTrackBy"
                 class="sub-section"
+                role="rowgroup"
+                [attr.aria-labelledby]="'grouped-search-result-' + n + ' ' + 'grouped-search-result-section' + i"
             >
                 <div *ngIf="!searchSection.isLoading">
                     <p
                         *ngIf="searchSection.shouldShowText"
+                        role="presentation"
                         class="p2 search-result-section-title search-result-section section-index-{{ n }}-{{ i }}"
                         [attr.data-ui]="DataUi.searchResultSectionTitles"
+                        [attr.id]="'grouped-search-result-section' + i"
                     >
                         <ng-container *ngTemplateOutlet="sectionTitle; context: { $implicit: searchSection }">
                         </ng-container>
@@ -186,7 +205,7 @@
                     <ng-container *ngTemplateOutlet="searchSectionTemplate; context: { $implicit: searchSection }">
                     </ng-container>
                 </div>
-            </section>
+            </div>
         </div>
     </div>
     <ng-content select=".bottom-of-results"></ng-content>

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -137,7 +137,12 @@
             [attr.aria-controls]="resultsGridId"
             [attr.aria-activedescendant]="activeDescendantId"
         />
-        <button class="btn btn-link pin-button" (click)="togglePinned()">
+        <button
+            class="btn btn-link pin-button"
+            [attr.aria-label]="'vcd.cc.search.pin.btn.label' | translate: accessibilityTitle"
+            [attr.aria-pressed]="searchService.isPinned"
+            (click)="togglePinned()"
+        >
             <clr-icon shape="pin" size="20" [ngClass]="this.searchService.isPinned ? 'is-solid' : ''"> </clr-icon>
         </button>
     </div>

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -230,6 +230,7 @@
     (keydown.enter)="onEnterKey($event)"
     *ngIf="!searchService.isPinned; else drawerComponent"
 >
+    <h1 class="modal-title">{{ accessibilityTitle }}</h1>
     <div class="modal-body" [attr.data-ui]="DataUi.modalBody">
         <ng-container *ngTemplateOutlet="quickSearchInterior"> </ng-container>
     </div>

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -34,6 +34,7 @@
                     type="button"
                     clrDropdownTrigger
                     [attr.data-ui]="DataUi.filterButton(filter.id)"
+                    [attr.aria-label]="'vcd.cc.search.filterBy.btn.label' | translate: filter.dropdownText"
                 >
                     {{ filter.dropdownText }}
                     <clr-icon shape="caret down"></clr-icon>

--- a/projects/components/src/quick-search/quick-search.component.scss
+++ b/projects/components/src/quick-search/quick-search.component.scss
@@ -19,7 +19,7 @@
     height: 500px;
 
     .search-input-container {
-        margin-top: 30px;
+        margin-top: 0.25rem;
         display: flex;
 
         .search-icon-container {

--- a/projects/components/src/quick-search/quick-search.component.scss
+++ b/projects/components/src/quick-search/quick-search.component.scss
@@ -56,6 +56,12 @@
             &:hover {
                 background-color: var(--clr-tree-link-hover-color);
             }
+
+            // These buttons are placed for semantic reasons
+            button {
+                background: none;
+                border: none;
+            }
         }
     }
 }

--- a/projects/components/src/quick-search/quick-search.component.ts
+++ b/projects/components/src/quick-search/quick-search.component.ts
@@ -116,6 +116,12 @@ export class QuickSearchComponent implements OnInit {
     }
 
     /**
+     * Visually hidden title adds dialog label for screen readers.
+     */
+    @Input()
+    public accessibilityTitle: string;
+
+    /**
      * This method along with `open` property provide two-way binding [(open)] for controlling the visibility state
      * of the quick search component
      */

--- a/projects/components/src/quick-search/quick-search.module.ts
+++ b/projects/components/src/quick-search/quick-search.module.ts
@@ -9,6 +9,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ClarityModule } from '@clr/angular';
 import { I18nModule } from '@vcd/i18n';
 import { ShowClippedTextDirectiveModule } from '../lib/directives/show-clipped-text.directive.module';
+import { AriaActivedescendantModule } from '../lib/directives';
 import { DrawerComponent } from './drawer/drawer.component';
 import { QuickSearchComponent } from './quick-search.component';
 
@@ -20,6 +21,7 @@ import { QuickSearchComponent } from './quick-search.component';
         ReactiveFormsModule,
         I18nModule,
         ShowClippedTextDirectiveModule,
+        AriaActivedescendantModule,
     ],
     declarations: [QuickSearchComponent, DrawerComponent],
     exports: [QuickSearchComponent],

--- a/projects/examples/src/components/quick-search/quick-search-content-projection.example.component.html
+++ b/projects/examples/src/components/quick-search/quick-search-content-projection.example.component.html
@@ -23,7 +23,7 @@
     </vcd-form-checkbox>
 </form>
 
-<vcd-quick-search [(open)]="spotlightOpen" [placeholder]="'Search...'">
+<vcd-quick-search accessibilityTitle="Quick Search" [(open)]="spotlightOpen" [placeholder]="'Search...'">
     <div class="top-of-results info" *ngIf="formGroup.controls['topSection'].value">Top of results</div>
     <div class="bottom-of-results info" *ngIf="formGroup.controls['bottomSection'].value">Bottom of results</div>
 </vcd-quick-search>

--- a/projects/examples/src/components/quick-search/quick-search-hide-empty-section-example.component.html
+++ b/projects/examples/src/components/quick-search/quick-search-hide-empty-section-example.component.html
@@ -13,4 +13,8 @@ Press <kbd>Command</kbd>+<kbd>f</kbd> on MacOS / <kbd>Ctrl</kbd>+<kbd>f</kbd> on
     </vcd-form-checkbox>
 </form>
 
-<vcd-quick-search [(open)]="spotlightOpen" [placeholder]="formGroup.value.placeholder"> </vcd-quick-search>
+<vcd-quick-search
+    accessibilityTitle="Quick Search"
+    [(open)]="spotlightOpen"
+    [placeholder]="formGroup.value.placeholder"
+></vcd-quick-search>

--- a/projects/examples/src/components/quick-search/quick-search-sync-async.example.component.html
+++ b/projects/examples/src/components/quick-search/quick-search-sync-async.example.component.html
@@ -18,4 +18,8 @@ Press <kbd>Command</kbd>+<kbd>f</kbd> on MacOS / <kbd>Ctrl</kbd>+<kbd>f</kbd> on
     </vcd-form-input>
 </form>
 
-<vcd-quick-search [(open)]="spotlightOpen" [placeholder]="formGroup.value.placeholder"> </vcd-quick-search>
+<vcd-quick-search
+    accessibilityTitle="Quick Search"
+    [(open)]="spotlightOpen"
+    [placeholder]="formGroup.value.placeholder"
+></vcd-quick-search>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [x] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Fixes quick-search component accessibility issues:

1. Missing dialog name
2. Missing filters 'labeled by' attribute
3. Results section inaccessibility by screen reader
4. Missing label of pin button

And removes an empty space above the search input inside the component.

## What manual testing did you do?

Prepare: 
1. `npx nx serve examples`
2. Turn on your screen reader

Test issues 1, 3, 4:

- Navigate to http://localhost:4200/quickSearch/example/async-sync-sections
- Open a quick-search modal
 
Expected:

- Screen reader to announce the dialog name
- Screen reader to announce the search results on arrow keys iteration
- Screen reader to announce "Pin <dialog-name>" when the pin button is in focus

Test issue 2:
- Navigate to http://localhost:4200/quickSearch/example/filters
- Open a quick-search modal 

Expected: 
- Screen reader to announce "Filter by <filter-name>" label when combo box filter is in focus

Test issue 3 with nested results: 
- Navigate to http://localhost:4200/quickSearch/example/nested
- Open a quick-search modal 

Expected:

- Screen reader to announce the search results and sub-category names on arrow keys iteration

## Screenshots

### The dialog name is announced on the quick-search component open:

![image](https://user-images.githubusercontent.com/49042716/221582647-82943d77-b3e8-4e99-b1d2-7746a496ba95.png)

### The selected search result is announced

![image](https://user-images.githubusercontent.com/49042716/221583531-930e395a-01c9-4cff-b023-09002309bbfc.png)

![Screenshot 2023-02-27 at 16 21 59](https://user-images.githubusercontent.com/49042716/221588745-942edd85-98a0-4064-85c9-749f4f323905.png)

### Pin button label and state are announced
﻿
![Screenshot 2023-02-27 at 16 15 38](https://user-images.githubusercontent.com/49042716/221586978-a17077fa-6e32-44e8-9319-00e5ecf10dc6.png)

### Filter label and name are announced

![image](https://user-images.githubusercontent.com/49042716/221589137-e5f34cd0-f333-4c1e-8547-3c3486faedf6.png)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
