### PR TITLE
Remove unused placeholder input in quick search example

### DIFF
--- a/projects/examples/src/components/quick-search/quick-search-hide-empty-section-example.component.html
+++ b/projects/examples/src/components/quick-search/quick-search-hide-empty-section-example.component.html
@@ -12,8 +12,4 @@
     </vcd-form-checkbox>
 </form>
 
-<vcd-quick-search
-    accessibilityTitle="Quick Search"
-    [(open)]="spotlightOpen"
-    [placeholder]="formGroup.controls.placeholder.value"
-></vcd-quick-search>
+<vcd-quick-search accessibilityTitle="Quick Search" [(open)]="spotlightOpen"></vcd-quick-search>


### PR DESCRIPTION
It was not needed for the example and referenced an invalid value from the `form.value`

It didn't fail compilation before  typed forms

## PR Type
-   [x] Bugfix

## What manual testing did you do?
Built the app in production mode so templates get compiled and tested. The new typed forms caught the problem.

