### PR TITLE
Add a number of results for screen readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ for further details.
 
 ## Peer Dependencies
 
-The component library depends on [Clarity](https://clarity.design/) and [Angular](https://angular.io/)
-which must be installed from your application's `package.json`. See [package.json](package.json) for version
-information.
+The component library depends on [Clarity](https://clarity.design/), [Clarity Core](https://core.clarity.design) and 
+[Angular](https://angular.io/) which must be installed from your application's `package.json`. 
+See [package.json](package.json) for version information.
 
 ## Code scaffolding
 

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Updated documentation to require the Clarity Core library and styles.
+* Updated remove filter string to be consistent with other VMware products.
+
+### Fixed
+* Added a number of quick-search results for screen readers
+
 ## [15.0.1-dev.5]
 
 ### Fixed

--- a/projects/components/README.md
+++ b/projects/components/README.md
@@ -9,6 +9,11 @@ translations for the strings in our components. This file is intended for usage 
 `npm install @vcd/ui-components` for the latest stable release or
 `npm install @vcd/ui-components@next` for the upcoming release, which could contain APIs that may not be stable
 
+## Dependencies
+The UI components library depends on [Clarity Angular](https://clarity.design) and [Clarity Core](https://core.clarity.design) libraries and styles.
+- [Install the Clarity Core guide](https://core.clarity.design/get-started/developing/)
+- [Install the Clarity Angular guide](https://clarity.design/documentation/get-started)
+
 
 ## Examples site
 Visit [our live examples site](https://vmware.github.io/vmware-cloud-director-ui-components/) for live examples, with source code, that you run on stackblitz. Powered by [Live Docs](https://github.com/vmware/live-docs)

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -25,7 +25,7 @@ vcd.cc.exporter.downloading=Downloading...
 vcd.cc.exporter.writing=Writing File...
 vcd.cc.quickSearch.partialResultTitle={title} ({lastItem} of {totalItems})
 vcd.cc.quickSearch.refineQuery=The search shows a maximum of {max} results. Refine your query to improve the accuracy.
-vcd.cc.quickSearch.removeFilter=Stop filtering by {selectedFilter}
+vcd.cc.quickSearch.removeFilter=Clear Filter {selectedFilter}
 vcd.cc.quickSearch.noResults=No results found.
 
 vcd.cc.units.bytes.B=B

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -119,3 +119,4 @@ vcd.cc.rights=Rights
 vcd.cc.search.filterBy=Filter By
 vcd.cc.search.filterBy.btn.label=Filter By {0}
 vcd.cc.search.pin.btn.label=Pin {0}
+vcd.cc.search.results.amount={0} results

--- a/projects/components/src/quick-search/quick-search.component.html
+++ b/projects/components/src/quick-search/quick-search.component.html
@@ -160,7 +160,7 @@
             [attr.data-ui]="DataUi.noResults"
             *ngIf="searchService.hasNoResults && !searchService.isLoading"
         >
-            <span role="gridcell" [vcdAriaActiveDescendant]="searchService.hasNoResults && !searchService.isLoading">
+            <span role="gridcell">
                 {{ 'vcd.cc.quickSearch.noResults' | translate }}
             </span>
         </div>
@@ -218,6 +218,16 @@
         </div>
     </div>
     <ng-content select=".bottom-of-results"></ng-content>
+    <div aria-live="polite" cds-layout="display:screen-reader-only">
+        <ng-container *ngIf="!searchService.isLoading">
+            <ng-container *ngIf="searchService.resultsCount > 0; else noResultsAmount">
+                {{ 'vcd.cc.search.results.amount' | translate: searchService.resultsCount }}
+            </ng-container>
+            <ng-template #noResultsAmount>
+                {{ 'vcd.cc.quickSearch.noResults' | translate }}
+            </ng-template>
+        </ng-container>
+    </div>
 </ng-template>
 
 <ng-template #drawerComponent>

--- a/projects/components/src/quick-search/quick-search.service.ts
+++ b/projects/components/src/quick-search/quick-search.service.ts
@@ -174,6 +174,11 @@ export class QuickSearchService {
     public hasNoResults: boolean = false;
 
     /**
+     * The total number of results of a last search
+     */
+    public resultsCount: number = 0;
+
+    /**
      * Register a search provider
      * @param provider The search provider {@link QuickSearchProvider}
      */
@@ -322,6 +327,7 @@ export class QuickSearchService {
         this.lastActiveFilters = activeFilters;
         this.lastSearchCriteria = searchCriteria;
         this.updateActiveSections(activeFilters);
+        this.resultsCount = 0;
 
         // Remember which is the current search. This will help us not to show results from an old search
         const searchId = ++this.searchId;
@@ -362,6 +368,8 @@ export class QuickSearchService {
                 // search function. However, we don't currently see any problem with that because the following code just re assigns variables
                 // with same values
                 searchSection.result = searchResult;
+                this.resultsCount += searchResult?.items?.length || 0;
+
                 searchSection.hasPartialResult = this.hasPartialResult(searchSection);
                 searchSection.isLoading = false;
                 this.hasNoResults = this.checkHasNoResults();

--- a/projects/examples/src/styles.scss
+++ b/projects/examples/src/styles.scss
@@ -1,3 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
 // TODO: Provide the users with option to select the prismjs CSS based on the theme they want
 @import '../../../node_modules/prismjs/themes/prism';
+@import '~@cds/core/global.min.css';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix

## What does this change do?

It is expected screen reader reads the search results amount when it is changed or the search is performed.

The change will add a new visually hidden (but not for screen readers) live aria with aria-live=polite attribute to make screen readers announce any change related to the results amount. Aria-live indicates that element will be updated and the politeness of the updates.

The accessibility team reached out to us with the issue that the old string isn't consistent with similar strings in other VMware products. The string is changed according to a discussion with an accessibility team member.

## What manual testing did you do?

Testing Done:
- Open /quickSearch/example/nested
- Open the quick-search modal
- Turn on your's screen reader
- Perform the search 
Expected screen reader to announce the results number.

- Open /quickSearch/example/filters
- Open the quick-search modal
- Turn on your's screen reader
- Select some filter
- Navigate to the "Clear Filter" button
Expected screen reader to announce "Clear Filter <filter-info>", where <filter-info> is the content of the label.

## Screenshots (if applicable)

<img width="895" alt="image" src="https://user-images.githubusercontent.com/49042716/225074810-3c077418-bde4-4572-8b53-c1d2f19116a7.png">

<img width="956" alt="image" src="https://user-images.githubusercontent.com/49042716/225075057-55820df5-e7c8-4494-a2a5-f37ea1dd6b1b.png">


![image](https://user-images.githubusercontent.com/49042716/226373724-05217f5e-6b2c-404f-af70-f9d16098b451.png)

## Does this PR introduce a breaking change?

-   [x] No
