### PR TITLE
Revert behavior of SelectorUtil.extractSelector

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Update styles for vcd-datagrid actions displayed with dropdown in row
+
+### Fixed
+* Restore behavior of SelectorUtils that was broken when splitting out WidgetObject
+* Remove of extra space in action columns on datagrid when using inline actions
 
 ## [15.0.1-dev.2]
 First version of @vcd/ui-components without WidgetObject and its related files

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1-dev.3]
+
 ### Fixed
 * Restore behavior of SelectorUtils that was broken when splitting out WidgetObject
 * Remove of extra space in action columns on datagrid when using inline actions

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "15.0.1-dev.2",
+    "version": "15.0.1-dev.3",
     "dependencies": {
         "@ngx-formly/core": ">=6.0.4"
     },

--- a/projects/widget-object/src/lib/angular/angular-widget-object-element.ts
+++ b/projects/widget-object/src/lib/angular/angular-widget-object-element.ts
@@ -24,7 +24,10 @@ export class AngularWidgetObjectElement implements WidgetObjectElement<TestEleme
     get(selector: string | FindElementOptions): AngularWidgetObjectElement {
         const cssSelector = SelectorUtil.extractSelector(selector);
         const elements = this.testElement.elements;
-        let matches = elements.map((element) => element.queryAll(By.css(cssSelector))).flat();
+        // If no selector is given, get all descendants
+        let matches = elements
+            .map((element) => element.queryAll(cssSelector ? By.css(cssSelector) : () => true))
+            .flat();
         if (typeof selector !== 'string') {
             if (typeof selector.index === 'number') {
                 matches = [matches[selector.index]];

--- a/projects/widget-object/src/lib/angular/angular-widget-object.spec.ts
+++ b/projects/widget-object/src/lib/angular/angular-widget-object.spec.ts
@@ -6,7 +6,7 @@
 import { Component, Input, Type } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { BaseWidgetObject } from '../widget-object';
+import { BaseWidgetObject, WidgetObjectElement } from '../widget-object';
 import { AngularWidgetObjectFinder } from './angular-widget-finder';
 import { AngularWidgetObjectElement, TestElement } from './angular-widget-object-element';
 
@@ -112,6 +112,10 @@ class ClickTrackerWidgetObject<T> extends BaseWidgetObject<T> {
         this.getNameInput().clear();
         this.getNameInput().type(value);
     }
+
+    getButton33(): WidgetObjectElement<T> {
+        return this.el.get({ exactText: 'BUTTON33' });
+    }
 }
 
 /**
@@ -196,6 +200,9 @@ describe('AngularWidgetObjectElement', () => {
         });
         it('can find an element by index', () => {
             expect(test.clickTracker!.getButtonByLabel({ index: 0 }).unwrap().text()).toEqual('BUTTON');
+        });
+        it('can find an element by text without using selectors', () => {
+            expect(test.clickTracker!.getButton33().unwrap().text()).toEqual('BUTTON33');
         });
     });
 

--- a/projects/widget-object/src/lib/selector-util.ts
+++ b/projects/widget-object/src/lib/selector-util.ts
@@ -6,19 +6,20 @@ import { FindElementOptions } from './widget-object';
 
 export class SelectorUtil {
     /**
-     * Extracts the selector from the parameter passed
+     * Extracts the selector from the parameter passed. It is possible that selector is a `FindElementOptions` but
+     * does not contain dataUiSelector or cssSelector. That would
+     *
+     * @return a CSS selector string to be used or undefined if no CSS selector can be found
      */
-    static extractSelector(selector: string | FindElementOptions): string {
+    static extractSelector(selector: string | FindElementOptions): string | undefined {
         if (typeof selector === 'string') {
             return selector;
-        }
-        if (selector.dataUiSelector) {
-            return `[data-ui="${selector.dataUiSelector}"]`;
-        }
+        } else {
+            if (selector.dataUiSelector) {
+                return `[data-ui="${selector.dataUiSelector}"]`;
+            }
 
-        if (!selector.cssSelector) {
-            throw new Error('Expected selector to contain either a `dataUiSelector` or `cssSelector` property');
+            return selector.cssSelector;
         }
-        return selector.cssSelector;
     }
 }


### PR DESCRIPTION
## PR Checklist

-   [x] Changelog has been updated

## PR Type

-   [x] Bugfix

## What does this change do?
Revert  `SelectorUtil.extractSelector` to what it was before `@vcd/widget-object` was split into its own lib. `extractSelector`'s signature now indicates that it could return undefined.



The specific case where this happens is when you call `el.get({text: 'some text'})` or `el.get({exactText: 'some text'})`. In that case, there is no `dataUiSelector` or `cssSelector` so the CSS selector is just `""`which will cause all nodes under the given `el` to be retrieved and then we'll filter for which ones contain text.


## Why was the previous change made?
When moving `WidgetObject` out to its won library, I thought `extractSelector` expected to always find a selector but that was not true so throwing an Error was causing some tests to fail.

The compiler was complaining about`SelectorUtil.extractSelector`'s return value of undefined not 
being allowed (because widget-object has stricter compilation).  

## What manual testing did you do?

* From VCD UI, ran the `catalog-management.feature` in headed mode
* Verified that it passed.

## Screenshots (if applicable)
This was revealed while running Catalog Management
![image](https://github.com/vmware/vmware-cloud-director-ui-components/assets/549331/6e9c8d40-c9f8-4141-ae00-5abb11788fe7)

## Does this PR introduce a breaking change?

-   [x] Yes - but it reverts it to the original contract that was changed by mistake.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
