### PR TITLE
[VACE-4391] Extensibility framework cause the actions menu to be redrawn numerous times causing tens/hundreds API calls to external systems

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Added ARIA support for vcd-form-select so that screen readers can read the description text if added
+* Dropdown position was re-computed incorrectly when the dropdown is re-drawn multiple times.
 
 ## [13.0.1-dev.8]
 

--- a/projects/components/src/dropdown/dynamic-dropdown-position.directive.ts
+++ b/projects/components/src/dropdown/dynamic-dropdown-position.directive.ts
@@ -109,7 +109,16 @@ export class DynamicDropdownPositionDirective {
         }
         const contentAreaRect = this.contentAreaElement.getBoundingClientRect();
         // When not in a modal, the position is relative to the `.content-area` element
-        if (dropdownMenuRect.bottom <= contentAreaRect.bottom) {
+
+        const enoughSpaceAtTheBottom = dropdownMenuRect.height <= contentAreaRect.bottom - dropdownTriggerRect.bottom;
+        const enoughSpaceAtTheTop = dropdownMenuRect.height <= dropdownTriggerRect.top - contentAreaRect.top;
+
+        if (!enoughSpaceAtTheBottom && !enoughSpaceAtTheTop) {
+            // If there is not ennough space at the top and bottom, keep the dropdown at the middle of the screen
+            return -(window.innerHeight / 2);
+        }
+
+        if (enoughSpaceAtTheBottom) {
             // Don't shift to the top if it's not being clipped at the bottom
             return 0;
         }
@@ -119,7 +128,7 @@ export class DynamicDropdownPositionDirective {
             const isFirstDropdownTrigger = !!this.dropdownTriggerElement.querySelector('button.first-dropdown-toggle');
             return isFirstDropdownTrigger ? -(dropdownTriggerHeight + dropdownMenuHeight) : -dropdownMenuHeight;
         }
-        if (dropdownTriggerRect.top - dropdownMenuRect.height < contentAreaRect.top) {
+        if (enoughSpaceAtTheTop) {
             // If the menu can get clipped by moving it to the top, push it down
             return -(dropdownMenuRect.bottom - contentAreaRect.bottom);
         }


### PR DESCRIPTION
[VACE-4391] Extensibility framework cause the actions menu to be redrawn numerous times causing tens/hundreds API calls to external systems

Issue:
When the action menus in vcd get refreshed with new items (replacing) the action menu "jumps" because there is not enough space for the action menu to be redrawn.

Fix:
If there is not enough space for the action menu to be redrawn, show it at the middle of the screen

Testing Done:
- Install common components to vcd and verify the action menu position remains constant  if it doesn't have enough space.

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
If there is not enough space for the action menu to be redrawn, show it at the middle of the screen

## What manual testing did you do?
Install common components to vcd and verify the action menu position remains constant  if it doesn't have enough space.

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
