### PR TITLE
Datagrid filter setFocus

### DIFF
--- a/projects/components/src/datagrid/filters/datagrid-filter.ts
+++ b/projects/components/src/datagrid/filters/datagrid-filter.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2019-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -64,7 +64,10 @@ export abstract class DatagridFilter<V, C extends FilterConfig<V>, F extends For
 {
     abstract formGroup: F;
 
-    protected constructor(filterContainer: ClrDatagridFilter, private subscriptionTracker: SubscriptionTracker) {
+    protected constructor(
+        protected filterContainer: ClrDatagridFilter,
+        private subscriptionTracker: SubscriptionTracker
+    ) {
         filterContainer.setFilter(this);
     }
 

--- a/projects/components/src/datagrid/filters/datagrid-filter.ts
+++ b/projects/components/src/datagrid/filters/datagrid-filter.ts
@@ -6,7 +6,7 @@
 import { Directive, Input, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ClrDatagridFilter, ClrDatagridFilterInterface } from '@clr/angular';
-import { Subject } from 'rxjs';
+import { Subject, timer } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { SubscriptionTracker } from '../../common/subscription/subscription-tracker';
 import {
@@ -99,6 +99,17 @@ export abstract class DatagridFilter<V, C extends FilterConfig<V>, F extends For
             ? this.formGroup.valueChanges.pipe(debounceTime(this.getDebounceTimeMs()))
             : this.formGroup.valueChanges;
         this.subscriptionTracker.subscribe(obs, () => this.changes.next(null));
+        this.subscribeToSetFocusWhenOpened();
+    }
+
+    private subscribeToSetFocusWhenOpened(): void {
+        this.subscriptionTracker.subscribe(this.filterContainer.openChange, (open: boolean) => {
+            if (open) {
+                this.subscriptionTracker.subscribe(timer(50), () => {
+                    this.setFocus();
+                });
+            }
+        });
     }
 
     /**
@@ -130,6 +141,11 @@ export abstract class DatagridFilter<V, C extends FilterConfig<V>, F extends For
      * Return true if the filter is currently activated (e.g. a value is provided)
      */
     abstract isActive(): boolean;
+
+    /**
+     * Called when the filter is opened to allow setting the focus on the desired element
+     */
+    protected abstract setFocus(): void;
 
     /**
      * Required by Clarity but ignored since we don't support client side filtering

--- a/projects/components/src/datagrid/filters/datagrid-multiselect-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-multiselect-filter.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, Host, OnDestroy } from '@angular/core';
+import { Component, ElementRef } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
 import { ClrDatagridFilter } from '@clr/angular';
 import { SelectOption } from '../../common/interfaces/select-option';
@@ -71,7 +71,7 @@ type BooleanFormGroup = FormGroup<{ [name: string]: AbstractControl<boolean, boo
     providers: [SubscriptionTracker],
 })
 export class DatagridMultiSelectFilterComponent extends DatagridFilter<string[], DatagridMultiSelectFilterConfig> {
-    constructor(filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker) {
+    constructor(filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker, private elemRef: ElementRef) {
         super(filterContainer, subTracker);
     }
 
@@ -126,6 +126,10 @@ export class DatagridMultiSelectFilterComponent extends DatagridFilter<string[],
             this.formGroup &&
             !!Object.keys(this.formGroup.getRawValue()).filter((frmCtrl) => this.formGroup.get(frmCtrl).value).length
         );
+    }
+
+    protected setFocus() {
+        this.elemRef?.nativeElement?.querySelector('input')?.focus();
     }
 }
 

--- a/projects/components/src/datagrid/filters/datagrid-multiselect-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-multiselect-filter.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2019-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -71,7 +71,7 @@ type BooleanFormGroup = FormGroup<{ [name: string]: AbstractControl<boolean, boo
     providers: [SubscriptionTracker],
 })
 export class DatagridMultiSelectFilterComponent extends DatagridFilter<string[], DatagridMultiSelectFilterConfig> {
-    constructor(private filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker) {
+    constructor(filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker) {
         super(filterContainer, subTracker);
     }
 

--- a/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2019-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -79,7 +79,7 @@ export class DatagridNumericFilterComponent
         to: new FormControl(null as number),
     });
 
-    constructor(private filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker) {
+    constructor(filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker) {
         super(filterContainer, subTracker);
     }
 

--- a/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-numeric-filter.component.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, Host, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
 import { ClrDatagridFilter } from '@clr/angular';
 import { SubscriptionTracker } from '../../common/subscription/subscription-tracker';
 import { NumberWithUnitFormInputComponent } from '../../form';
@@ -79,7 +79,7 @@ export class DatagridNumericFilterComponent
         to: new FormControl(null as number),
     });
 
-    constructor(filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker) {
+    constructor(filterContainer: ClrDatagridFilter, subTracker: SubscriptionTracker, private elemRef: ElementRef) {
         super(filterContainer, subTracker);
     }
 
@@ -129,6 +129,10 @@ export class DatagridNumericFilterComponent
 
     close(): void {
         this.filterContainer.open = false;
+    }
+
+    protected setFocus() {
+        this.elemRef?.nativeElement?.querySelector('input')?.focus();
     }
 }
 

--- a/projects/components/src/datagrid/filters/datagrid-select-filter.component.html
+++ b/projects/components/src/datagrid/filters/datagrid-select-filter.component.html
@@ -2,7 +2,7 @@
     <div class="clr-form-control">
         <div class="clr-control-container">
             <div class="clr-select-wrapper">
-                <select [formControl]="formGroup.controls.filterSelect" class="clr-select">
+                <select #selectElement [formControl]="formGroup.controls.filterSelect" class="clr-select">
                     <option [ngValue]="anyChoice.value">{{ anyChoice.display }}</option>
                     <option *ngFor="let option of config.options" [ngValue]="option.value">
                         {{ option.isTranslatable ? (option.display | translate) : option.display }}

--- a/projects/components/src/datagrid/filters/datagrid-select-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-select-filter.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2019-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 import { Component, OnInit } from '@angular/core';
@@ -68,7 +68,7 @@ export class DatagridSelectFilterComponent
         filterSelect: new FormControl('' as string | number),
     });
 
-    constructor(private filterContainer: ClrDatagridFilter, private fb: FormBuilder, subTracker: SubscriptionTracker) {
+    constructor(filterContainer: ClrDatagridFilter, private fb: FormBuilder, subTracker: SubscriptionTracker) {
         super(filterContainer, subTracker);
     }
 

--- a/projects/components/src/datagrid/filters/datagrid-select-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-select-filter.component.ts
@@ -2,7 +2,7 @@
  * Copyright 2019-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { ClrDatagridFilter } from '@clr/angular';
 import { SelectOption } from '../../common/interfaces/select-option';
@@ -56,6 +56,8 @@ export class DatagridSelectFilterComponent
     extends DatagridFilter<string | number, DatagridSelectFilterConfig>
     implements OnInit
 {
+    @ViewChild('selectElement') selectElement: ElementRef;
+
     /**
      * Displayed as the first option with a falsy value. Selecting this option would deactivate the filter
      */
@@ -96,6 +98,10 @@ export class DatagridSelectFilterComponent
 
     isActive(): boolean {
         return !!(this.formGroup && this.formGroup.controls.filterSelect.value);
+    }
+
+    protected setFocus() {
+        this.selectElement?.nativeElement.focus();
     }
 }
 

--- a/projects/components/src/datagrid/filters/datagrid-string-filter.component.html
+++ b/projects/components/src/datagrid/filters/datagrid-string-filter.component.html
@@ -1,5 +1,6 @@
 <form>
     <input
+        #inputElement
         type="text"
         name="search"
         class="clr-input"

--- a/projects/components/src/datagrid/filters/datagrid-string-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-string-filter.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { ClrDatagridFilter } from '@clr/angular';
 import { SubscriptionTracker } from '../../common/subscription/subscription-tracker';
@@ -37,6 +37,8 @@ export class DatagridStringFilterComponent extends DatagridFilter<string, Datagr
         filterText: new FormControl(''),
     });
 
+    @ViewChild('inputElement') inputElement: ElementRef;
+
     protected placeholder: LazyString;
 
     constructor(
@@ -69,6 +71,10 @@ export class DatagridStringFilterComponent extends DatagridFilter<string, Datagr
 
     isActive(): boolean {
         return !!(this.formGroup && this.formGroup.controls.filterText.value);
+    }
+
+    protected setFocus() {
+        this.inputElement?.nativeElement.focus();
     }
 
     /**

--- a/projects/components/src/datagrid/filters/datagrid-string-filter.component.ts
+++ b/projects/components/src/datagrid/filters/datagrid-string-filter.component.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 VMware, Inc.
+ * Copyright 2019-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -40,7 +40,7 @@ export class DatagridStringFilterComponent extends DatagridFilter<string, Datagr
     protected placeholder: LazyString;
 
     constructor(
-        private filterContainer: ClrDatagridFilter,
+        filterContainer: ClrDatagridFilter,
         private translationService: TranslationService,
         subTracker: SubscriptionTracker
     ) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [x] Version bump
-   [ ] Other... Please describe:

## What does this change do?
When opening a datagrid filter the focus should go directly to the relevant HTML element so that the user can start filtering right away.
Up to now the focus was on the flter close button 'X'. This is extremely boring when using string filter because the user has to click first on the input field (or TAB to it) and then start writing.

## What manual testing did you do?
In the example applications navigate to `Datagrid` -> `Datagrid Filters` (`/datagrid/example/datagrid-filter`)
Open each of the filters and verify that the focus is on the `input` field or the `select` .

## Screenshots (if applicable)

## Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Breaking changes need:
- removing  modifier for ClrDatagridFilter parameter of the child constructor, i.e. it should be `filterContainer: ClrDatagridFilter` only
- implement setFocus() method on the child class

## Other information
