### PR TITLE
ErrorBanner errorMessage improvements

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.1-dev.13]
+### Fixed
+- Fix ExpressionChangedAfterItHasBeenCheckedError
+- Fix ErrorBannerExampleComponent when closed with X button
+### Changed
+* errorMessage reset value is `null` instead of `undefined`
+
 ## [15.0.1-dev.12]
 ### Fixed
 - Fixed CSV Sanitization problem when a value contained quotes or started with whitespace

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vcd/ui-components",
-    "version": "15.0.1-dev.12",
+    "version": "15.0.1-dev.13",
     "dependencies": {
         "@ngx-formly/core": ">=6.0.4"
     },

--- a/projects/components/src/common/error/error-banner.component.spec.ts
+++ b/projects/components/src/common/error/error-banner.component.spec.ts
@@ -59,6 +59,40 @@ describe('ErrorBannerComponent', () => {
         });
     });
 
+    describe('errorMessage two-way binding', () => {
+        beforeEach(function (this: HasFinderAndError): void {
+            this.finder.hostComponent.message = 'Error!!';
+            this.finder.detectChanges();
+        });
+
+        it('sets the errorMessage to null when closed with the X button', function (this: HasFinderAndError): void {
+            this.errorBannerWO.close();
+            this.finder.detectChanges();
+            expect(this.finder.hostComponent.message).toBe(null);
+            expect(this.errorBannerWO.getDisplayedError()).toBe('');
+        });
+
+        it('does not reset the errorMessage when closed with null', function (this: HasFinderAndError): void {
+            this.finder.hostComponent.message = null;
+            this.finder.detectChanges();
+            expect(this.finder.hostComponent.message).toBe(null);
+            expect(this.errorBannerWO.getDisplayedError()).toBe('');
+        });
+
+        it('does not reset the errorMessage when closed with empty string', function (this: HasFinderAndError): void {
+            this.finder.hostComponent.message = '';
+            this.finder.detectChanges();
+            expect(this.finder.hostComponent.message).toBe('');
+            expect(this.errorBannerWO.getDisplayedError()).toBe('');
+        });
+
+        it('does not reset the errorMessage when closed with undefined', function (this: HasFinderAndError): void {
+            this.finder.hostComponent.message = undefined;
+            this.finder.detectChanges();
+            expect(this.finder.hostComponent.message).toBe(undefined);
+            expect(this.errorBannerWO.getDisplayedError()).toBe('');
+        });
+    });
     describe('ARIA role', () => {
         it('is `alert` for the default alertType `danger`', function (this: HasFinderAndError): void {
             expect(this.errorBannerWO.ariaRole).toBe('alert');

--- a/projects/components/src/common/error/error-banner.component.spec.ts
+++ b/projects/components/src/common/error/error-banner.component.spec.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 VMware, Inc.
+ * Copyright 2020-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -20,6 +20,7 @@ class TestErrorComponent {
 
 interface HasFinderAndError {
     finder: WidgetFinder<TestErrorComponent>;
+    errorBannerWO: ErrorBannerWidgetObject;
 }
 
 describe('ErrorBannerComponent', () => {
@@ -30,36 +31,49 @@ describe('ErrorBannerComponent', () => {
         }).compileComponents();
 
         this.finder = new WidgetFinder(TestErrorComponent);
+        this.errorBannerWO = this.finder.find({ woConstructor: ErrorBannerWidgetObject });
         this.finder.detectChanges();
     });
 
-    it('can display an error when shown', function (this: HasFinderAndError): void {
-        this.finder.hostComponent.message = 'Error!!';
-        this.finder.detectChanges();
-        expect(this.finder.hostComponent.errorBanner.closed).toBeFalsy();
-        expect(this.finder.hostComponent.errorBanner.errorMessage).toEqual('Error!!');
-        this.finder.hostComponent.errorBanner.onAlertClosedChange(true);
-        expect(this.finder.hostComponent.errorBanner.errorMessage).toBeFalsy();
+    describe('general', () => {
+        it('can display an error', function (this: HasFinderAndError): void {
+            this.finder.hostComponent.message = 'Error!!';
+            this.finder.detectChanges();
+            expect(this.errorBannerWO.getDisplayedError()).toBe('Error!!');
+        });
+
+        it('hides the error when closed with the X button', function (this: HasFinderAndError): void {
+            this.finder.hostComponent.message = 'Error!!';
+            this.finder.detectChanges();
+            this.errorBannerWO.close();
+            this.finder.detectChanges();
+            expect(this.errorBannerWO.getDisplayedError()).toBe('');
+        });
+
+        it('hides the error when closed with null', function (this: HasFinderAndError): void {
+            this.finder.hostComponent.message = 'Error!!';
+            this.finder.detectChanges();
+            this.finder.hostComponent.message = null;
+            this.finder.detectChanges();
+            expect(this.errorBannerWO.getDisplayedError()).toBe('');
+        });
     });
 
     describe('ARIA role', () => {
         it('is `alert` for the default alertType `danger`', function (this: HasFinderAndError): void {
-            const errorBannerWO = this.finder.find({ woConstructor: ErrorBannerWidgetObject });
-            expect(errorBannerWO.ariaRole).toBe('alert');
+            expect(this.errorBannerWO.ariaRole).toBe('alert');
         });
 
         it('is `status` for the alertType `warning`', function (this: HasFinderAndError): void {
             this.finder.hostComponent.errorBanner.alertType = 'warning';
             this.finder.detectChanges();
-            const errorBannerWO = this.finder.find({ woConstructor: ErrorBannerWidgetObject });
-            expect(errorBannerWO.ariaRole).toBe('status');
+            expect(this.errorBannerWO.ariaRole).toBe('status');
         });
 
         it('is `status` for the alertType `info`', function (this: HasFinderAndError): void {
             this.finder.hostComponent.errorBanner.alertType = 'info';
             this.finder.detectChanges();
-            const errorBannerWO = this.finder.find({ woConstructor: ErrorBannerWidgetObject });
-            expect(errorBannerWO.ariaRole).toBe('status');
+            expect(this.errorBannerWO.ariaRole).toBe('status');
         });
     });
 });

--- a/projects/components/src/common/error/error-banner.component.ts
+++ b/projects/components/src/common/error/error-banner.component.ts
@@ -1,9 +1,11 @@
 /*!
- * Copyright 2020 VMware, Inc.
+ * Copyright 2020-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+const NO_ERROR_VALUE = null;
 
 /**
  * Component that displays the error message only if a non empty errorMessage is passed in
@@ -14,7 +16,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
     styleUrls: ['./error-banner.component.scss'],
 })
 export class ErrorBannerComponent {
-    private _errorMessage;
+    private _errorMessage: string | null = NO_ERROR_VALUE;
 
     closed = true;
 
@@ -44,7 +46,7 @@ export class ErrorBannerComponent {
      * Sets the error message displayed by this error banner.
      */
     set errorMessage(val: string) {
-        this._errorMessage = val;
+        this._errorMessage = val || NO_ERROR_VALUE;
         this.closed = !val;
     }
 
@@ -58,8 +60,10 @@ export class ErrorBannerComponent {
      */
     onAlertClosedChange(closed: boolean): void {
         if (closed) {
-            this._errorMessage = undefined;
-            this.errorMessageChange.emit(undefined);
+            if (this._errorMessage) {
+                this._errorMessage = NO_ERROR_VALUE;
+                this.errorMessageChange.emit(this._errorMessage);
+            }
             this.dismissed.next();
         }
     }

--- a/projects/components/src/common/error/error-banner.wo.ts
+++ b/projects/components/src/common/error/error-banner.wo.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 VMware, Inc.
+ * Copyright 2020-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -11,6 +11,14 @@ import { ErrorBannerComponent } from './error-banner.component';
  */
 export class ErrorBannerWidgetObject extends WidgetObject<ErrorBannerComponent> {
     static tagName = 'vcd-error-banner';
+
+    public getDisplayedError(): string {
+        return this.findElement('clr-alert').nativeElement.textContent;
+    }
+
+    public close(): string {
+        return this.findElement('clr-alert .close').nativeElement.click();
+    }
 
     /**
      * The ARIA role of the component.

--- a/projects/examples/src/components/error/error-banner.example.component.html
+++ b/projects/examples/src/components/error/error-banner.example.component.html
@@ -1,2 +1,2 @@
-<button (click)="showError = !showError">Show/Hide Error</button>
-<vcd-error-banner [errorMessage]="showError ? 'Error!' : undefined"></vcd-error-banner>
+<button (click)="errorMessage = errorMessage ? null : 'Error!'">Show/Hide Error</button>
+<vcd-error-banner [(errorMessage)]="errorMessage"></vcd-error-banner>

--- a/projects/examples/src/components/error/error-banner.example.component.ts
+++ b/projects/examples/src/components/error/error-banner.example.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 VMware, Inc.
+ * Copyright 2020-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -13,5 +13,5 @@ import { Component } from '@angular/core';
     templateUrl: './error-banner.example.component.html',
 })
 export class ErrorBannerExampleComponent {
-    showError = false;
+    errorMessage: string;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Examples have been added / updated (for bug fixes / features)
-   [x] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [x] Example website changes
-   [x] Version bump
-   [ ] Other... Please describe:

## What does this change do?
Please take a look at the distinct commits.
All changes are related to the ErrorBannerComponent and refer to:
* fix ExpressionChangedAfterItHasBeenCheckedError due to incorrect emit behavior for `errorMessage`
* use `null` for resetting `errorMessage` when closing the banner
* fix wrong unit tests
* fix the example for the case when the nabber is closed with the X button

## What manual testing did you do?
Please take a look at the distinct commits.

## Screenshots (if applicable)
| Before | After |
|--------|--------|
| <img width="1719" alt="Screenshot 2023-11-17 at 15 43 34" src="https://github.com/vmware/vmware-cloud-director-ui-components/assets/866923/5a7242b9-df60-4aa3-bfdd-d401afa8d6df">| <img width="1716" alt="Screenshot 2023-11-17 at 23 55 10" src="https://github.com/vmware/vmware-cloud-director-ui-components/assets/866923/db2c1541-e071-4c2b-a8c7-8cf197887f71">| 

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
