### PR TITLE
Fix wider column for vcd-datagrid when actions are displayed with dropdown in a row 

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Update styles for vcd-datagrid actions displayed with dropdown in row
 
 ## [15.0.1-dev.2]
 First version of @vcd/ui-components without WidgetObject and its related files

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -18,8 +18,13 @@
         <ng-container *ngTemplateOutlet="actionBar"> </ng-container>
     </clr-dg-action-bar>
 
-    <clr-dg-column *ngIf="shouldDisplayContextualActionsInRow" [ngClass]="'buttons-' + maxFeaturedActionsOnRow">
-        {{ 'vcd.cc.datagrid.actions' | translate }}
+    <clr-dg-column
+        *ngIf="shouldDisplayContextualActionsInRow"
+        [ngClass]="shouldDisplayContextualActionsInDropdpown ?  'dropdown-actions' : 'buttons-' + maxFeaturedActionsOnRow"
+        >
+        <ng-container *ngIf="!shouldDisplayContextualActionsInDropdpown"> 
+            {{ 'vcd.cc.datagrid.actions' | translate }} 
+        </ng-container>
     </clr-dg-column>
     <clr-dg-column
         *ngFor="let column of columnsConfig; trackBy: columnTrackBy"
@@ -52,7 +57,7 @@
         <clr-dg-cell
             *ngIf="shouldDisplayContextualActionsInRow"
             class="action-button-cell"
-            [ngClass]="'buttons-' + maxFeaturedActionsOnRow"
+            [ngClass]="shouldDisplayContextualActionsInDropdpown ?  'dropdown-actions' : 'buttons-' + maxFeaturedActionsOnRow"
         >
             <vcd-action-menu
                 #actionMenuInRow
@@ -124,3 +129,4 @@
     >
     </vcd-action-menu>
 </ng-template>
+

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -50,9 +50,16 @@ clr-dg-action-bar.top-action-bar {
     flex: 0 1 auto;
 }
 
-.action-button-cell {
-    padding-top: $PADDING;
-    padding-bottom: $PADDING;
+.dropdown-actions {
+    min-width: unset;
+    width: 38px !important;
+
+    ::ng-deep .nested-dropdown {
+        padding: 0 0.6rem 0 0;
+        .dropdown-toggle {
+            padding: 0;
+        }
+    }
 }
 
 .action-button-group {

--- a/projects/components/src/datagrid/datagrid.component.ts
+++ b/projects/components/src/datagrid/datagrid.component.ts
@@ -25,7 +25,7 @@ import { Observable } from 'rxjs';
 import { FormGroup } from '@angular/forms';
 import { ActionMenuComponent } from '../action-menu/action-menu.component';
 import { ActivityReporter } from '../common/activity-reporter';
-import { ActionHandlerType, ActionItem, ActionType } from '../common/interfaces/action-item.interface';
+import { ActionHandlerType, ActionItem, ActionStyling, ActionType } from '../common/interfaces/action-item.interface';
 import { SubscriptionTracker } from '../common/subscription/subscription-tracker';
 import { TooltipSize } from '../lib/directives/show-clipped-text.directive';
 import { DatagridFilter } from './filters/datagrid-filter';
@@ -475,6 +475,13 @@ export class DatagridComponent<R extends B, B = any> implements OnInit, AfterVie
      */
     get shouldDisplayContextualActionsInRow(): boolean {
         return this.actionDisplayConfig?.contextual?.position === DatagridContextualActionPosition.ROW;
+    }
+
+    /**
+     * If the contextual buttons should display in a row.
+     */
+    get shouldDisplayContextualActionsInDropdpown(): boolean {
+        return this.actionDisplayConfig?.contextual?.styling === ActionStyling.DROPDOWN;
     }
 
     /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe: CSS Style changes

## What does this change do?

Fixes a bug where the action column was too wide when using actions are displayed inline but there are no featured actions, therefore, no space should be reserved for them in the action column.


## What manual testing did you do?
- Run examples 
- go to Datagrid details
- Select `Display config of contextual actions` 
- select `Dropdown` for Styling
- select `In row` for Position
- verify that actions column does not have a header and it is not wider that it should
- verify that actions are looking ok with all configurations 


## Screenshots (if applicable)

| Before | After |
|--------|--------|
| <img width="1483" alt="Screenshot 2023-05-16 at 21 52 11" src="https://github.com/vmware/vmware-cloud-director-ui-components/assets/77797592/1aa4c96d-175f-47cd-8457-7eff363cc13b"> | ![after](https://github.com/vmware/vmware-cloud-director-ui-components/assets/77797592/6126e385-198b-4b23-84bf-e80096287aa7)| 

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
