### PR TITLE
Pass the preserve selection value to Clarity datagrid

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1-dev.7]
+
+### Fixed
+- Pass the preserve selection value to Clarity datagrid
+
 ## [15.0.1-dev.6]
 
 ### Changed

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "15.0.1-dev.6",
+    "version": "15.0.1-dev.7",
     "dependencies": {
         "@ngx-formly/core": ">=6.0.4"
     },

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -9,6 +9,7 @@
     (clrDgRefresh)="gridStateChanged($event)"
     (clrDgSelectedChange)="onClarityDatafridSelectionChange()"
     (clrDgSingleSelectedChange)="onClarityDatafridSelectionChange()"
+    [clrDgPreserveSelection]="preserveSelection"
 >
     <clr-dg-placeholder>{{ emptyGridPlaceholder }}</clr-dg-placeholder>
     <clr-dg-action-bar class="top-action-bar" *ngIf="shouldShowActionBarOnTop">
@@ -22,8 +23,8 @@
         *ngIf="shouldDisplayContextualActionsInRow && contextualActions?.length"
         [ngClass]="shouldDisplayContextualActionsInDropdpown ?  'dropdown-actions' : 'buttons-' + maxFeaturedActionsOnRow"
         >
-        <ng-container *ngIf="!shouldDisplayContextualActionsInDropdpown"> 
-            {{ 'vcd.cc.datagrid.actions' | translate }} 
+        <ng-container *ngIf="!shouldDisplayContextualActionsInDropdpown">
+            {{ 'vcd.cc.datagrid.actions' | translate }}
         </ng-container>
     </clr-dg-column>
     <clr-dg-column
@@ -57,7 +58,9 @@
         <clr-dg-cell
             *ngIf="shouldDisplayContextualActionsInRow && contextualActions?.length"
             class="action-button-cell"
-            [ngClass]="shouldDisplayContextualActionsInDropdpown ?  'dropdown-actions' : 'buttons-' + maxFeaturedActionsOnRow"
+            [ngClass]="
+                shouldDisplayContextualActionsInDropdpown ? 'dropdown-actions' : 'buttons-' + maxFeaturedActionsOnRow
+            "
         >
             <vcd-action-menu
                 #actionMenuInRow
@@ -129,4 +132,3 @@
     >
     </vcd-action-menu>
 </ng-template>
-

--- a/projects/examples/src/components/datagrid/datagrid-preserve-selection.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-preserve-selection.example.component.ts
@@ -1,0 +1,100 @@
+/*!
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component } from '@angular/core';
+import {
+    CheckBoxStyling,
+    DatagridStringFilter,
+    GridColumn,
+    GridDataFetchResult,
+    GridSelectionType,
+    GridState,
+    WildCardPosition,
+} from '@vcd/ui-components';
+import { FormControl } from '@angular/forms';
+
+interface Data {
+    name: string;
+    city: string;
+}
+
+/**
+ * Preserve selection when set to true will keep the datagrid selection on filter change.
+ */
+@Component({
+    selector: 'vcd-datagrid-preserve-selection-example',
+    template: `
+        The default behavior is for datagrid to clear the selection whenever the datagrid's filters value are changed.
+        Enabling the datagrid preserve selection will keep the selection.
+
+        <p>Toggle to turn datagrid preserve selection on or off</p>
+        <form class="clr-form-compact">
+            <vcd-form-checkbox
+                [formControl]="checkboxControl"
+                [label]="'Preserve Selection'"
+                [styling]="CheckBoxStyling.TOGGLESWITCH"
+            >
+            </vcd-form-checkbox>
+        </form>
+        <vcd-datagrid
+            [gridData]="gridData"
+            (gridRefresh)="refresh($event)"
+            [columns]="columns"
+            [selectionType]="selectionType"
+            [datagridSelection]="selectedItems"
+            (datagridSelectionChange)="selectionChanged($event)"
+            [preserveSelection]="checkboxControl.value"
+            [trackBy]="trackByName"
+        ></vcd-datagrid>
+    `,
+})
+export class DatagridPreserveSelectionExampleComponent {
+    protected readonly CheckBoxStyling = CheckBoxStyling;
+
+    selectionType = GridSelectionType.Multi;
+    GridSelectionType = GridSelectionType;
+
+    gridData: GridDataFetchResult<Data> = {
+        items: [],
+    };
+
+    columns: GridColumn<Data>[] = [
+        {
+            displayName: 'Name',
+            renderer: 'name',
+            queryFieldName: 'name',
+            filter: DatagridStringFilter(WildCardPosition.END, ''),
+        },
+        {
+            displayName: 'City',
+            renderer: 'city',
+            queryFieldName: 'city',
+            filter: DatagridStringFilter(WildCardPosition.END, ''),
+        },
+    ];
+
+    selectedItems = [{ name: 'Bob', city: 'Palo Alto' }];
+
+    checkboxControl = new FormControl(true);
+
+    selectionChanged(selected: Data[]): void {
+        console.log(selected);
+    }
+
+    refresh(): void {
+        this.gridData = {
+            items: [
+                { name: 'Bob', city: 'Palo Alto' },
+                { name: 'Mary', city: 'Boston' },
+                { name: 'Harry', city: 'Austin' },
+            ],
+            totalItems: 3,
+        };
+    }
+
+    trackByName = (index: number, record: Data): string => {
+        return record.name;
+    };
+}

--- a/projects/examples/src/components/datagrid/datagrid-preserve-selection.example.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid-preserve-selection.example.module.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { VcdComponentsModule } from '@vcd/ui-components';
+import { DatagridPreserveSelectionExampleComponent } from './datagrid-preserve-selection.example.component';
+
+@NgModule({
+    declarations: [DatagridPreserveSelectionExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
+    exports: [DatagridPreserveSelectionExampleComponent],
+})
+export class DatagridPreserveSelectionExampleModule {}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019-2021 VMware, Inc.
+ * Copyright 2019-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -46,6 +46,8 @@ import { DatagridThreeRenderersExampleComponent } from './datagrid-three-rendere
 import { DatagridThreeRenderersExampleModule } from './datagrid-three-renderers.example.module';
 import { DatagridIsRowSelectableExampleComponent } from './datagrid-is-row-selectable-example.component';
 import { DatagridIsRowSelectableExampleModule } from './datagrid-is-row-selectable-example.module';
+import { DatagridPreserveSelectionExampleComponent } from './datagrid-preserve-selection.example.component';
+import { DatagridPreserveSelectionExampleModule } from './datagrid-preserve-selection.example.module';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -123,6 +125,11 @@ Documentation.registerDocumentationEntry({
             urlSegment: 'datagrid-filter',
         },
         {
+            component: DatagridPreserveSelectionExampleComponent,
+            title: 'Preserve selection',
+            urlSegment: 'preserve-selection',
+        },
+        {
             component: DatagridCliptextExampleComponent,
             title: 'Cliptext in the datagrid cells',
             urlSegment: 'datagrid-cliptext',
@@ -179,6 +186,7 @@ Documentation.registerDocumentationEntry({
         DatagridColumnWidthExampleModule,
         DatagridActionDisplayConfigExampleModule,
         DatagridIsRowSelectableExampleModule,
+        DatagridPreserveSelectionExampleModule,
     ],
 })
 export class DatagridExamplesModule {}


### PR DESCRIPTION
VCD datagrid preserve selection input is not passed to Clarity datagrid. Clarity datagrid default behavior is to clear selection whenever the datagrid filter value is changed. By passing the preserve selection flag onto the Clarity datagrid, it will not clear the selection.

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Pass the preserve selection value onto the Clarity datagrid.

## What manual testing did you do?
Wrote the example page for preserve selection. Used it to manually test that selection is kept when preserve selection is on.

## Screenshots (if applicable)
![Screenshot 2023-07-25 at 5 10 12 PM](https://github.com/vmware/vmware-cloud-director-ui-components/assets/67131449/2147bd61-aa18-4462-9ce8-62323fa5eb7a)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
