### PR TITLE
Add aria-label to action-menu items

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Added ARIA support for vcd-form-select so that screen readers can read the description text if added
 * Dropdown position was re-computed incorrectly when the dropdown is re-drawn multiple times.
+* Added aria-label to vcd-action-menu items for more fine grained screen reader announcements
 
 ## [13.0.1-dev.8]
 
@@ -21,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed accessibility of filters inside the quick-search component
-* Fixed inaccessibility of quick-search results by a screen reader  
+* Fixed inaccessibility of quick-search results by a screen reader
 * Added a name property for quick-search dialog so that a screen reader can announce a proper dialog name
 * Fixed accessibility of the pin button inside the quick-search component
 * Removed empty space above search input inside the quick-search component

--- a/projects/components/src/action-menu/action-menu.component.html
+++ b/projects/components/src/action-menu/action-menu.component.html
@@ -92,6 +92,11 @@
         (click)="runActionHandler(action)"
         [disabled]="isActionDisabled(action)"
         [attr.data-ui]="action.textKey"
+        [attr.aria-label]="
+            action.isTranslatable === false
+                ? action.ariaLabel || action.textKey
+                : (action.ariaLabel || action.textKey | translate)
+        "
     >
         <ng-container *ngIf="shouldShowText">{{
             action.isTranslatable === false ? action.textKey : (action.textKey | translate)

--- a/projects/components/src/common/interfaces/action-item.interface.ts
+++ b/projects/components/src/common/interfaces/action-item.interface.ts
@@ -45,6 +45,10 @@ export interface BaseActionItem<R, T> {
      */
     textKey?: string;
     /**
+     * The i18n key or a translated string for the action button's aria-label. If omitted, textKey will be used instead.
+     */
+    ariaLabel?: string;
+    /**
      * The css class the button should have.
      *
      * Must be unique among all added actions within an action list
@@ -79,7 +83,7 @@ export interface BaseActionItem<R, T> {
      */
     children?: ActionItem<R, T>[];
     /**
-     * To mark if the {@link #ActionItem.textKey} has to be translated or not
+     * To mark if {@link #ActionItem.textKey} and {@link #ActionItem.ariaLabel} have to be translated or not.
      */
     isTranslatable?: boolean;
     /**


### PR DESCRIPTION
Before this commit there was no way to programatically set the aria-label of action menu items. Setting the aria-label is necessary as sometimes the visual button label (textKey) is not sufficient information for users using screen readers.

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
-   [x] Feature

## What does this change do?
Adds `aria-label` capabilities to `vcd-action-menu`

## What manual testing did you do?
1. Place the built changes on the VCD project
2. Add `ariaLabel: 'my-string'` to any `vcd-action-menu` item
3. Verify the action button's `aria-label` value is 'my-string'  

## Does this PR introduce a breaking change?

-   [x] No
