### PR TITLE
Fix clr-datagrid matching the wrong trackBy for selection comparison

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix wrong trackBy being used for grid selection identity comparison
 
 ## [15.0.1-dev.9]
 ### Add
 - Add a new `@Input hideLabel` for our form control components.
--
+
 ## [15.0.1-dev.8]
 
 ### Fixed

--- a/projects/components/src/datagrid/datagrid.component.html
+++ b/projects/components/src/datagrid/datagrid.component.html
@@ -10,6 +10,7 @@
     (clrDgSelectedChange)="onClarityDatafridSelectionChange()"
     (clrDgSingleSelectedChange)="onClarityDatafridSelectionChange()"
     [clrDgPreserveSelection]="preserveSelection"
+    [clrDgItemsTrackBy]="clrDgItemsTrackBy"
 >
     <clr-dg-placeholder>{{ emptyGridPlaceholder }}</clr-dg-placeholder>
     <clr-dg-action-bar class="top-action-bar" *ngIf="shouldShowActionBarOnTop">


### PR DESCRIPTION
Clarity introduced a new 'clrDgItemsTrackBy' input property which is used to compare the identity of selected grid items.

This new property has a different signature than the regular trackBy function, which is why we are taking our client's provided trackBy and wrapping it before passing into clrDgItemsTrackBy.

Link for the original bug: https://github.com/vmware-archive/clarity/issues/3936
Link for clarity's fix: https://github.com/vmware-clarity/ng-clarity/pull/539

## PR Checklist

-   [x] Changelog has been updated

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix

## What does this change do?
Fixes clarity's ["Datagrid uses wrong trackBy and breaks selection"](https://github.com/vmware-archive/clarity/issues/3936) bug by applying their [bugfix](https://github.com/vmware-clarity/ng-clarity/pull/539).

## What manual testing did you do?
Tested against VCD's codebase.

## Does this PR introduce a breaking change?
-   [x] No

## Other information
