### PR TITLE
Route analyzer segments

### DIFF
--- a/projects/examples/src/components/datagrid/datagrid-preserve-selection.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-preserve-selection.example.component.ts
@@ -40,7 +40,7 @@ interface Data {
         </form>
         <vcd-datagrid
             [gridData]="gridData"
-            (gridRefresh)="refresh($event)"
+            (gridRefresh)="refresh()"
             [columns]="columns"
             [selectionType]="selectionType"
             [datagridSelection]="selectedItems"

--- a/projects/route-analyzer/CHANGELOG.MD
+++ b/projects/route-analyzer/CHANGELOG.MD
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.0.11]
+
+
+## [0.0.13]
+### [Added]
+Generate file with segments to be used when redirecting to relative URLs or when reading params from the URL
+
+## [0.0.12]
 ### [Fixed]
 Logging on `evaluateNode` now happens on errors only.
 

--- a/projects/route-analyzer/README.md
+++ b/projects/route-analyzer/README.md
@@ -73,7 +73,7 @@ A flat list of objects containing a route builder function and the
 HTML tagName associated with the component that will be rendered by that
 route. Objects are exported as separate objects like the example below
 
-### Example TypeScript output
+### Example output
 
 ```typescript
 export const administration_accessControl_users_userId_general = {
@@ -114,6 +114,82 @@ for (const entry of topLevelRoutes) {
 
 -   Compilation errors if routes change
 -   No hard coding or joining path segments from application.
+
+## Segments Typescript
+
+A list of strings representing each segment found in the application. Each
+string is prepended with `segment_`.
+
+### Example output
+
+If we use `/administration/access-control/users/:userId/general` as an example route, the following
+variables will be generated
+
+```typescript
+export const segment_administration = 'administration';
+export const segment_accessControl = 'access-control';
+export const segment_users = 'users';
+export const segment_userId = ':userId';
+export const segment_general = 'general';
+```
+
+### Example usage
+
+#### Do not use variables in your route definitions
+
+Your route definitions are the source of truth, just define them using regular strings.
+It will be easier to read your routes.
+
+```typescript
+const routes = [
+    {
+        path: CLOUD_RESOURCES.ORGANIZATIONS,
+        component: OrganizationsListTenantComponent,
+    },
+    {
+        path: `${CLOUD_RESOURCES.ORGANIZATIONS}/:${CLOUD_RESOURCES.ORGANIZATION_ID}`,
+        loadChildren: () => import('@my/org-details.module').then((m) => m.OrgDetailsModule),
+    },
+];
+```
+
+Becomes
+
+```typescript
+const routes = [
+    {
+        path: 'organizations',
+        component: OrgListComponent,
+    },
+    {
+        path: 'organizations/:orgId',
+        loadChildren: () => import('@my/org-details.module').then((m) => m.OrgDetailsModule),
+    },
+];
+```
+
+And you use it from places where you need relative links or when reading router attributes
+
+```typescript
+constructor(private activatedRoute: ActivatedRoute) {
+    this.activatedRoute.queryParams.subscribe(params => {
+        let date = params[segment_orgId];
+    });
+}
+```
+
+```typescript
+router.navigate(`../${segments_general}`);
+```
+
+### Benefits
+
+-   Partial string value checking through compilation if segments change
+    -   Not fail-proof since the segments aren't scoped to whole routes. That
+        means you won't get an error if the same segment still exists somewhere else in your route definitions
+-   Leave your route definitions easier to read if you had been previously using manually
+    maintained constants for your route.
+    -   At the expense of being forced to duplicate strings in route definitions
 
 ## Public API
 

--- a/projects/route-analyzer/package.json
+++ b/projects/route-analyzer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/route-analyzer",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "bin": "cli.js",
     "dependencies": {
         "ts-evaluator": "1.1.0",

--- a/projects/route-analyzer/src/cli.ts
+++ b/projects/route-analyzer/src/cli.ts
@@ -10,6 +10,8 @@ import ts from 'typescript';
 import yargs from 'yargs';
 import * as routeAnalyzer from './lib/route-analyzer';
 import { generateRouteBuilder } from './lib/gen-route-builder';
+import { generateRouteSegments } from './lib/gen-route-segments';
+import { join, normalize } from '@angular-devkit/core';
 
 const argv = yargs
     .option('entryFile', {
@@ -35,6 +37,12 @@ const argv = yargs
         type: 'string',
         default: 'app-routes.ts',
     })
+    .option('segmentsFile', {
+        alias: 's',
+        description: 'Name of TypeScript file containing all route segments as separate constants.',
+        type: 'string',
+        default: 'app-segments.ts',
+    })
     .help()
     .demandOption(['entryFile', 'outputDirectory'])
     .alias('help', 'h')
@@ -48,9 +56,11 @@ const appRoutes = routeAnalyzer.getRoutesByEntryPoint([argv.entryFile], {
 });
 
 const options = { mode: 0o755, encoding: UTF8 };
-const outputJsonFile = argv.outputDirectory + '/' + argv.jsonFile;
-const outputTs = argv.outputDirectory + '/' + argv.tsFile;
+const outputJsonFile = join(normalize(argv.outputDirectory), argv.jsonFile);
+const outputTs = join(normalize(argv.outputDirectory), argv.tsFile);
+const outputTsSegments = join(normalize(argv.outputDirectory), argv.segmentsFile);
 
 fs.mkdirSync(argv.outputDirectory, { recursive: true });
 fs.writeFileSync(outputJsonFile, JSON.stringify(appRoutes, undefined, 2), options);
 fs.writeFileSync(outputTs, generateRouteBuilder(appRoutes), options);
+fs.writeFileSync(outputTsSegments, generateRouteSegments(appRoutes), options);

--- a/projects/route-analyzer/src/lib/gen-route-segments.ts
+++ b/projects/route-analyzer/src/lib/gen-route-segments.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { join, normalize, Path } from '@angular-devkit/core';
+import { AppRoute } from './app-route';
+import { split } from '@angular-devkit/core/src/virtual-fs/path';
+
+export function generateRouteSegments(routes: AppRoute[]): string {
+    const segments = new Set<string>();
+
+    function traverse(
+        children: AppRoute[],
+        cb: (route: AppRoute, parentPath: Path) => void,
+        parentPath = normalize('/')
+    ) {
+        for (const child of children) {
+            cb(child, parentPath);
+            if (child.children) {
+                traverse(child.children, cb, join(parentPath, child.path));
+            }
+        }
+    }
+
+    traverse(routes, (route, parentPath) => {
+        if (!route.path || route.path === '**') {
+            return;
+        }
+        for (const segment of split(normalize(route.path))) {
+            segments.add(segment);
+        }
+    });
+
+    return Array.from(segments)
+        .map((segment) => {
+            const identifier = segment.replace(/-/g, '_');
+            const stripColon = (val: string) => (segment[0] == ':' ? val.slice(1) : val);
+            return `export const segment_${stripColon(identifier)} = ${JSON.stringify(stripColon(segment))};`;
+        })
+        .join('\n');
+}

--- a/projects/route-analyzer/src/lib/utils.ts
+++ b/projects/route-analyzer/src/lib/utils.ts
@@ -50,7 +50,7 @@ export function getArrayItemsInitializer(
     if (ts.isIdentifier(expression)) {
         const variableInitializer = getVariableInitializer(expression, typeChecker);
         if (ts.isObjectLiteralExpression(variableInitializer)) {
-            arrayLiteralExpression = ts.createArrayLiteral([variableInitializer]);
+            arrayLiteralExpression = ts.factory.createArrayLiteralExpression([variableInitializer]);
         } else if (ts.isArrayLiteralExpression(variableInitializer)) {
             arrayLiteralExpression = variableInitializer;
         } else {
@@ -97,7 +97,6 @@ export function evaluateNode(
         return val.value as object;
     }
     if (throwOnFailure) {
-        console.error({ evaluating: node.getText(), val });
         throw new Error(`Corner case hit when evaluating: `);
     }
 }


### PR DESCRIPTION
Generate constants for segments in routes

See comments in [README.md](https://github.com/juanmendes/vmware-cloud-director-ui-components/blob/dd91c33e1d8f3a78ab6bd19bbbd717f7d20c5f59/projects/route-analyzer/README.md#segments-typescript).

## Segments Typescript

A list of strings representing each segment found in the application. Each
string is prepended with `segment_`.

### Example output

If we use `/administration/access-control/users/:userId/general` as an example route, the following
variables will be generated

```typescript
export const segment_administration = 'administration';
export const segment_accessControl = 'access-control';
export const segment_users = 'users';
export const segment_userId = ':userId';
export const segment_general = 'general';
```

### Example usage

#### Do not use variables in your route definitions

Your route definitions are the source of truth, just define them using regular strings.
It will be easier to read your routes.

```typescript
const routes = [
    {
        path: CLOUD_RESOURCES.ORGANIZATIONS,
        component: OrganizationsListTenantComponent,
    },
    {
        path: `${CLOUD_RESOURCES.ORGANIZATIONS}/:${CLOUD_RESOURCES.ORGANIZATION_ID}`,
        loadChildren: () => import('@my/org-details.module').then((m) => m.OrgDetailsModule),
    },
];
```

Becomes

```typescript
const routes = [
    {
        path: 'organizations',
        component: OrgListComponent,
    },
    {
        path: 'organizations/:orgId',
        loadChildren: () => import('@my/org-details.module').then((m) => m.OrgDetailsModule),
    },
];
```

And you use it from places where you need relative links or when reading router attributes

```typescript
constructor(private activatedRoute: ActivatedRoute) {
    this.activatedRoute.queryParams.subscribe(params => {
        let date = params[segment_orgId];
    });
}
```

```typescript
router.navigate(`../${segments_general}`);
```

### Benefits

-   Partial string value checking through compilation if segments change
    -   Not fail-proof since the segments aren't scoped to whole routes. That
        means you won't get an error if the same segment still exists somewhere else in your route definitions
-   Leave your route definitions easier to read if you had been previously using manually
    maintained constants for your route.
    -   At the expense of being forced to duplicate strings in route definitions



One of the shortcomings is that the variables created are not scoped
to the route they came from. That is because if they were, the names
would have to be extremely long. For example, for a path such as
`cloud/organizations/:orgId`, and we wanted to access the orgId segment,
we would need something like the following

```
export const  segment_cloud = "organizations";
export const  segment_cloud_organizations = "organizations";
export const  segment_cloud_organizations_orgId = "orgId";
```

That would give us a little bit more safety at the expense of creating extremely
long variables. We could have suggested a pattern where they are renamed
as they are imported but we didn't think the extra safety was worth that effort.

```
import  {segment_cloud_organizations_orgId as segment_orgId} from "@my/path"
```


## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Feature

## What does this change do?

## What manual testing did you do?
Ran the 
## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
