### PR TITLE
Fix tooltip keyboard a11y

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix tooltip keyboard accessibility
+
 ## [15.0.1-dev.7]
 
 ### Fixed

--- a/projects/examples/src/app/components/show-clipped-text/focusing/focusing-clipped-text-example.component.html
+++ b/projects/examples/src/app/components/show-clipped-text/focusing/focusing-clipped-text-example.component.html
@@ -1,0 +1,63 @@
+<section>
+    The clipped text directive accessibility and user control! Components with overflow content to become focusable,
+    ensuring seamless keyboard navigation for tooltip-equipped components. To test it you can modify content through
+    input and adjust component size via a range slider located below. It is expected the host element to not be
+    focusable when it not overflows, in case it had no predefined positive tab index.
+</section>
+
+<section>
+    <h4>Host element with default tab index</h4>
+    <div class="clr-row">
+        <clr-input-container class="clr-col-md-6">
+            <label>Text for div below:</label>
+            <input
+                clrInput
+                name="name"
+                ngModel="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet et minus saepe sapiente. Delectus, facilis itaque neque optio quis soluta."
+                #divContent
+            />
+        </clr-input-container>
+        <clr-range-container [clrRangeHasProgress]="true" class="clr-col-md-6">
+            <label>Component size: {{ divWidth.value + ' px' }} </label>
+            <input type="range" clrRange ngModel="100" min="100" max="1000" #divWidth />
+        </clr-range-container>
+    </div>
+    <div class="clr-row">
+        <div
+            class="example-el"
+            [vcdShowClippedText]="{ size: TooltipSize.sm }"
+            [ngStyle]="{ width: divWidth.value + 'px' }"
+        >
+            {{ divContent.value }}
+        </div>
+    </div>
+</section>
+<section>
+    <h4>Host element with predefined positive tab index</h4>
+    <div class="clr-row">
+        <clr-input-container class="clr-col-md-6">
+            <label>Text for div below:</label>
+            <input
+                clrInput
+                tabindex="1"
+                name="name"
+                ngModel="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet et minus saepe sapiente. Delectus, facilis itaque neque optio quis soluta."
+                #divContent1
+            />
+        </clr-input-container>
+        <clr-range-container [clrRangeHasProgress]="true" class="clr-col-md-6">
+            <label>Component size: {{ divWidth1.value + ' px' }} </label>
+            <input type="range" clrRange ngModel="100" min="100" max="1000" tabindex="2" #divWidth1 />
+        </clr-range-container>
+    </div>
+    <div class="clr-row">
+        <div
+            class="example-el"
+            tabindex="3"
+            [vcdShowClippedText]="{ size: TooltipSize.sm }"
+            [ngStyle]="{ width: divWidth1.value + 'px' }"
+        >
+            {{ divContent1.value }}
+        </div>
+    </div>
+</section>

--- a/projects/examples/src/app/components/show-clipped-text/focusing/focusing-clipped-text-example.component.scss
+++ b/projects/examples/src/app/components/show-clipped-text/focusing/focusing-clipped-text-example.component.scss
@@ -1,0 +1,7 @@
+.example-el {
+    border: 1px solid black;
+    display: inline-block;
+    min-height: 1rem;
+    margin-top: 0.5rem;
+    min-width: 100px;
+}

--- a/projects/examples/src/app/components/show-clipped-text/focusing/focusing-clipped-text-example.component.ts
+++ b/projects/examples/src/app/components/show-clipped-text/focusing/focusing-clipped-text-example.component.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TooltipSize, VcdComponentsModule } from '@vcd/ui-components';
+import { ClarityModule } from '@clr/angular';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+    standalone: true,
+    selector: 'vcd-focusing-clipped-text-example',
+    templateUrl: 'focusing-clipped-text-example.component.html',
+    styleUrls: ['focusing-clipped-text-example.component.scss'],
+    imports: [CommonModule, VcdComponentsModule, ClarityModule, FormsModule],
+})
+export class FocusingClippedTextExampleComponent {
+    protected readonly TooltipSize = TooltipSize;
+}

--- a/projects/examples/src/app/components/show-clipped-text/show-clipped-text-examples.module.ts
+++ b/projects/examples/src/app/components/show-clipped-text/show-clipped-text-examples.module.ts
@@ -13,6 +13,7 @@ import { ShowClippedTextPositioningExampleComponent } from './positioning/show-c
 import { ShowClippedTextPositioningExampleModule } from './positioning/show-clipped-text-positioning-example.module';
 import { ShowClippedTextSizingExampleComponent } from './sizing/show-clipped-text-sizing-example.component';
 import { ShowClippedTextSizingExampleModule } from './sizing/show-clipped-text-sizing-example.module';
+import { FocusingClippedTextExampleComponent } from './focusing/focusing-clipped-text-example.component';
 
 Documentation.registerDocumentationEntry({
     component: ShowClippedTextDirective,
@@ -33,6 +34,11 @@ Documentation.registerDocumentationEntry({
             component: HideClippedTextPositioningExampleComponent,
             title: 'Hide the tooltip when the component is destroyed',
             urlSegment: 'hide-clipped-text',
+        },
+        {
+            component: FocusingClippedTextExampleComponent,
+            title: 'Focusing on host element when it overflows',
+            urlSegment: 'focus-clipped-text',
         },
     ],
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [x] Documentation content changes
-   [x] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?
The element with the assigned tooltip has to be accessible through the tab key.
There are cases when users don't use a screen reader, but use the tab key to navigate through the UI.
So if hostElement has a tooltip, it should be focusable.

## Fix Description:
The directive will be observing the subtree characterData and resizing mutations because it could lead to overflow changing. It will save the initial tabIndex and change it just in case the element is non-focusable, otherwise, there is no need to change it. The changes are not needed in case the element is not overflowing.

## What manual testing did you do?
- Open examples and go to show-clipped-text-sizing
- Try changing all tree inputs and depending on overflowing they should and shouldn't be accessible through the Tab key.

## Screenshots

![image](https://github.com/vmware/vmware-cloud-director-ui-components/assets/49042716/b25912c6-7758-4d6a-a258-361ab1c82598)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
