### PR TITLE
Remove flattening of actions

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+-  Remove flattening of actions, fixes bug "Context of a VM keeps refreshing when powering ON a VM"
 
 ## [15.0.1-dev.3]
 

--- a/projects/components/src/dropdown/dropdown.component.ts
+++ b/projects/components/src/dropdown/dropdown.component.ts
@@ -133,7 +133,7 @@ export class DropdownComponent implements AfterViewInit {
      * Nested list of dropdown objects
      */
     @Input() set items(items: ActionItem<unknown, unknown>[]) {
-        this._items = this.flattenNestedItemsWithSingleChild(items);
+        this._items = items;
     }
     get items(): ActionItem<unknown, unknown>[] {
         return this._items;
@@ -267,33 +267,6 @@ export class DropdownComponent implements AfterViewInit {
      * NOTE: Without this, nested drop downs don't get rendered on the screen
      */
     @Input() trackByFunction: TrackByFunction<ActionItem<unknown, unknown>> = (index, item) => item.textKey;
-
-    private flattenNestedItemsWithSingleChild(items: ActionItem<unknown, unknown>[]): ActionItem<unknown, unknown>[] {
-        items.forEach((item) => {
-            // Flatten out the dropdowns with single children at each level of dropdown
-            this.flattenItemsWithSingleChild(items);
-            if (item.children) {
-                // Repeat the same for other nested levels
-                this.flattenNestedItemsWithSingleChild(item.children);
-            }
-        });
-        return items;
-    }
-
-    private flattenItemsWithSingleChild(items: ActionItem<unknown, unknown>[]): void {
-        const singleChildItemIndices: number[] = [];
-        items.forEach((item, index) => {
-            // Collect the indices of single child items
-            if (item.children && item.children.length === 1) {
-                singleChildItemIndices.push(index);
-            }
-        });
-        singleChildItemIndices.forEach((singleChildItemIndex) => {
-            // Delete them from the original list and add their children to the beginning of the current list
-            const singleChildItem = items.splice(singleChildItemIndex, 1).pop();
-            items.unshift(singleChildItem.children[0]);
-        });
-    }
 
     /**
      * Nested menus are toggled using the mouseover and mouseout events instead of mouse clicks. So the claritys
@@ -539,9 +512,9 @@ export class DropdownFocusHandlerDirective implements AfterViewInit, OnDestroy {
 
     private getDropdownItemElement(item: Element): HTMLElement {
         // We only need the underlying button that opens the nested dropdown as that is the activatable/focusable item
-        return (item.matches(ActivatableMenuItemType.BUTTON)
-            ? item
-            : item.querySelector(NESTED_DROPDOWN_TRIGGER)) as HTMLElement;
+        return (
+            item.matches(ActivatableMenuItemType.BUTTON) ? item : item.querySelector(NESTED_DROPDOWN_TRIGGER)
+        ) as HTMLElement;
     }
 
     private linkMenuItems(): void {


### PR DESCRIPTION
Flattening of dropdowns with single action is causing issues, when the parent dropdown content is "dynamic".
It causes menus to jump when the parent contains
one child and few seconds alter 2+ child actions.

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Removes the flattening of dropdowns with a single child.

## What manual testing did you do?
Verified that the dropdowns with a single child don't get flattened, in VM screens of vCD.

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
