### PR TITLE
[VACE-4563] VM actions menu is being cutoff at the top and not displaying Power On/Off action

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Fix: VM actions menu is being cutoff at the top and not displaying Power On/Off action
 
 ## [15.0.1-dev.1]
 First release with Angular/Clarity 15

--- a/projects/components/src/dropdown/dynamic-dropdown-position.directive.ts
+++ b/projects/components/src/dropdown/dynamic-dropdown-position.directive.ts
@@ -114,8 +114,14 @@ export class DynamicDropdownPositionDirective {
         const enoughSpaceAtTheTop = dropdownMenuRect.height <= dropdownTriggerRect.top - contentAreaRect.top;
 
         if (!enoughSpaceAtTheBottom && !enoughSpaceAtTheTop) {
-            // If there is not ennough space at the top and bottom, keep the dropdown at the middle of the screen
-            return -(window.innerHeight / 2);
+            /**
+             * If there is not enough space at the top and bottom, keep the dropdown at the middle of the screen,
+             * relative to the dropdown trigger.
+             *
+             * IMPORTANT: In some cases the menu might be cut off, becuase there is no space on the screen,
+             * based on the rules of this (positionTop) function.
+             */
+            return -dropdownMenuHeight / 2;
         }
 
         if (enoughSpaceAtTheBottom) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Position the dropdown action menue in the middle relative to the dropdown trigger button.
In some cases menu might be still cut off, because of the position rules of the positionTop function in dynamic-dropdown component.

## What manual testing did you do?
Verify action menus are not cut off, when having multiple rows of vapp cards.

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
