### PR TITLE
Add placeholder to datagrid-string-filter

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add placeholder for datagrid-string filter to resolve accessibility issue
 
 ## [15.0.1-dev.10]
 ### Fixed

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [15.0.1-dev.11]
 ### Fixed
 - Add placeholder for datagrid-string filter to resolve accessibility issue
 

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "15.0.1-dev.10",
+    "version": "15.0.1-dev.11",
     "dependencies": {
         "@ngx-formly/core": ">=6.0.4"
     },

--- a/projects/components/src/assets/resources/en.properties
+++ b/projects/components/src/assets/resources/en.properties
@@ -92,6 +92,7 @@ vcd.cc.numeric.filter.to=To:
 vcd.cc.bad.input=Invalid number
 
 vcd.cc.datagrid.actions=Actions
+vcd.cc.datagrid.common.filter.items=Filter items
 
 vcd.cc.action.menu.actions=All Actions
 vcd.cc.action.menu.other.actions=Other Actions

--- a/projects/components/src/datagrid/filters/datagrid-string-filter.component.html
+++ b/projects/components/src/datagrid/filters/datagrid-string-filter.component.html
@@ -1,3 +1,10 @@
 <form>
-    <input type="text" name="search" [formControl]="formGroup.controls.filterText" class="clr-input" />
+    <input
+        type="text"
+        name="search"
+        class="clr-input"
+        [attr.aria-label]="placeholder | lazyString"
+        [placeholder]="placeholder | lazyString"
+        [formControl]="formGroup.controls.filterText"
+    />
 </form>

--- a/projects/components/src/datagrid/filters/datagrid-string-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-string-filter.component.ts
@@ -9,6 +9,8 @@ import { ClrDatagridFilter } from '@clr/angular';
 import { SubscriptionTracker } from '../../common/subscription/subscription-tracker';
 import { FilterBuilder } from '../../utils/filter-builder';
 import { DatagridFilter, FilterComponentRendererSpec, FilterConfig, FilterRendererSpec } from './datagrid-filter';
+import { TranslationService } from '@vcd/i18n';
+import { LazyString } from '../../utils/types';
 
 export enum WildCardPosition {
     NONE = 0,
@@ -22,6 +24,7 @@ export enum WildCardPosition {
  */
 export interface DatagridStringFilterConfig extends FilterConfig<string> {
     wildCardPosition?: WildCardPosition;
+    placeholder?: string;
 }
 
 @Component({
@@ -34,7 +37,13 @@ export class DatagridStringFilterComponent extends DatagridFilter<string, Datagr
         filterText: new FormControl(''),
     });
 
-    constructor(private filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker) {
+    protected placeholder: LazyString;
+
+    constructor(
+        private filterContainer: ClrDatagridFilter,
+        private translationService: TranslationService,
+        subTracker: SubscriptionTracker
+    ) {
         super(filterContainer, subTracker);
     }
 
@@ -51,6 +60,11 @@ export class DatagridStringFilterComponent extends DatagridFilter<string, Datagr
             value = this.addWildCard(value, this.config.wildCardPosition);
         }
         return filterBuilder.equalTo(value).getString();
+    }
+
+    protected onBeforeSetConfig(config: DatagridStringFilterConfig) {
+        this.placeholder =
+            config?.placeholder || this.translationService.translateAsync('vcd.cc.datagrid.common.filter.items');
     }
 
     isActive(): boolean {
@@ -77,16 +91,19 @@ export class DatagridStringFilterComponent extends DatagridFilter<string, Datagr
  * Creates a {@link FilterRendererSpec} with the given config.
  * @param wildCardPosition where the * should go in the FIQL string output.
  * @param value the default value of the filter
+ * @param placeholder for the input field
  */
 export function DatagridStringFilter(
     wildCardPosition?: WildCardPosition,
-    value?: string
+    value?: string,
+    placeholder?: string
 ): FilterRendererSpec<DatagridStringFilterConfig> {
     return FilterComponentRendererSpec({
         type: DatagridStringFilterComponent,
         config: {
             wildCardPosition,
             value,
+            placeholder,
         },
     });
 }

--- a/projects/examples/src/components/datagrid/datagrid-string-filter-placeholder.example.component.ts
+++ b/projects/examples/src/components/datagrid/datagrid-string-filter-placeholder.example.component.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright 2021 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { Component, OnInit } from '@angular/core';
+import {
+    DatagridStringFilter,
+    GridColumn,
+    GridDataFetchResult,
+    GridState,
+    SubscriptionTracker,
+    VcdDatagridModule,
+    WildCardPosition,
+} from '@vcd/ui-components';
+import { ClarityModule, ClrCommonFormsModule } from '@clr/angular';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { debounceTime } from 'rxjs';
+
+interface MockDataType {
+    name: string;
+}
+
+const MOCK_DATA: MockDataType[] = [
+    { name: 'Italy' },
+    { name: 'Holy See' },
+    { name: 'Germany' },
+    { name: 'Gibraltar' },
+    { name: 'Nepal' },
+    { name: 'Greece' },
+];
+
+function getColumns(placeholder?: string): GridColumn<MockDataType>[] {
+    return [
+        {
+            displayName: 'Name',
+            renderer: 'name',
+            queryFieldName: 'name',
+            filter: DatagridStringFilter(WildCardPosition.NONE, '', placeholder),
+        },
+    ];
+}
+@Component({
+    standalone: true,
+    imports: [VcdDatagridModule, ClrCommonFormsModule, ClarityModule, ReactiveFormsModule],
+    providers: [SubscriptionTracker],
+    template: `
+        <p>
+            The <code>placeholder</code> config property is allowing users to set a filter input placeholder. This
+            addition is important for enhancing accessibility, ensuring a more inclusive user experience. The default
+            placeholder value ensures this accessibility for cases where users do not provide a custom placeholder.
+        </p>
+        <p>You can test it with the provided datagrid and input which is bound with a placeholder value.</p>
+        <clr-input-container>
+            <label>Filter placeholder:</label>
+            <input clrInput [formControl]="placeholderControl" #placeholderInput />
+        </clr-input-container>
+        <vcd-datagrid [gridData]="gridData" (gridRefresh)="refresh($event)" [columns]="columns"></vcd-datagrid>
+    `,
+})
+export class DatagridStringFilterPlaceholderExampleComponent implements OnInit {
+    protected gridData: GridDataFetchResult<MockDataType> = {
+        items: [],
+    };
+
+    protected columns = getColumns();
+
+    protected placeholderControl = new FormControl('');
+
+    constructor(private subscriptionTracker: SubscriptionTracker) {}
+
+    ngOnInit(): void {
+        this.subscriptionTracker.subscribe(
+            this.placeholderControl.valueChanges.pipe(debounceTime(100)),
+            (value) => (this.columns = getColumns(value))
+        );
+    }
+
+    protected refresh(eventData: GridState<MockDataType>): void {
+        this.gridData = {
+            items: MOCK_DATA,
+            totalItems: 2,
+        };
+    }
+}

--- a/projects/examples/src/components/datagrid/datagrid.examples.module.ts
+++ b/projects/examples/src/components/datagrid/datagrid.examples.module.ts
@@ -48,6 +48,7 @@ import { DatagridIsRowSelectableExampleComponent } from './datagrid-is-row-selec
 import { DatagridIsRowSelectableExampleModule } from './datagrid-is-row-selectable-example.module';
 import { DatagridPreserveSelectionExampleComponent } from './datagrid-preserve-selection.example.component';
 import { DatagridPreserveSelectionExampleModule } from './datagrid-preserve-selection.example.module';
+import { DatagridStringFilterPlaceholderExampleComponent } from './datagrid-string-filter-placeholder.example.component';
 
 Documentation.registerDocumentationEntry({
     component: DatagridComponent,
@@ -158,6 +159,11 @@ Documentation.registerDocumentationEntry({
             component: DatagridColumnWidthExampleComponent,
             title: 'Set the width of columns through CSS class names',
             urlSegment: 'datagrid-column-width',
+        },
+        {
+            component: DatagridStringFilterPlaceholderExampleComponent,
+            title: 'String Filter Placeholder',
+            urlSegment: 'datagrid-filter-placeholder',
         },
     ],
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [x] Documentation content changes
-   [x] Example website changes
-   [x] Version bump
-   [ ] Other... Please describe:

## What does this change do?
The absence of a placeholder led to the lack of accessibility. The
change will add a default "Find Items" placeholder which can be replaced
with a custom one.

## What manual testing did you do?

- Open examples > datagrid/example/datagrid-filter-placeholder
- Open the "Name" column filter
- Filter is expected to have the default "Filter Items" placeholder
- Change the input above the datagrid
- Open the "Name" column filter
- Filter is expected to have a custom placeholder


## Screenshots (if applicable)

![image](https://github.com/vmware/vmware-cloud-director-ui-components/assets/49042716/92cccd7f-6af0-4003-820d-bce49b254c9b)

![image](https://github.com/vmware/vmware-cloud-director-ui-components/assets/49042716/200b02f0-6b65-4b77-92a5-39514f596386)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

