### PR TITLE
Fix VCD datagrid dropdown actions column width

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Minor fix for datagrid dropdown actions column width in some corner cases when datagrid is empty or the columns are rendered before the grid is populated with data
 
 ## [15.0.1-dev.3]
 

--- a/projects/components/src/datagrid/datagrid.component.scss
+++ b/projects/components/src/datagrid/datagrid.component.scss
@@ -52,7 +52,7 @@ clr-dg-action-bar.top-action-bar {
 
 .dropdown-actions {
     min-width: unset;
-    width: 38px !important;
+    max-width: 38px;
 
     ::ng-deep .nested-dropdown {
         padding: 0 0.6rem 0 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [X] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Minor fix for datagrid dropdown actions column width in some corner cases when datagrid is empty or the columns are rendered before the grid is populated with data

## What manual testing did you do?

Test in the VCD project (no way to test it in the components examples since the issue is a corner case)

Empty state test case steps:
1. Go to Provider Gateway details in the Provider portal with no BGP Community Lists added (should see the empty state)
2. Verify that the column width is normal (38px)

| Before | After |
|--------|--------|
|  <img width="1004" alt="Screenshot 2023-06-06 at 19 06 11" src="https://github.com/vmware/vmware-cloud-director-ui-components/assets/77797592/f82ac73b-8ad4-4453-90ad-d2e28a46ead7"> | <img width="851" alt="Screenshot 2023-06-06 at 19 05 54" src="https://github.com/vmware/vmware-cloud-director-ui-components/assets/77797592/cd1ec3cf-be59-4f74-9a2d-3424539519e9"> |
 
Columns rendered before data case steps:
1. Go to Content hub in the Tenant portal 
2. Go to Content -> Application Images (this should be opened by default)
3. Switch to see grid view
4. Verify that the column width is normal (38px)

| Before | After |
|--------|--------|
| https://github.com/vmware/vmware-cloud-director-ui-components/assets/77797592/796c3686-77c0-4ca2-a246-f5957c526459 | https://github.com/vmware/vmware-cloud-director-ui-components/assets/77797592/08c42861-989e-4090-85d6-b354d555806f |

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Bug Number: https://jira.eng.vmware.com/browse/VDU-8198