### PR TITLE
Error in activity reporter not visible, need to scroll to the top

### DIFF
--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * errorMessage reset value is `null` instead of `undefined`
 * Add scrollIntoView method for the vcd-banner-activity-reporter
-* Add examples for vcd-banner-activity-reporter scrollIntoView behavior
+* Added an example for vcd-banner-activity-reporter scrollIntoView behavior
 
 ## [15.0.1-dev.12]
 ### Fixed

--- a/projects/components/CHANGELOG.MD
+++ b/projects/components/CHANGELOG.MD
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix ErrorBannerExampleComponent when closed with X button
 ### Changed
 * errorMessage reset value is `null` instead of `undefined`
+* Add scrollIntoView method for the vcd-banner-activity-reporter
+* Add examples for vcd-banner-activity-reporter scrollIntoView behavior
 
 ## [15.0.1-dev.12]
 ### Fixed

--- a/projects/components/src/common/activity-reporter/banner-activity-reporter.component.ts
+++ b/projects/components/src/common/activity-reporter/banner-activity-reporter.component.ts
@@ -1,9 +1,9 @@
 /*!
- * Copyright 2020 VMware, Inc.
+ * Copyright 2020-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Component, Inject, Input } from '@angular/core';
+import { Component, ElementRef, Inject, Input } from '@angular/core';
 import { TranslationService } from '@vcd/i18n';
 import { LazyString } from '@vcd/i18n';
 import { ActivityPromiseResolver } from './activity-promise-resolver';
@@ -29,6 +29,7 @@ export class BannerActivityReporterComponent extends ActivityReporter {
 
     constructor(
         private translationService: TranslationService,
+        private elementRef: ElementRef,
         @Inject(ActivityPromiseResolver) promiseResolver: ActivityPromiseResolver<any>
     ) {
         super(promiseResolver);
@@ -49,6 +50,7 @@ export class BannerActivityReporterComponent extends ActivityReporter {
     reportError(errorText: string): void {
         this.errorText = errorText;
         this.running = false;
+        this.scrollIntoView();
     }
 
     /**
@@ -59,6 +61,7 @@ export class BannerActivityReporterComponent extends ActivityReporter {
             this.successMessage = successMessage;
         }
         this.running = false;
+        this.scrollIntoView();
     }
 
     /**
@@ -73,6 +76,13 @@ export class BannerActivityReporterComponent extends ActivityReporter {
      */
     onSuccessClosed(): void {
         this.successMessage = null;
+    }
+
+    /**
+     * Scroll to the banner activity reporter.
+     */
+    private scrollIntoView(): void {
+        this.elementRef.nativeElement.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     }
 
     /*

--- a/projects/examples/src/components/activity-reporter/activity-reporter.examples.module.ts
+++ b/projects/examples/src/components/activity-reporter/activity-reporter.examples.module.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 VMware, Inc.
+ * Copyright 2020-2023 VMware, Inc.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
@@ -10,6 +10,8 @@ import { BannerActivityReporterExampleComponent } from './banner-activity-report
 import { BannerActivityReporterExampleModule } from './banner-activity-reporter.example.module';
 import { SpinnerActivityReporterExampleComponent } from './spinner-activity-reporter.example.component';
 import { SpinnerActivityReporterExampleModule } from './spinner-activity-reporter.example.module';
+import { BannerActivityReporterScrollIntoViewExampleComponent } from './banner-activity-reporter-scroll-into-view.example.component';
+import { BannerActivityReporterScrollIntoViewExampleModule } from './banner-activity-reporter-scroll-into-view.example.module';
 
 Documentation.registerDocumentationEntry({
     component: BannerActivityReporterComponent,
@@ -20,6 +22,11 @@ Documentation.registerDocumentationEntry({
             component: BannerActivityReporterExampleComponent,
             title: 'Show/Hide the banner activity reporter',
             urlSegment: 'banner-activity-reporter',
+        },
+        {
+            component: BannerActivityReporterScrollIntoViewExampleComponent,
+            title: 'Scroll into view of the banner activity reporter',
+            urlSegment: 'banner-activity-reporter-scroll-into-view',
         },
     ],
 });
@@ -41,6 +48,10 @@ Documentation.registerDocumentationEntry({
  * A module that imports all activity reporter examples.
  */
 @NgModule({
-    imports: [SpinnerActivityReporterExampleModule, BannerActivityReporterExampleModule],
+    imports: [
+        SpinnerActivityReporterExampleModule,
+        BannerActivityReporterExampleModule,
+        BannerActivityReporterScrollIntoViewExampleModule,
+    ],
 })
 export class ActivityReporterExamplesModule {}

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter-scroll-into-view.example.component.html
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter-scroll-into-view.example.component.html
@@ -1,0 +1,13 @@
+<clr-wizard [clrWizardOpen]="true">
+    <clr-wizard-title>Wizard</clr-wizard-title>
+    <clr-wizard-page>
+        <ng-template clrPageTitle>Wizard Page</ng-template>
+        Throw Error and Report Success buttons at the bottom of page after pressing Start Activity Reporter.
+        <button *ngIf="!showBanner" (click)="startActivity()">Start Activity Reporter</button>
+        <vcd-banner-activity-reporter></vcd-banner-activity-reporter>
+        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+
+        <button *ngIf="showBanner" (click)="throwError()">Throw Error</button>
+        <button *ngIf="showBanner" (click)="reportSuccess()">Report Success</button>
+    </clr-wizard-page>
+</clr-wizard>

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter-scroll-into-view.example.component.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter-scroll-into-view.example.component.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { ActivityReporter, BannerActivityReporterComponent } from '@vcd/ui-components';
+
+/**
+ * Scroll into view of the banner activity reporter
+ */
+@Component({
+    selector: 'vcd-banner-activity-reporter-scroll-into-view-example',
+    templateUrl: './banner-activity-reporter-scroll-into-view.example.component.html',
+})
+export class BannerActivityReporterScrollIntoViewExampleComponent {
+    showBanner = false;
+    resolve;
+    reject;
+
+    @ViewChild(BannerActivityReporterComponent, { static: true }) reporter: ActivityReporter;
+
+    startActivity(): void {
+        this.showBanner = true;
+        this.reporter
+            .monitorGet(
+                new Promise((resolve, reject) => {
+                    this.reject = reject;
+                    this.resolve = resolve;
+                })
+            )
+            .then((result) => {
+                this.showBanner = false;
+                return result;
+            });
+    }
+
+    throwError(): void {
+        this.reject('Error!!');
+    }
+
+    reportSuccess(): void {
+        this.resolve('done!');
+    }
+}

--- a/projects/examples/src/components/activity-reporter/banner-activity-reporter-scroll-into-view.example.module.ts
+++ b/projects/examples/src/components/activity-reporter/banner-activity-reporter-scroll-into-view.example.module.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ClarityModule } from '@clr/angular';
+import { VcdComponentsModule } from '@vcd/ui-components';
+import { BannerActivityReporterScrollIntoViewExampleComponent } from './banner-activity-reporter-scroll-into-view.example.component';
+
+@NgModule({
+    declarations: [BannerActivityReporterScrollIntoViewExampleComponent],
+    imports: [CommonModule, ClarityModule, ReactiveFormsModule, VcdComponentsModule],
+    exports: [BannerActivityReporterScrollIntoViewExampleComponent],
+})
+export class BannerActivityReporterScrollIntoViewExampleModule {}


### PR DESCRIPTION
Bugfix: Add a scrollToMessage method for the vcd-banner-activity-reporter. This increases the visibility of success and error messages by having them in the view of the user.

Testing Done:
- Edited examples locally to have a page where the error/success message is not visible.
- Observed that the scrolling to the error/success message worked.

https://github.com/vmware/vmware-cloud-director-ui-components/assets/40737169/4950a5df-1a69-427c-b516-3cd2cc22bb9f

[COR-12499](https://jira.eng.vmware.com/browse/COR-12499)
https://bugzilla.eng.vmware.com/show_bug.cgi?id=2858757