### PR TITLE
[i18n] Add number formatting to the translation service based on the user locale

### DIFF
--- a/projects/i18n/src/lib/service/mock-translation-service.ts
+++ b/projects/i18n/src/lib/service/mock-translation-service.ts
@@ -31,6 +31,10 @@ class MockTranslationService extends TranslationService {
         return new BehaviorSubject(this.translate(key, params));
     }
 
+    formatNumber(number: number): string {
+        return number.toLocaleString();
+    }
+
     formatDate(date: Date): string {
         return date.toLocaleString();
     }

--- a/projects/i18n/src/lib/service/translation-service.ts
+++ b/projects/i18n/src/lib/service/translation-service.ts
@@ -6,6 +6,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+import NumberFormatOptions = Intl.NumberFormatOptions;
 
 /**
  * Basic translations.
@@ -53,6 +54,15 @@ abstract class TranslationService {
         ...this.defaultTimeFormat,
     };
 
+    /** 
+     * Options to format Number
+     */
+    protected readonly defaultNumberFormat: NumberFormatOptions = {
+        // override the default which is 3 to be able to respect user defined precision
+        maximumFractionDigits: 20,
+        useGrouping: false
+    };
+
     /**
      * Register translations (used by moådules)
      */
@@ -73,6 +83,14 @@ abstract class TranslationService {
      * @return translated string.
      */
     abstract translate(key: string, params?: any[]): string;
+
+    /**
+     * Format a number with current locale.
+     * @param number number
+     * @param options to specify the format of the number string.
+     * @return formatted number.
+     */
+    abstract formatNumber(number: number, options?: object): string;
 
     /**
      * Format a date with current locale.
@@ -120,4 +138,5 @@ export const TRANSLATION_MAPPING = {
  *          false (for 24-hour format)
  */
 export type  FormatDateOptions =  DateTimeFormatOptions;
+export type FormatNumberOptions = NumberFormatOptions;
 export { TranslationService };


### PR DESCRIPTION
  ## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Examples have been added / updated (for bug fixes / features)
-   [ ] Changelog has been updated (there is no changelog for i18n project)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Example website changes
-   [ ] Version bump
-   [ ] Other... Please describe:

## What does this change do?

Add number formatting to the translation service based on the user locale

Description
===========
Currently the decimal point in the numbers was incorrect for some locales (IT, ES, FR, DE, pt-BR) - it was displayed as dot, but should be coma.

Fix Description
===============
Add a format number method that uses Intl.NumberFormat() method to format the number based on locale 

Note: I have added 2 default format options:
*  `maximumFractionDigits: 20` - The default one is 3. We need to override this to be able to respect user defined precision if it is set
* `useGrouping: false` - Disable grouping, since currently we are not using any grouping of the large numbers (ex. number = 1234567.89, Output with grouping: 1,234,567.89, Output without grouping: 1234567.89). 

## What manual testing did you do?

* All unit tests are passing 
* The changes are tested within VCD application 

Expected:

The number format displays correctly for FR/ES/DE/IT/pt-BR languages, the decimal point is displayed as comma.


## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
