### PR TITLE
[a11y] Add aria-describedby attribute to the Form Select component

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* Added ARIA support for vcd-form-select so that screen readers can read the description text if added
 
 ## [13.0.1-dev.6]
 

--- a/projects/components/src/form/form-select/form-select.component.html
+++ b/projects/components/src/form/form-select/form-select.component.html
@@ -16,7 +16,7 @@
                     class="clr-select"
                     [id]="id"
                     [attr.aria-required]="showAsterisk"
-                    [attr.aria-describedby]="showErrors ? errorsId : ''"
+                    [attr.aria-describedby]="showErrors ? errorsId : descriptionId"
                     [formControl]="formControl"
                 >
                     <option *ngFor="let option of options" [value]="option.value" [disabled]="option.disabled">

--- a/projects/components/src/form/form-select/form-select.component.spec.ts
+++ b/projects/components/src/form/form-select/form-select.component.spec.ts
@@ -17,6 +17,10 @@ export class VcdFormSelectWidgetObject extends WidgetObject<FormSelectComponent>
         return this.findElement('select').nativeElement;
     }
 
+    private get subtextElement(): HTMLElement {
+        return this.findElement('.clr-subtext').nativeElement;
+    }
+
     /**
      * Returns the 'shape' attribute if defined, returns empty string if undefined
      */
@@ -37,6 +41,14 @@ export class VcdFormSelectWidgetObject extends WidgetObject<FormSelectComponent>
         this.selectElement.selectedIndex = index;
         this.selectElement.dispatchEvent(new Event('change'));
         this.detectChanges();
+    }
+
+    getInputAttributeValue(attribute: string): string {
+        return this.selectElement.getAttribute(attribute);
+    }
+
+    getSubtextAttributeValue(attribute: string): string {
+        return this.subtextElement.getAttribute(attribute);
     }
 }
 
@@ -128,7 +140,7 @@ describe('FormSelectComponent', () => {
 
         it(
             'validator can return key/value where the value is NOT an array,' +
-                ' in which case an array of control\'s value is passed to the translation service',
+            ' in which case an array of control\'s value is passed to the translation service',
             () => {
                 const selectNumberWo = finder.find({
                     woConstructor: VcdFormSelectWidgetObject,
@@ -140,6 +152,23 @@ describe('FormSelectComponent', () => {
             }
         );
     });
+
+    describe('ARIA', () => {
+        it('has "aria-describedby" attribute value set to "errorsId" when "showErrors" is "true"', () => {
+            selectInput.select(0); // Selecting first empty value option to trigger the required validator.
+            expect(selectInput.getSubtextAttributeValue('id')).toBe(selectInput.component.errorsId);
+            expect(selectInput.getInputAttributeValue('aria-describedby')).toBe(selectInput.component.errorsId);
+        });
+
+        it('has "aria-describedby" attribute value set to "descriptionId" when "showErrors" is "false"', () => {
+            expect(selectInput.getSubtextAttributeValue('id')).toBe(
+                selectInput.component.descriptionId
+            );
+            expect(selectInput.getInputAttributeValue('aria-describedby')).toBe(
+                selectInput.component.descriptionId
+            );
+        });
+    });
 });
 
 @Component({
@@ -150,6 +179,7 @@ describe('FormSelectComponent', () => {
                 [options]="options"
                 [formControlName]="'selectInput'"
                 class="select-input"
+                [description]="'Help Text'"
             >
             </vcd-form-select>
             <vcd-form-select [options]="numberOptions" [formControlName]="'selectNumber'" class="select-number-input">


### PR DESCRIPTION
  ## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Use aria-describedby  attribute for description in the vcd-form-select input subtext when showError is false.

## What manual testing did you do?

1. npx nx serve
2. Turn on your screen reader
3. Navigate to http://localhost:4200/formSelect/example/form-select
4. Focus Select Input 

Expected:

Screen reader to announce the input description "Select Input description."

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
