### PR TITLE
Reverting package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "zone.js": "~0.11.4"
       },
       "devDependencies": {
-        "@actions/core": "1.9.1",
+        "@actions/core": "1.2.6",
         "@actions/github": "2.1.1",
         "@angular-devkit/build-angular": "13.3.9",
         "@angular-eslint/builder": "13.5.0",
@@ -98,7 +98,6 @@
         "karma-coverage-istanbul-reporter": "3.0.3",
         "karma-jasmine": "~4.0.0",
         "karma-jasmine-html-reporter": "^1.5.0",
-        "macos-release": "3.1.0",
         "mkdirp": "^1.0.4",
         "ng-packagr": "13.3.1",
         "nx": "15.0.4",
@@ -113,23 +112,10 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
-      "dev": true,
-      "dependencies": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@actions/core/node_modules/@actions/http-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.0.tgz",
-      "integrity": "sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==",
-      "dev": true,
-      "dependencies": {
-        "tunnel": "^0.0.6"
-      }
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==",
+      "dev": true
     },
     "node_modules/@actions/github": {
       "version": "2.1.1",
@@ -23654,12 +23640,11 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "node_modules/macos-release": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.1.0.tgz",
-      "integrity": "sha512-/M/R0gCDgM+Cv1IuBG1XGdfTFnMEG6PZeT+KGWHO/OG+imqmaD9CH5vHBTycEM3+Kc4uG2Il+tFAuUWLqQOeUA==",
-      "dev": true,
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
+      "integrity": "sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -25793,17 +25778,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/os-name/node_modules/macos-release": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz",
-      "integrity": "sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A==",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/os-tmpdir": {
@@ -33737,9 +33711,9 @@
       },
       "dependencies": {
         "@actions/http-client": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.0.tgz",
-          "integrity": "sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+          "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
           "dev": true,
           "requires": {
             "tunnel": "^0.0.6"
@@ -51302,10 +51276,9 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "macos-release": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.1.0.tgz",
-      "integrity": "sha512-/M/R0gCDgM+Cv1IuBG1XGdfTFnMEG6PZeT+KGWHO/OG+imqmaD9CH5vHBTycEM3+Kc4uG2Il+tFAuUWLqQOeUA==",
-      "dev": true
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
+      "integrity": "sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g=="
     },
     "magic-string": {
       "version": "0.25.7",
@@ -52950,13 +52923,6 @@
       "requires": {
         "macos-release": "^2.2.0",
         "windows-release": "^3.1.0"
-      },
-      "dependencies": {
-        "macos-release": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz",
-          "integrity": "sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A=="
-        }
       }
     },
     "os-tmpdir": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.5.0",
-    "macos-release": "3.1.0",
     "mkdirp": "^1.0.4",
     "ng-packagr": "13.3.1",
     "nx": "15.0.4",

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Implemented forward compatibility with RxJS 7.
+### Fixed
+* Reverted package.json and package-lock.json
 
 ## [13.0.1-dev.7]
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Build related changes

## What does this change do?
There's an issue publishing the tarball presumably because of a dependency. This change reverts package.json and package-lock.json to its 13.0.1-dev.7 contents. There was a transitive dependency `macos-release` that _seemed_ to be out of date when I tried building on my macOS Ventura machine (13.1) so I added an explicit `devDependency` to its latest version via npm install. It's possible it or any other dependency that was upgraded is causing the issue. 

## Does this PR introduce a breaking change?

-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
